### PR TITLE
Timeout on long-running cells

### DIFF
--- a/docs/command_line_tools/nbgrader assign.ipynb
+++ b/docs/command_line_tools/nbgrader assign.ipynb
@@ -37,7 +37,13 @@
       "--quiet\r\n",
       "    set log level to logging.CRITICAL (minimize logging output)\r\n",
       "--recursive\r\n",
-      "    Recursively find notebook files.\r\n",
+      "    Recursively find notebook files.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "--profile=<Unicode> (BaseIPythonApplication.profile)\r\n",
       "    Default: u'default'\r\n",
       "    The IPython profile to use.\r\n",
@@ -194,13 +200,20 @@
       "--IncludeHeaderFooter.header=<Unicode>\r\n",
       "    Default: ''\r\n",
       "    Path to header notebook\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\r\n",
+      "CheckGradeIds options\r\n",
+      "---------------------\r\n",
+      "--CheckGradeIds.default_language=<Unicode>\r\n",
+      "    Default: 'ipython'\r\n",
+      "    DEPRECATED default highlight language, please use language_info metadata\r\n",
+      "    instead\r\n",
+      "--CheckGradeIds.display_data_priority=<List>\r\n",
+      "    Default: ['text/html', 'application/pdf', 'text/latex', 'image/svg+xml...\r\n",
+      "    An ordered list of preferred output type, the first encountered will usually\r\n",
+      "    be used when converting discarding the others.\r\n",
+      "--CheckGradeIds.enabled=<Bool>\r\n",
+      "    Default: False\r\n",
+      "\r\n",
       "LockCells options\r\n",
       "-----------------\r\n",
       "--LockCells.default_language=<Unicode>\r\n",

--- a/docs/command_line_tools/nbgrader autograde.ipynb
+++ b/docs/command_line_tools/nbgrader autograde.ipynb
@@ -80,13 +80,7 @@
       "Parameters are set from command-line arguments of the form:\r\n",
       "`--Class.trait=value`. This line is evaluated in Python, so simple expressions\r\n",
       "are allowed, e.g.:: `--C.a='range(3)'` For setting C.a=[0,1,2].\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\r\n",
       "AutogradeApp options\r\n",
       "--------------------\r\n",
       "--AutogradeApp.auto_create=<Bool>\r\n",
@@ -224,7 +218,13 @@
       "--OverwriteGradeCells.db_name=<Unicode>\r\n",
       "    Default: 'gradebook'\r\n",
       "    Database name\r\n",
-      "--OverwriteGradeCells.db_port=<Integer>\r\n",
+      "--OverwriteGradeCells.db_port=<Integer>\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "    Default: 27017\r\n",
       "    Port for the database\r\n",
       "--OverwriteGradeCells.default_language=<Unicode>\r\n",
@@ -238,19 +238,19 @@
       "--OverwriteGradeCells.enabled=<Bool>\r\n",
       "    Default: False\r\n",
       "\r\n",
-      "ExecutePreprocessor options\r\n",
-      "---------------------------\r\n",
-      "--ExecutePreprocessor.default_language=<Unicode>\r\n",
+      "Execute options\r\n",
+      "---------------\r\n",
+      "--Execute.default_language=<Unicode>\r\n",
       "    Default: 'ipython'\r\n",
       "    DEPRECATED default highlight language, please use language_info metadata\r\n",
       "    instead\r\n",
-      "--ExecutePreprocessor.display_data_priority=<List>\r\n",
+      "--Execute.display_data_priority=<List>\r\n",
       "    Default: ['text/html', 'application/pdf', 'text/latex', 'image/svg+xml...\r\n",
       "    An ordered list of preferred output type, the first encountered will usually\r\n",
       "    be used when converting discarding the others.\r\n",
-      "--ExecutePreprocessor.enabled=<Bool>\r\n",
+      "--Execute.enabled=<Bool>\r\n",
       "    Default: False\r\n",
-      "--ExecutePreprocessor.timeout=<Integer>\r\n",
+      "--Execute.timeout=<Integer>\r\n",
       "    Default: 30\r\n",
       "    The time to wait (in seconds) for output from executions.\r\n",
       "\r\n",

--- a/docs/command_line_tools/nbgrader validate.ipynb
+++ b/docs/command_line_tools/nbgrader validate.ipynb
@@ -37,7 +37,13 @@
       "--quiet\r\n",
       "    set log level to logging.CRITICAL (minimize logging output)\r\n",
       "--recursive\r\n",
-      "    Recursively find notebook files.\r\n",
+      "    Recursively find notebook files.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "--profile=<Unicode> (BaseIPythonApplication.profile)\r\n",
       "    Default: u'default'\r\n",
       "    The IPython profile to use.\r\n",

--- a/docs/user_guide/3 - Releasing assignments.ipynb
+++ b/docs/user_guide/3 - Releasing assignments.ipynb
@@ -144,7 +144,13 @@
       "[AssignApp] Writing 9866 bytes to /Users/jhamrick/project/tools/nbgrader/docs/user_guide/release_example/student/Problem 1.ipynb\r\n",
       "[AssignApp] Changing to directory: teacher\r\n",
       "[AssignApp] Converting notebook Problem 2.ipynb to notebook\r\n",
-      "[AssignApp] Support files will be in Problem 2_files/\r\n",
+      "[AssignApp] Support files will be in Problem 2_files/\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "[AssignApp] Writing output to directory: student\r\n",
       "[AssignApp] Writing 2689 bytes to /Users/jhamrick/project/tools/nbgrader/docs/user_guide/release_example/student/Problem 2.ipynb\r\n"
      ]
@@ -172,15 +178,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[AssignApp] Using existing profile dir: u'/Users/jhamrick/.nbgrader/profile_default'\r\n"
+      "[AssignApp] Using existing profile dir: u'/Users/jhamrick/.nbgrader/profile_default'\r\n",
+      "[AssignApp] Changing to directory: teacher\r\n",
+      "[AssignApp] Converting notebook Problem 1.ipynb to notebook\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[AssignApp] Changing to directory: teacher\r\n",
-      "[AssignApp] Converting notebook Problem 1.ipynb to notebook\r\n",
       "[AssignApp] Support files will be in Problem 1_files/\r\n"
      ]
     },

--- a/docs/user_guide/4 - Autograding.ipynb
+++ b/docs/user_guide/4 - Autograding.ipynb
@@ -51,8 +51,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "nbgrader_autograde_config.py  \u001b[34msubmitted\u001b[m\u001b[m/\r\n",
-      "nbgrader_formgrade_config.py\r\n",
+      "nbgrader_autograde_config.py  nbgrader_formgrade_config.py  \u001b[34msubmitted\u001b[m\u001b[m/\r\n",
       "\r\n",
       "./submitted:\r\n",
       "\u001b[34mBitdiddle\u001b[m\u001b[m/ \u001b[34mHacker\u001b[m\u001b[m/\r\n",
@@ -106,9 +105,9 @@
     {
      "data": {
       "text/plain": [
-       "[{\"_id\": \"576a1af2-b862-42d2-b061-b2f31c905171\", \"email\": null, \"student_id\": \"Bitdiddle\", \"last_name\": \"Bitdiddle\", \"first_name\": \"Ben\"},\n",
-       " {\"_id\": \"2770ea2b-d670-474f-ada9-0ba68c0f32cd\", \"email\": null, \"student_id\": \"Hacker\", \"last_name\": \"Hacker\", \"first_name\": \"Alyssa\"},\n",
-       " {\"_id\": \"eb8fabd9-68ec-45ff-ae42-958928ea3e9f\", \"email\": null, \"student_id\": \"Reasoner\", \"last_name\": \"Reasoner\", \"first_name\": \"Louis\"}]"
+       "[{\"_id\": \"9a93dbb0-1727-419e-94e5-787a4bb76171\", \"student_id\": \"Bitdiddle\", \"last_name\": \"Bitdiddle\", \"email\": null, \"first_name\": \"Ben\"},\n",
+       " {\"_id\": \"c8d3e3c9-ff96-4ca2-ac78-60ff51150d38\", \"student_id\": \"Hacker\", \"last_name\": \"Hacker\", \"email\": null, \"first_name\": \"Alyssa\"},\n",
+       " {\"_id\": \"5d71ba5a-5dbb-40c2-bce8-3e3ae506c80d\", \"student_id\": \"Reasoner\", \"last_name\": \"Reasoner\", \"email\": null, \"first_name\": \"Louis\"}]"
       ]
      },
      "execution_count": 4,
@@ -202,11 +201,29 @@
      "output_type": "stream",
      "text": [
       "[AutogradeApp] Using existing profile dir: u'/Users/jhamrick/.nbgrader/profile_default'\r\n",
-      "[AutogradeApp] Directory tree prefix: submitted/\r\n",
+      "[AutogradeApp] Directory tree prefix: submitted/\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "[AutogradeApp] Changing to directory: submitted/Bitdiddle\r\n",
       "[AutogradeApp] Converting notebook Problem 1.ipynb to notebook\r\n",
-      "[AutogradeApp] Support files will be in Problem 1_files/\r\n",
-      "[AutogradeApp] Student ID: Bitdiddle\r\n",
+      "[AutogradeApp] Support files will be in Problem 1_files/\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[AutogradeApp] Student ID: Bitdiddle\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "[AutogradeApp] Executing notebook with kernel: python3\r\n"
      ]
     },
@@ -218,8 +235,20 @@
       "[AutogradeApp] Writing 26743 bytes to /Users/jhamrick/project/tools/nbgrader/docs/user_guide/grade_example/autograded/Bitdiddle/Problem 1.ipynb\r\n",
       "[AutogradeApp] Changing to directory: submitted/Bitdiddle\r\n",
       "[AutogradeApp] Converting notebook Problem 2.ipynb to notebook\r\n",
-      "[AutogradeApp] Support files will be in Problem 2_files/\r\n",
-      "[AutogradeApp] Student ID: Bitdiddle\r\n",
+      "[AutogradeApp] Support files will be in Problem 2_files/\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[AutogradeApp] Student ID: Bitdiddle\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "[AutogradeApp] Executing notebook with kernel: python3\r\n"
      ]
     },
@@ -238,7 +267,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[AutogradeApp] Student ID: Hacker\r\n",
+      "[AutogradeApp] Student ID: Hacker\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "[AutogradeApp] Executing notebook with kernel: python3\r\n"
      ]
     },
@@ -250,8 +285,20 @@
       "[AutogradeApp] Writing 24718 bytes to /Users/jhamrick/project/tools/nbgrader/docs/user_guide/grade_example/autograded/Hacker/Problem 1.ipynb\r\n",
       "[AutogradeApp] Changing to directory: submitted/Hacker\r\n",
       "[AutogradeApp] Converting notebook Problem 2.ipynb to notebook\r\n",
-      "[AutogradeApp] Support files will be in Problem 2_files/\r\n",
-      "[AutogradeApp] Student ID: Hacker\r\n",
+      "[AutogradeApp] Support files will be in Problem 2_files/\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[AutogradeApp] Student ID: Hacker\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "[AutogradeApp] Executing notebook with kernel: python3\r\n"
      ]
     },
@@ -347,10 +394,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[AutogradeApp] Student ID: Bitdiddle\r\n",
+      "[AutogradeApp] Student ID: Bitdiddle\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "[AutogradeApp] WARNING | Checksum for grade cell correct_squares has changed!\r\n",
       "[AutogradeApp] WARNING | Checksum for grade cell correct_sum_of_squares has changed!\r\n",
-      "[AutogradeApp] WARNING | Checksum for grade cell plot_axis_limits has changed!\r\n",
+      "[AutogradeApp] WARNING | Checksum for grade cell plot_axis_limits has changed!\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "[AutogradeApp] WARNING | Checksum for grade cell plot_data has changed!\r\n"
      ]
     },
@@ -365,18 +424,24 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[AutogradeApp] Writing output to directory: autograded/Bitdiddle\r\n",
-      "[AutogradeApp] Writing 52565 bytes to /Users/jhamrick/project/tools/nbgrader/docs/user_guide/grade_example/autograded/Bitdiddle/Problem 1.ipynb\r\n",
-      "[AutogradeApp] Changing to directory: submitted/Bitdiddle\r\n",
-      "[AutogradeApp] Converting notebook Problem 2.ipynb to notebook\r\n",
-      "[AutogradeApp] Support files will be in Problem 2_files/\r\n"
+      "[AutogradeApp] Writing output to directory: autograded/Bitdiddle\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[AutogradeApp] Student ID: Bitdiddle\r\n",
+      "[AutogradeApp] Writing 52565 bytes to /Users/jhamrick/project/tools/nbgrader/docs/user_guide/grade_example/autograded/Bitdiddle/Problem 1.ipynb\r\n",
+      "[AutogradeApp] Changing to directory: submitted/Bitdiddle\r\n",
+      "[AutogradeApp] Converting notebook Problem 2.ipynb to notebook\r\n",
+      "[AutogradeApp] Support files will be in Problem 2_files/\r\n",
+      "[AutogradeApp] Student ID: Bitdiddle\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "[AutogradeApp] Executing notebook with kernel: python3\r\n"
      ]
     },
@@ -388,13 +453,7 @@
       "[AutogradeApp] Writing 2727 bytes to /Users/jhamrick/project/tools/nbgrader/docs/user_guide/grade_example/autograded/Bitdiddle/Problem 2.ipynb\r\n",
       "[AutogradeApp] Changing to directory: submitted/Hacker\r\n",
       "[AutogradeApp] Converting notebook Problem 1.ipynb to notebook\r\n",
-      "[AutogradeApp] Support files will be in Problem 1_files/\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "[AutogradeApp] Support files will be in Problem 1_files/\r\n",
       "[AutogradeApp] Student ID: Hacker\r\n"
      ]
     },
@@ -414,7 +473,13 @@
       "[AutogradeApp] Changing to directory: submitted/Hacker\r\n",
       "[AutogradeApp] Converting notebook Problem 2.ipynb to notebook\r\n",
       "[AutogradeApp] Support files will be in Problem 2_files/\r\n",
-      "[AutogradeApp] Student ID: Hacker\r\n",
+      "[AutogradeApp] Student ID: Hacker\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "[AutogradeApp] Executing notebook with kernel: python3\r\n"
      ]
     },
@@ -422,7 +487,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[AutogradeApp] Writing output to directory: autograded/Hacker\r\n",
+      "[AutogradeApp] Writing output to directory: autograded/Hacker\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "[AutogradeApp] Writing 2819 bytes to /Users/jhamrick/project/tools/nbgrader/docs/user_guide/grade_example/autograded/Hacker/Problem 2.ipynb\r\n"
      ]
     }

--- a/docs/user_guide/grade_example/autograded/Bitdiddle/Problem 1.ipynb
+++ b/docs/user_guide/grade_example/autograded/Bitdiddle/Problem 1.ipynb
@@ -389,7 +389,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.text.Text at 0x10aa78f28>"
+       "<matplotlib.text.Text at 0x105c30860>"
       ]
      },
      "execution_count": 11,
@@ -573,7 +573,7 @@
        "4mBmZkO4OJiZ2RAuDmZmNoSLg5mZDeHiYGZmQ/wvmcgGPw/gFOQAAAAASUVORK5CYII=\n"
       ],
       "text/plain": [
-       "<matplotlib.figure.Figure at 0x10aa46a58>"
+       "<matplotlib.figure.Figure at 0x105bfd470>"
       ]
      },
      "metadata": {},

--- a/docs/user_guide/grade_example/autograded/Hacker/Problem 1.ipynb
+++ b/docs/user_guide/grade_example/autograded/Hacker/Problem 1.ipynb
@@ -521,7 +521,7 @@
        "FqB3AAAAAElFTkSuQmCC\n"
       ],
       "text/plain": [
-       "<matplotlib.figure.Figure at 0x110dfef98>"
+       "<matplotlib.figure.Figure at 0x10f3eb940>"
       ]
      },
      "metadata": {},

--- a/nbgrader/apps/autogradeapp.py
+++ b/nbgrader/apps/autogradeapp.py
@@ -1,10 +1,10 @@
 from IPython.config.loader import Config
 from IPython.utils.traitlets import Unicode, List, Bool
-from IPython.nbconvert.preprocessors import ClearOutputPreprocessor, ExecutePreprocessor
+from IPython.nbconvert.preprocessors import ClearOutputPreprocessor
 from nbgrader.apps.customnbconvertapp import CustomNbConvertApp
 from nbgrader.apps.customnbconvertapp import aliases as base_aliases
 from nbgrader.apps.customnbconvertapp import flags as base_flags
-from nbgrader.preprocessors import FindStudentID, SaveAutoGrades, OverwriteGradeCells
+from nbgrader.preprocessors import FindStudentID, SaveAutoGrades, OverwriteGradeCells, Execute
 
 aliases = {}
 aliases.update(base_aliases)
@@ -50,7 +50,7 @@ class AutogradeApp(CustomNbConvertApp):
             FindStudentID,
             ClearOutputPreprocessor,
             OverwriteGradeCells,
-            ExecutePreprocessor,
+            Execute,
             SaveAutoGrades
         ])
         return classes
@@ -69,7 +69,7 @@ class AutogradeApp(CustomNbConvertApp):
                 'nbgrader.preprocessors.OverwriteGradeCells'
             )
         self.extra_config.Exporter.preprocessors.extend([
-            'IPython.nbconvert.preprocessors.ExecutePreprocessor',
+            'nbgrader.preprocessors.Execute',
             'nbgrader.preprocessors.SaveAutoGrades'
         ])
         self.config.merge(self.extra_config)

--- a/nbgrader/preprocessors/__init__.py
+++ b/nbgrader/preprocessors/__init__.py
@@ -8,3 +8,4 @@ from .computechecksums import ComputeChecksums
 from .savegradecells import SaveGradeCells
 from .overwritegradecells import OverwriteGradeCells
 from .checkgradeids import CheckGradeIds
+from .execute import Execute

--- a/nbgrader/preprocessors/execute.py
+++ b/nbgrader/preprocessors/execute.py
@@ -1,0 +1,89 @@
+from IPython.nbconvert.preprocessors import ExecutePreprocessor
+from IPython.nbformat.v4 import output_from_msg
+from IPython.kernel.manager import KernelManager
+
+try:
+    from queue import Empty  # Py 3
+except ImportError:
+    from Queue import Empty  # Py 2
+
+
+class Execute(ExecutePreprocessor):
+
+    def preprocess(self, nb, resources):
+        kernel_name = nb.metadata.get('kernelspec', {}).get('name', 'python')
+
+        self.km = KernelManager(kernel_name=kernel_name)
+        self.km.start_kernel(startup_timeout=60, extra_arguments=self.extra_arguments)
+        self.kc = self.km.client()
+        self.kc.start_channels(stdin=False)
+        self.kc.wait_for_ready()
+
+        try:
+            self.log.info("Executing notebook with kernel: %s" % kernel_name)
+            nb, resources = super(ExecutePreprocessor, self).preprocess(nb, resources)
+        finally:
+            self.kc.stop_channels()
+            self.km.shutdown_kernel(now=True)
+
+        return nb, resources
+
+    def run_cell(self, cell):
+        msg_id = self.kc.execute(cell.source)
+        self.log.debug("Executing cell:\n%s", cell.source)
+        # wait for finish, with timeout
+        while True:
+            try:
+                msg = self.kc.shell_channel.get_msg(timeout=self.timeout)
+            except Empty:
+                self.log.error("Timeout waiting for execute reply")
+                self.log.error("Interrupting kernel")
+                self.km.interrupt_kernel()
+                break
+
+            if msg['parent_header'].get('msg_id') == msg_id:
+                break
+            else:
+                # not our reply
+                continue
+
+        outs = []
+
+        while True:
+            try:
+                msg = self.kc.iopub_channel.get_msg(timeout=self.timeout)
+            except Empty:
+                self.log.warn("Timeout waiting for IOPub output")
+                break
+            if msg['parent_header'].get('msg_id') != msg_id:
+                # not an output from our execution
+                continue
+
+            msg_type = msg['msg_type']
+            self.log.debug("output: %s", msg_type)
+            content = msg['content']
+
+            # set the prompt number for the input and the output
+            if 'execution_count' in content:
+                cell['execution_count'] = content['execution_count']
+
+            if msg_type == 'status':
+                self.log.debug(content)
+                if content['execution_state'] == 'idle':
+                    break
+                else:
+                    continue
+            elif msg_type == 'execute_input':
+                continue
+            elif msg_type == 'clear_output':
+                outs = []
+                continue
+
+            try:
+                out = output_from_msg(msg)
+            except ValueError:
+                self.log.error("unhandled iopub msg: " + msg_type)
+            else:
+                outs.append(out)
+
+        return outs


### PR DESCRIPTION
This creates a modified version of the execute preprocessor that will (1) not allow standard input, and (2) timeout on long running cells with a kernel interrupt and continue running cells after that. With these two changes, if students leave `%debug` or `%raw_input` statements in their code, or if they have infinite loops/recursion, it won't cause the autograder to break.

Fixes #70