### PR TITLE
Anonymize students and add notebook link

### DIFF
--- a/nbgrader/apps/notebookapp.py
+++ b/nbgrader/apps/notebookapp.py
@@ -1,0 +1,24 @@
+import os
+from tornado import ioloop
+from IPython.html.notebookapp import NotebookApp
+
+class FormGradeNotebookApp(NotebookApp):
+    """A Subclass of the regular NotebookApp that can be spawned by the form grader."""
+    open_browser = False
+
+    def _ipython_dir_default(self):
+        d = os.path.join(os.environ["HOME"], ".nbgrader")
+        self._ipython_dir_changed('ipython_dir', d, d)
+        return d
+    
+    def _confirm_exit(self):
+        # disable the exit confirmation for background notebook processes
+        ioloop.IOLoop.instance().stop()
+    
+
+def main():
+    return FormGradeNotebookApp.launch_instance()
+
+
+if __name__ == "__main__":
+    main()

--- a/nbgrader/html/formgrade.py
+++ b/nbgrader/html/formgrade.py
@@ -1,5 +1,13 @@
 import json
 import os
+import urllib
+
+# python 3 compatibility
+try:
+    quote_plus = urllib.quote_plus
+except AttributeError:
+    quote_plus = urllib.parse.quote_plus
+
 
 from flask import Flask, request, abort, redirect, url_for, render_template, send_from_directory
 app = Flask(__name__, static_url_path='')
@@ -186,7 +194,10 @@ def view_submission(submission_id):
         'next': next_submission,
         'prev': prev_submission,
         'index': ix,
-        'total': len(submissions)
+        'total': len(submissions),
+        'notebook_path': "http://localhost:{}/notebooks/{}".format(
+            app.notebook_server_port,
+            os.path.relpath(filename, app.notebook_dir))
     }
 
     output, resources = app.exporter.from_filename(filename, resources=resources)

--- a/nbgrader/html/formgrade.py
+++ b/nbgrader/html/formgrade.py
@@ -2,13 +2,6 @@ import json
 import os
 import urllib
 
-# python 3 compatibility
-try:
-    quote_plus = urllib.quote_plus
-except AttributeError:
-    quote_plus = urllib.parse.quote_plus
-
-
 from flask import Flask, request, abort, redirect, url_for, render_template, send_from_directory
 app = Flask(__name__, static_url_path='')
 

--- a/nbgrader/html/static/js/formgrade.js
+++ b/nbgrader/html/static/js/formgrade.js
@@ -139,6 +139,7 @@ $(window).load(function () {
 
     $("li.previous a").tooltip({container: 'body'});
     $("li.next a").tooltip({container: 'body'});
+    $("li.live-notebook a").tooltip({container: 'body'});
 
     // disable link selection on tabs
     $('a').attr('tabindex', '-1');

--- a/nbgrader/html/static/js/formgrade.js
+++ b/nbgrader/html/static/js/formgrade.js
@@ -1,4 +1,4 @@
-/*global $, Backbone, student, nb_uuid */
+/*global $, Backbone, student, submission_id */
 
 var Grade = Backbone.Model.extend({
     idAttribute: "_id",
@@ -48,7 +48,7 @@ var Grade = Backbone.Model.extend({
 
 var Grades = Backbone.Collection.extend({
     model: Grade,
-    url: "/api/notebook/" + nb_uuid + "/grades"
+    url: "/api/notebook/" + submission_id + "/grades"
 });
 
 var Comment = Backbone.Model.extend({
@@ -83,7 +83,7 @@ var Comment = Backbone.Model.extend({
 
 var Comments = Backbone.Collection.extend({
     model: Comment,
-    url: "/api/notebook/" + nb_uuid + "/comments"
+    url: "/api/notebook/" + submission_id + "/comments"
 });
 
 var getIndex = function (elem) {

--- a/nbgrader/html/templates/formgrade.tpl
+++ b/nbgrader/html/templates/formgrade.tpl
@@ -59,7 +59,7 @@ var submission_id = "{{ resources.submission_id }}";
             <li><a href="/assignments">Assignments</a></li>
             <li><a href="/assignments/{{ resources.assignment_id }}">{{ resources.assignment_id }}</a></li>
             <li><a href="/assignments/{{ resources.assignment_id }}/{{ resources.notebook_id }}">{{ resources.notebook_id }}</a></li>
-            <li class="active">Submission #{{ resources.index + 1 }}</li>
+            <li class="active"><a target="_blank" href="{{ resources.notebook_path }}">Submission #{{ resources.index + 1 }}</a></li>
           </ul>
         </ul>
       </div>

--- a/nbgrader/html/templates/formgrade.tpl
+++ b/nbgrader/html/templates/formgrade.tpl
@@ -59,7 +59,11 @@ var submission_id = "{{ resources.submission_id }}";
             <li><a href="/assignments">Assignments</a></li>
             <li><a href="/assignments/{{ resources.assignment_id }}">{{ resources.assignment_id }}</a></li>
             <li><a href="/assignments/{{ resources.assignment_id }}/{{ resources.notebook_id }}">{{ resources.notebook_id }}</a></li>
-            <li class="active"><a target="_blank" href="{{ resources.notebook_path }}">Submission #{{ resources.index + 1 }}</a></li>
+            <li class="active live-notebook">
+              <a data-toggle="tooltip" data-placement="right" title="Open live notebook" target="_blank" href="{{ resources.notebook_path }}">
+                Submission #{{ resources.index + 1 }}
+              </a>
+            </li>
           </ul>
         </ul>
       </div>

--- a/nbgrader/html/templates/formgrade.tpl
+++ b/nbgrader/html/templates/formgrade.tpl
@@ -15,7 +15,7 @@
 <script src="/static/lib/bootstrap.min.js"></script>
 
 <script type="text/javascript">
-var nb_uuid = "{{ resources.notebook_uuid }}";
+var submission_id = "{{ resources.submission_id }}";
 </script>
 
 <script src="/static/js/formgrade.js"></script>
@@ -44,7 +44,7 @@ var nb_uuid = "{{ resources.notebook_uuid }}";
         <ul class="nav navbar-nav navbar-left">
           {%- if resources.prev -%}
           <li class="previous">
-            <a data-toggle="tooltip" data-placement="right" title="{{ resources.prev.last_name }}, {{ resources.prev.first_name }}" href="/assignments/{{ resources.assignment_id }}/{{ resources.notebook_id }}/{{ resources.prev.student_id }}">
+            <a data-toggle="tooltip" data-placement="right" title="{{ resources.index }} remaining" href="/submissions/{{ resources.prev }}">
             &larr; Prev
             </a>
           </li>
@@ -59,7 +59,7 @@ var nb_uuid = "{{ resources.notebook_uuid }}";
             <li><a href="/assignments">Assignments</a></li>
             <li><a href="/assignments/{{ resources.assignment_id }}">{{ resources.assignment_id }}</a></li>
             <li><a href="/assignments/{{ resources.assignment_id }}/{{ resources.notebook_id }}">{{ resources.notebook_id }}</a></li>
-            <li class="active">{{ resources.student.student_id }}</li>
+            <li class="active">Submission #{{ resources.index + 1 }}</li>
           </ul>
         </ul>
       </div>
@@ -67,7 +67,7 @@ var nb_uuid = "{{ resources.notebook_uuid }}";
         <ul class="nav navbar-nav navbar-right">
           {%- if resources.next -%}
           <li class="next">
-            <a data-toggle="tooltip" data-placement="left" title="{{ resources.next.last_name }}, {{ resources.next.first_name }}" href="/assignments/{{ resources.assignment_id }}/{{ resources.notebook_id }}/{{ resources.next.student_id }}">
+            <a data-toggle="tooltip" data-placement="left" title="{{ resources.total - (resources.index + 1) }} remaining" href="/submissions/{{ resources.next }}">
             Next &rarr;
             </a>
           </li>
@@ -82,7 +82,10 @@ var nb_uuid = "{{ resources.notebook_uuid }}";
   <div class="container">
     <div class="panel panel-default">
       <div class="panel-heading">
-        <h4>{{ resources.notebook_id }} - {{ resources.student.last_name }}, {{ resources.student.first_name }}</h4>
+        <h4 class="panel-title">
+          <span>{{ resources.notebook_id }}</span>
+          <span class="pull-right">Submission {{ resources.index + 1 }} / {{ resources.total }}</span>
+        </h4>
       </div>
       <div class="panel-body">
         <div id="notebook" class="border-box-sizing">

--- a/nbgrader/html/templates/notebook_submissions.tpl
+++ b/nbgrader/html/templates/notebook_submissions.tpl
@@ -10,51 +10,25 @@
 <div class="panel-body">
   The following table lists all the student submissions for the
   notebook "{{ notebook_id }}", which is part of the assignment "{{
-  assignment.assignment_id }}". By clicking on a student's name, you
-  can grade their submitted notebook.
+  assignment.assignment_id }}". By clicking on a submission id, you
+  can grade the submitted notebook.
 </div>
 {%- endblock -%}
 
 {%- block table -%}
 <thead>
   <tr>
-    <th>Student name</th>
-    <th class="center">Student ID</th>
+    <th>Submission ID</th>
     <th class="center">Score</th>
-    <th class="center">Received?</th>
     <th class="center">Manual grade?</th>
   </tr>
 </thead>
 <tbody>
   {%- for submission in submissions -%}
-  {%- if submission.score == None -%}
-  <tr class="warning">
-  {%- else -%}
   <tr>
-  {%- endif -%}
-    <td>
-      {%- if submission.score != None -%}
-      <a href="/assignments/{{ assignment.assignment_id }}/{{ notebook_id }}/{{ submission.student.student_id }}">
-        {{ submission.student.last_name }}, {{ submission.student.first_name }}
-      </a>
-      {%- else -%}
-        {{ submission.student.last_name }}, {{ submission.student.first_name }}
-      {%- endif -%}
-    </td>
-    <td class="center">{{ submission.student.student_id }}</td>
+    <td><a href="/submissions/{{ submission._id }}">Submission #{{ submission.index + 1 }}</a></td>
     <td class="center">
-      {%- if submission.score == None -%}
-      -
-      {%- else -%}
       {{ submission.score | float | round(2) }} / {{ submission.max_score | float | round(2) }}
-      {%- endif -%}
-    </td>
-    <td class="center">
-      {%- if submission.score == None -%}
-      <span class="glyphicon glyphicon-remove"></span>
-      {%- else -%}
-      <span class="glyphicon glyphicon-ok"></span>
-      {%- endif -%}
     </td>
     <td class="center">
       {%- if submission.needs_manual_grade -%}


### PR DESCRIPTION
This sorts submissions by submission id, rather than by student id, and does not display the student id in the grading interface. This is better, because when you are just going through and grading all assignments, it is better for the order to be randomized and for the student names to be anonymized. However, this presents a challenge, which is that it makes it impossible to manually open the student's notebook in a live notebook server -- so this additionally adds functionality to launch a notebook server along with the formgrader, and a link to open the live notebook if so desired.

* Fixes #84
* Fixes #85 
