### PR TITLE
Formgrader UI improvements

### DIFF
--- a/nbgrader/html/static/css/formgrade.css
+++ b/nbgrader/html/static/css/formgrade.css
@@ -74,3 +74,47 @@ div#notebook-container {
 div.prompt {
   min-width: 21ex;
 }
+
+img {
+    border: 2px solid red;
+}
+
+div.nbgrader_cell {
+    width: 100%;
+}
+
+div.nbgrader_cell .panel-heading {
+    padding: 0.4em 0.6em;
+    height: 37px;
+}
+
+div.nbgrader_cell .panel-footer {
+    padding: 0.4em 0.6em;
+}
+
+div.nbgrader_cell .panel-body {
+    padding: 0.4em;
+}
+
+.comment {
+    width: 100%;
+    margin-top: 0.5em;
+}
+
+div.nbgrader_cell .input_area {
+    background: white;
+    border: none;
+}
+
+.score {
+    color: black;
+}
+
+span.nbgrader-label {
+    line-height: 25px;
+}
+
+.save-icon {
+    margin-left: 1em;
+    top: 4px;
+}

--- a/nbgrader/html/static/js/formgrade.js
+++ b/nbgrader/html/static/js/formgrade.js
@@ -116,8 +116,8 @@ $(window).load(function () {
     $("li.previous a").tooltip({container: 'body'});
     $("li.next a").tooltip({container: 'body'});
 
+    // disable link selection on tabs
     $('a').attr('tabindex', '-1');
-    $('li.next a').attr('tabindex', $("input, textarea").length - 1);
 
     $("input, textarea").on('keydown', function(e) { 
         var keyCode = e.keyCode || e.which;

--- a/nbgrader/html/static/js/formgrade.js
+++ b/nbgrader/html/static/js/formgrade.js
@@ -76,10 +76,37 @@ var Comments = Backbone.Collection.extend({
     url: "/api/notebook/" + nb_uuid + "/comments"
 });
 
+var getIndex = function (elem) {
+    var elems = $("input, textarea");
+    return elems.index(elem);
+};
+
+var selectNext = function (target, shift) {
+    var index, elems;
+    elems = $("input, textarea");
+    if (shift) {
+        index = getIndex(target) - 1;
+    } else {
+        index = getIndex(target) + 1;
+    }
+    if (index === elems.length) {
+        index = 0;
+    } else if (index === -1) {
+        index = elems.length - 1;
+    }
+    $(elems[index]).select();
+};
+
+var scrollTo = function (elem) {
+    var target = elem.closest(".nbgrader_cell");
+    return target.offset().top - $(window).height() * 0.33 + 60;
+};
+
 var grades;
 var comments;
+var last_selected;
     
-$(document).ready(function () {
+$(window).load(function () {
     grades = new Grades();
     grades.fetch();
 
@@ -88,4 +115,55 @@ $(document).ready(function () {
 
     $("li.previous a").tooltip({container: 'body'});
     $("li.next a").tooltip({container: 'body'});
+
+    $('a').attr('tabindex', '-1');
+    $('li.next a').attr('tabindex', $("input, textarea").length - 1);
+
+    $("input, textarea").on('keydown', function(e) { 
+        var keyCode = e.keyCode || e.which;
+
+        if (keyCode === 9) { // tab
+            e.preventDefault();
+            e.stopPropagation();
+            selectNext(e.currentTarget, e.shiftKey);
+            
+        } else if (keyCode === 27) { // escape
+            $(e.currentTarget).blur();
+        }
+    });
+
+    $("body").on('keydown', function(e) {
+        var keyCode = e.keyCode || e.which;
+        var href;
+
+        if (keyCode === 9) { // tab
+            e.preventDefault();
+            selectNext(last_selected, e.shiftKey);
+
+        } else if (keyCode === 13) { // enter
+            last_selected.select();
+        } else if (keyCode == 39 && e.shiftKey) {
+            href = $("li.next a").attr("href");
+            if (href) {
+                window.location = href + "#" + getIndex(last_selected);
+            }
+        } else if (keyCode == 37 && e.shiftKey) {
+            href = $("li.previous a").attr("href");
+            if (href) {
+                window.location = href + "#" + getIndex(last_selected);
+            }
+        }
+    });
+
+    var index = parseInt(document.URL.split('#')[1]) || 0;
+    last_selected = $($("input, textarea")[index]);
+    last_selected.select();
+    $("body, html").stop().scrollTop(scrollTo(last_selected));
+
+    $("input, textarea").focus(function (event) {
+        last_selected = $(event.currentTarget);
+        $("body, html").stop().animate({
+            scrollTop: scrollTo(last_selected)
+        }, 500);
+    });
 });

--- a/nbgrader/html/static/js/formgrade.js
+++ b/nbgrader/html/static/js/formgrade.js
@@ -5,7 +5,7 @@ var Grade = Backbone.Model.extend({
     urlRoot: "/api/grade",
     initialize: function () {
         var elem = $("#" + this.get("grade_id"));
-        var glyph = $(elem.siblings()[0]);
+        var glyph = $("#" + this.get("grade_id") + "-saved");
         elem.val(this.get("score"));
         elem.attr("placeholder", this.get("autoscore"));
         glyph.hide();
@@ -46,7 +46,7 @@ var Comment = Backbone.Model.extend({
     urlRoot: "/api/comment",
     initialize: function () {
         var elem = $($(".comment")[this.get("comment_id")]);
-        var glyph = $($(elem.siblings()[0]).children()[0]);
+        var glyph = $($(".comment-saved")[this.get("comment_id")]);
         elem.val(this.get("comment"));
         glyph.hide();
 


### PR DESCRIPTION
A few things to (hopefully) significantly improve the grading experience with the formgrader, including:

* making it clearer which score/comment fields go with which cells
* automatic scrolling to the first score/comment field
* smooth scrolling to the next score/comment field when tab is pressed
* press shift+right arrow to move to the same field in the next student's assignment, or shift+left arrow to move to the same field in the previous student's assignment
* cycle back to the first score/comment field after the last

Example of tabbing and moving between assignments (when the page looks like it is refreshing, that is actually moving to a different submission):

![](http://i.imgur.com/aoUcHJW.gif)