### PR TITLE
Check solution cell type

### DIFF
--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -183,13 +183,19 @@ class SolutionCell(Base):
     assignment = association_proxy("notebook", "assignment")
 
     comments = relationship("Comment", backref="cell")
+    cell_type = Column(Enum("code", "markdown"), nullable=False)
+    source = Column(Text())
+    checksum = Column(String(128))
 
     def to_dict(self):
         return {
             "id": self.id,
             "name": self.name,
             "notebook": self.notebook.name,
-            "assignment": self.assignment.name
+            "assignment": self.assignment.name,
+            "cell_type": self.cell_type,
+            "source": self.source,
+            "checksum": self.checksum
         }
 
     def __repr__(self):

--- a/nbgrader/apps/assignapp.py
+++ b/nbgrader/apps/assignapp.py
@@ -11,7 +11,7 @@ from nbgrader.preprocessors import (
     ClearSolutions,
     LockCells,
     ComputeChecksums,
-    SaveGradeCells,
+    SaveCells,
     CheckGradeIds
 )
 
@@ -93,7 +93,7 @@ class AssignApp(BaseNbConvertApp):
             ClearSolutions,
             ClearOutputPreprocessor,
             ComputeChecksums,
-            SaveGradeCells
+            SaveCells
         ])
         return classes
 
@@ -109,6 +109,6 @@ class AssignApp(BaseNbConvertApp):
         ]
         if self.save_cells:
             self.extra_config.Exporter.preprocessors.append(
-                'nbgrader.preprocessors.SaveGradeCells'
+                'nbgrader.preprocessors.SaveCells'
             )
         self.config.merge(self.extra_config)

--- a/nbgrader/apps/autogradeapp.py
+++ b/nbgrader/apps/autogradeapp.py
@@ -98,12 +98,12 @@ class AutogradeApp(BaseNbConvertApp):
         ]
         if self.overwrite_cells:
             self.extra_config.Exporter.preprocessors.append(
-                'nbgrader.preprocessors.OverwriteGradeCells'
+                'nbgrader.preprocessors.OverwriteCells'
             )
         else:
             self.extra_config.Exporter.preprocessors.extend([
                 'nbgrader.preprocessors.ComputeChecksums',
-                'nbgrader.preprocessors.SaveGradeCells'
+                'nbgrader.preprocessors.SaveCells'
             ])
         self.extra_config.Exporter.preprocessors.extend([
             'nbgrader.preprocessors.Execute',

--- a/nbgrader/preprocessors/__init__.py
+++ b/nbgrader/preprocessors/__init__.py
@@ -6,6 +6,6 @@ from .saveautogrades import SaveAutoGrades
 from .displayautogrades import DisplayAutoGrades
 from .computechecksums import ComputeChecksums
 from .savecells import SaveCells
-from .overwritegradecells import OverwriteGradeCells
+from .overwritecells import OverwriteCells
 from .checkgradeids import CheckGradeIds
 from .execute import Execute

--- a/nbgrader/preprocessors/__init__.py
+++ b/nbgrader/preprocessors/__init__.py
@@ -5,7 +5,7 @@ from .findstudentid import FindStudentID
 from .saveautogrades import SaveAutoGrades
 from .displayautogrades import DisplayAutoGrades
 from .computechecksums import ComputeChecksums
-from .savegradecells import SaveGradeCells
+from .savecells import SaveCells
 from .overwritegradecells import OverwriteGradeCells
 from .checkgradeids import CheckGradeIds
 from .execute import Execute

--- a/nbgrader/preprocessors/computechecksums.py
+++ b/nbgrader/preprocessors/computechecksums.py
@@ -4,15 +4,27 @@ from .. import utils
 class ComputeChecksums(Preprocessor):
     """A preprocessor to compute checksums of grade cells."""
 
+    def preprocess(self, nb, resources):
+        self.comment_index = 0
+        nb, resources = super(ComputeChecksums, self).preprocess(nb, resources)
+        return nb, resources
+
     def preprocess_cell(self, cell, resources, cell_index):
-        # compute checksums of grade cells, but not those of solution
-        # cells, because solution cells will be modified by students
-        if utils.is_grade(cell) and not utils.is_solution(cell):
+        # compute checksums of grade cell and solution cells
+        if utils.is_grade(cell) or utils.is_solution(cell):
             checksum = utils.compute_checksum(cell)
             cell.metadata.nbgrader['checksum'] = checksum
-            self.log.debug(
-                "Checksum for '%s' is %s",
-                cell.metadata.nbgrader['grade_id'],
-                checksum)
+
+            if utils.is_grade(cell):
+                self.log.debug(
+                    "Checksum for '%s' is %s",
+                    cell.metadata.nbgrader['grade_id'],
+                    checksum)
+            if utils.is_solution(cell):
+                self.log.debug(
+                    "Checksum for solution cell #%s is %s",
+                    self.comment_index,
+                    checksum)
+                self.comment_index += 1
 
         return cell, resources

--- a/nbgrader/tests/base.py
+++ b/nbgrader/tests/base.py
@@ -9,6 +9,8 @@ from IPython.nbformat import read as read_nb
 from IPython.nbformat import write as write_nb
 from IPython.nbformat.v4 import new_notebook, new_code_cell, new_markdown_cell
 
+from nbgrader.utils import compute_checksum
+
 
 class TestBase(object):
 
@@ -49,8 +51,43 @@ print("hello")
         cell.metadata.nbgrader["grade"] = True
         cell.metadata.nbgrader["grade_id"] = grade_id
         cell.metadata.nbgrader["points"] = points
+        cell.metadata.nbgrader["checksum"] = compute_checksum(cell)
 
         return cell
+
+    @staticmethod
+    def _create_solution_cell(source, cell_type):
+        if cell_type == "markdown":
+            cell = new_markdown_cell(source=source)
+        elif cell_type == "code":
+            cell = new_code_cell(source=source)
+        else:
+            raise ValueError("invalid cell type: {}".format(cell_type))
+
+        cell.metadata.nbgrader = {}
+        cell.metadata.nbgrader["solution"] = True
+        cell.metadata.nbgrader["checksum"] = compute_checksum(cell)
+
+        return cell
+
+    @staticmethod
+    def _create_grade_and_solution_cell(source, cell_type, grade_id, points):
+        if cell_type == "markdown":
+            cell = new_markdown_cell(source=source)
+        elif cell_type == "code":
+            cell = new_code_cell(source=source)
+        else:
+            raise ValueError("invalid cell type: {}".format(cell_type))
+
+        cell.metadata.nbgrader = {}
+        cell.metadata.nbgrader["solution"] = True
+        cell.metadata.nbgrader["grade"] = True
+        cell.metadata.nbgrader["grade_id"] = grade_id
+        cell.metadata.nbgrader["points"] = points
+        cell.metadata.nbgrader["checksum"] = compute_checksum(cell)
+
+        return cell
+
 
     @staticmethod
     def _empty_notebook(path):

--- a/nbgrader/tests/test_api.py
+++ b/nbgrader/tests/test_api.py
@@ -85,12 +85,16 @@ class TestApi(object):
         now = datetime.datetime.now()
         a = api.Assignment(name='foo', duedate=now)
         n = api.Notebook(name='blah', assignment=a)
-        s = api.SolutionCell(name='foo', notebook=n)
+        s = api.SolutionCell(name='foo', notebook=n, source="hello", 
+            cell_type="code", checksum="12345")
         self.db.add(a)
         self.db.commit()
 
         assert s.id
         assert s.name == 'foo'
+        assert s.cell_type == "code"
+        assert s.source == "hello"
+        assert s.checksum == "12345"
         assert s.assignment == a
         assert s.notebook == n
         assert s.comments == []
@@ -393,7 +397,7 @@ class TestApi(object):
         now = datetime.datetime.now()
         a = api.Assignment(name='foo', duedate=now)
         n = api.Notebook(name='blah', assignment=a)
-        sc = api.SolutionCell(name='foo', notebook=n)
+        sc = api.SolutionCell(name='foo', notebook=n, cell_type="code")
         s = api.Student(id="12345", first_name='Jane', last_name='Doe', email='janedoe@nowhere')
         sa = api.SubmittedAssignment(assignment=a, student=s)
         sn = api.SubmittedNotebook(assignment=sa, notebook=n)

--- a/nbgrader/tests/test_computechecksums.py
+++ b/nbgrader/tests/test_computechecksums.py
@@ -1,4 +1,6 @@
 from nbgrader.preprocessors import ComputeChecksums
+from nbgrader.utils import compute_checksum
+from nose.tools import assert_equal, assert_not_equal
 from .base import TestBase
 
 
@@ -7,6 +9,7 @@ class TestComputeChecksums(TestBase):
     def setup(self):
         super(TestComputeChecksums, self).setup()
         self.preprocessor = ComputeChecksums()
+        self.preprocessor.comment_index = 0
 
     def test_code_cell_no_checksum(self):
         """Test that no checksum is computed for a regular code cell"""
@@ -20,16 +23,27 @@ class TestComputeChecksums(TestBase):
             self._create_text_cell(), {}, 0)
         assert "nbgrader" not in cell.metadata or "checksum" not in cell.metadata.nbgrader
 
-    def test_checksum_cell_type(self):
+    def test_checksum_grade_cell_type(self):
         """Test that the checksum is computed for grade cells of different cell types"""
         cell1 = self._create_grade_cell("", "code", "foo", 1)
         cell1 = self.preprocessor.preprocess_cell(cell1, {}, 0)[0]
         cell2 = self._create_grade_cell("", "markdown", "foo", 1)
         cell2 = self.preprocessor.preprocess_cell(cell2, {}, 0)[0]
 
-        assert cell1.metadata.nbgrader["checksum"]
-        assert cell2.metadata.nbgrader["checksum"]
-        assert cell1.metadata.nbgrader["checksum"] != cell2.metadata.nbgrader["checksum"]
+        assert_equal(cell1.metadata.nbgrader["checksum"], compute_checksum(cell1))
+        assert_equal(cell2.metadata.nbgrader["checksum"], compute_checksum(cell2))
+        assert_not_equal(cell1.metadata.nbgrader["checksum"], cell2.metadata.nbgrader["checksum"])
+
+    def test_checksum_solution_cell_type(self):
+        """Test that the checksum is computed for solution cells of different cell types"""
+        cell1 = self._create_solution_cell("", "code")
+        cell1 = self.preprocessor.preprocess_cell(cell1, {}, 0)[0]
+        cell2 = self._create_solution_cell("", "markdown")
+        cell2 = self.preprocessor.preprocess_cell(cell2, {}, 0)[0]
+
+        assert_equal(cell1.metadata.nbgrader["checksum"], compute_checksum(cell1))
+        assert_equal(cell2.metadata.nbgrader["checksum"], compute_checksum(cell2))
+        assert_not_equal(cell1.metadata.nbgrader["checksum"], cell2.metadata.nbgrader["checksum"])
 
     def test_checksum_points(self):
         """Test that the checksum is computed for grade cells with different points"""
@@ -38,9 +52,9 @@ class TestComputeChecksums(TestBase):
         cell2 = self._create_grade_cell("", "code", "foo", 2)
         cell2 = self.preprocessor.preprocess_cell(cell2, {}, 0)[0]
 
-        assert cell1.metadata.nbgrader["checksum"]
-        assert cell2.metadata.nbgrader["checksum"]
-        assert cell1.metadata.nbgrader["checksum"] != cell2.metadata.nbgrader["checksum"]
+        assert_equal(cell1.metadata.nbgrader["checksum"], compute_checksum(cell1))
+        assert_equal(cell2.metadata.nbgrader["checksum"], compute_checksum(cell2))
+        assert_not_equal(cell1.metadata.nbgrader["checksum"], cell2.metadata.nbgrader["checksum"])
 
     def test_checksum_grade_id(self):
         """Test that the checksum is computed for grade cells with different ids"""
@@ -49,24 +63,40 @@ class TestComputeChecksums(TestBase):
         cell2 = self._create_grade_cell("", "code", "bar", 1)
         cell2 = self.preprocessor.preprocess_cell(cell2, {}, 0)[0]
 
-        assert cell1.metadata.nbgrader["checksum"]
-        assert cell2.metadata.nbgrader["checksum"]
-        assert cell1.metadata.nbgrader["checksum"] != cell2.metadata.nbgrader["checksum"]
+        assert_equal(cell1.metadata.nbgrader["checksum"], compute_checksum(cell1))
+        assert_equal(cell2.metadata.nbgrader["checksum"], compute_checksum(cell2))
+        assert_not_equal(cell1.metadata.nbgrader["checksum"], cell2.metadata.nbgrader["checksum"])
 
-    def test_checksum_source(self):
+    def test_checksum_grade_source(self):
         """Test that the checksum is computed for grade cells with different sources"""
         cell1 = self._create_grade_cell("a", "code", "foo", 1)
         cell1 = self.preprocessor.preprocess_cell(cell1, {}, 0)[0]
         cell2 = self._create_grade_cell("b", "code", "foo", 1)
         cell2 = self.preprocessor.preprocess_cell(cell2, {}, 0)[0]
 
-        assert cell1.metadata.nbgrader["checksum"]
-        assert cell2.metadata.nbgrader["checksum"]
-        assert cell1.metadata.nbgrader["checksum"] != cell2.metadata.nbgrader["checksum"]
+        assert_equal(cell1.metadata.nbgrader["checksum"], compute_checksum(cell1))
+        assert_equal(cell2.metadata.nbgrader["checksum"], compute_checksum(cell2))
+        assert_not_equal(cell1.metadata.nbgrader["checksum"], cell2.metadata.nbgrader["checksum"])
 
-    def test_no_checksum_grade_and_solution(self):
-        """Test that a checksum is not created for grade cells that are also solution cells"""
-        cell = self._create_grade_cell("", "markdown", "foo", 1)
-        cell.metadata.nbgrader["solution"] = True
-        cell = self.preprocessor.preprocess_cell(cell, {}, 0)[0]
-        assert "checksum" not in cell.metadata.nbgrader
+    def test_checksum_solution_source(self):
+        """Test that the checksum is computed for solution cells with different sources"""
+        cell1 = self._create_solution_cell("a", "code")
+        cell1 = self.preprocessor.preprocess_cell(cell1, {}, 0)[0]
+        cell2 = self._create_solution_cell("b", "code")
+        cell2 = self.preprocessor.preprocess_cell(cell2, {}, 0)[0]
+
+        assert_equal(cell1.metadata.nbgrader["checksum"], compute_checksum(cell1))
+        assert_equal(cell2.metadata.nbgrader["checksum"], compute_checksum(cell2))
+        assert_not_equal(cell1.metadata.nbgrader["checksum"], cell2.metadata.nbgrader["checksum"])
+
+    def test_checksum_grade_and_solution(self):
+        """Test that a checksum is created for grade cells that are also solution cells"""
+        cell1 = self._create_grade_cell("", "markdown", "foo", 1)
+        cell1 = self.preprocessor.preprocess_cell(cell1, {}, 0)[0]
+        cell2 = self._create_grade_cell("", "markdown", "foo", 1)
+        cell2.metadata.nbgrader["solution"] = True
+        cell2 = self.preprocessor.preprocess_cell(cell2, {}, 0)[0]
+
+        assert_equal(cell1.metadata.nbgrader["checksum"], compute_checksum(cell1))
+        assert_equal(cell2.metadata.nbgrader["checksum"], compute_checksum(cell2))
+        assert_not_equal(cell1.metadata.nbgrader["checksum"], cell2.metadata.nbgrader["checksum"])

--- a/nbgrader/tests/test_overwritecells.py
+++ b/nbgrader/tests/test_overwritecells.py
@@ -37,7 +37,7 @@ class TestSaveCells(TestBase):
 
         assert_equal(cell.metadata.nbgrader["points"], 1)
 
-    def test_overwrite_source(self):
+    def test_overwrite_grade_source(self):
         """Is the source overwritten for grade cells?"""
         cell = self._create_grade_cell("hello", "code", "foo", 1)
         nb = new_notebook()
@@ -49,9 +49,19 @@ class TestSaveCells(TestBase):
 
         assert_equal(cell.source, "hello")
 
-    def test_dont_overwrite_source(self):
+    def test_dont_overwrite_grade_and_solution_source(self):
         """Is the source not overwritten for grade+solution cells?"""
         cell = self._create_grade_and_solution_cell("hello", "code", "foo", 1)
+        nb = new_notebook()
+        nb.cells.append(cell)
+        nb, resources = self.preprocessor1.preprocess(nb, self.resources)
+
+        cell.source = "hello!"
+        nb, resources = self.preprocessor2.preprocess(nb, self.resources)
+
+    def test_dont_overwrite_solution_source(self):
+        """Is the source not overwritten for solution cells?"""
+        cell = self._create_solution_cell("hello", "code")
         nb = new_notebook()
         nb.cells.append(cell)
         nb, resources = self.preprocessor1.preprocess(nb, self.resources)

--- a/nbgrader/tests/test_overwritecells.py
+++ b/nbgrader/tests/test_overwritecells.py
@@ -1,0 +1,111 @@
+from nose.tools import assert_equal
+from nbgrader.preprocessors import SaveCells, OverwriteCells
+from nbgrader.api import Gradebook
+from nbgrader.utils import compute_checksum
+from IPython.nbformat.v4 import new_notebook
+
+from .base import TestBase
+
+
+class TestSaveCells(TestBase):
+
+    def setup(self):
+        super(TestSaveCells, self).setup()
+        db_url = self._init_db()
+        self.gb = Gradebook(db_url)
+        self.gb.add_assignment("ps0")
+
+        self.preprocessor1 = SaveCells()
+        self.preprocessor2 = OverwriteCells()
+        self.resources = {
+            "nbgrader": {
+                "db_url": db_url,
+                "assignment": "ps0",
+                "notebook": "test"
+            }
+        }
+
+    def test_overwrite_points(self):
+        """Are points overwritten for grade cells?"""
+        cell = self._create_grade_cell("hello", "code", "foo", 1)
+        nb = new_notebook()
+        nb.cells.append(cell)
+        nb, resources = self.preprocessor1.preprocess(nb, self.resources)
+
+        cell.metadata.nbgrader["points"] = 2
+        nb, resources = self.preprocessor2.preprocess(nb, self.resources)
+
+        assert_equal(cell.metadata.nbgrader["points"], 1)
+
+    def test_overwrite_source(self):
+        """Is the source overwritten for grade cells?"""
+        cell = self._create_grade_cell("hello", "code", "foo", 1)
+        nb = new_notebook()
+        nb.cells.append(cell)
+        nb, resources = self.preprocessor1.preprocess(nb, self.resources)
+
+        cell.source = "hello!"
+        nb, resources = self.preprocessor2.preprocess(nb, self.resources)
+
+        assert_equal(cell.source, "hello")
+
+    def test_dont_overwrite_source(self):
+        """Is the source not overwritten for grade+solution cells?"""
+        cell = self._create_grade_and_solution_cell("hello", "code", "foo", 1)
+        nb = new_notebook()
+        nb.cells.append(cell)
+        nb, resources = self.preprocessor1.preprocess(nb, self.resources)
+
+        cell.source = "hello!"
+        nb, resources = self.preprocessor2.preprocess(nb, self.resources)
+
+        assert_equal(cell.source, "hello!")
+
+    def test_overwrite_grade_cell_type(self):
+        """Is the cell type overwritten for grade cells?"""
+        cell = self._create_grade_cell("hello", "code", "foo", 1)
+        nb = new_notebook()
+        nb.cells.append(cell)
+        nb, resources = self.preprocessor1.preprocess(nb, self.resources)
+
+        cell.cell_type = "markdown"
+        nb, resources = self.preprocessor2.preprocess(nb, self.resources)
+
+        assert_equal(cell.cell_type, "code")
+
+    def test_overwrite_grade_cell_type(self):
+        """Is the cell type overwritten for solution cells?"""
+        cell = self._create_solution_cell("hello", "code")
+        nb = new_notebook()
+        nb.cells.append(cell)
+        nb, resources = self.preprocessor1.preprocess(nb, self.resources)
+
+        cell.cell_type = "markdown"
+        nb, resources = self.preprocessor2.preprocess(nb, self.resources)
+
+        assert_equal(cell.cell_type, "code")
+
+    def test_overwrite_grade_checksum(self):
+        """Is the checksum overwritten for grade cells?"""
+        cell = self._create_grade_cell("hello", "code", "foo", 1)
+        nb = new_notebook()
+        nb.cells.append(cell)
+        nb, resources = self.preprocessor1.preprocess(nb, self.resources)
+
+        cell.metadata.nbgrader["checksum"] = "1234"
+        nb, resources = self.preprocessor2.preprocess(nb, self.resources)
+
+        assert_equal(cell.metadata.nbgrader["checksum"], compute_checksum(cell))
+
+    def test_overwrite_solution_checksum(self):
+        """Is the checksum overwritten for solution cells?"""
+        cell = self._create_solution_cell("hello", "code")
+        nb = new_notebook()
+        nb.cells.append(cell)
+        nb, resources = self.preprocessor1.preprocess(nb, self.resources)
+
+        cell.metadata.nbgrader["checksum"] = "1234"
+        nb, resources = self.preprocessor2.preprocess(nb, self.resources)
+
+        assert_equal(cell.metadata.nbgrader["checksum"], compute_checksum(cell))
+

--- a/nbgrader/tests/test_savecells.py
+++ b/nbgrader/tests/test_savecells.py
@@ -1,0 +1,116 @@
+from nose.tools import assert_equal
+from nbgrader.preprocessors import SaveCells
+from nbgrader.api import Gradebook
+from IPython.nbformat.v4 import new_notebook
+
+from .base import TestBase
+
+
+class TestSaveCells(TestBase):
+
+    def setup(self):
+        super(TestSaveCells, self).setup()
+        db_url = self._init_db()
+        self.gb = Gradebook(db_url)
+        self.gb.add_assignment("ps0")
+
+        self.preprocessor = SaveCells()
+        self.resources = {
+            "nbgrader": {
+                "db_url": db_url,
+                "assignment": "ps0",
+                "notebook": "test"
+            }
+        }
+
+    def test_save_code_grade_cell(self):
+        cell = self._create_grade_cell("hello", "code", "foo", 1)
+        nb = new_notebook()
+        nb.cells.append(cell)
+
+        nb, resources = self.preprocessor.preprocess(nb, self.resources)
+
+        gb = self.preprocessor.gradebook
+        grade_cell = gb.find_grade_cell("foo", "test", "ps0")
+        assert_equal(grade_cell.max_score, 1, "max_score is incorrect")
+        assert_equal(grade_cell.source, "hello", "source is incorrect")
+        assert_equal(grade_cell.checksum, cell.metadata.nbgrader["checksum"], "checksum is incorrect")
+        assert_equal(grade_cell.cell_type, "code", "cell_type is incorrect")
+
+    def test_save_markdown_grade_cell(self):
+        cell = self._create_grade_cell("hello", "markdown", "foo", 1)
+        nb = new_notebook()
+        nb.cells.append(cell)
+
+        nb, resources = self.preprocessor.preprocess(nb, self.resources)
+
+        gb = self.preprocessor.gradebook
+        grade_cell = gb.find_grade_cell("foo", "test", "ps0")
+        assert_equal(grade_cell.max_score, 1, "max_score is incorrect")
+        assert_equal(grade_cell.source, "hello", "source is incorrect")
+        assert_equal(grade_cell.checksum, cell.metadata.nbgrader["checksum"], "checksum is incorrect")
+        assert_equal(grade_cell.cell_type, "markdown", "cell_type is incorrect")
+
+    def test_save_code_solution_cell(self):
+        cell = self._create_solution_cell("hello", "code")
+        nb = new_notebook()
+        nb.cells.append(cell)
+
+        nb, resources = self.preprocessor.preprocess(nb, self.resources)
+
+        gb = self.preprocessor.gradebook
+        solution_cell = gb.find_solution_cell(0, "test", "ps0")
+        assert_equal(solution_cell.source, "hello", "source is incorrect")
+        assert_equal(solution_cell.checksum, cell.metadata.nbgrader["checksum"], "checksum is incorrect")
+        assert_equal(solution_cell.cell_type, "code", "cell_type is incorrect")
+
+    def test_save_markdown_solution_cell(self):
+        cell = self._create_solution_cell("hello", "markdown")
+        nb = new_notebook()
+        nb.cells.append(cell)
+
+        nb, resources = self.preprocessor.preprocess(nb, self.resources)
+
+        gb = self.preprocessor.gradebook
+        solution_cell = gb.find_solution_cell(0, "test", "ps0")
+        assert_equal(solution_cell.source, "hello", "source is incorrect")
+        assert_equal(solution_cell.checksum, cell.metadata.nbgrader["checksum"], "checksum is incorrect")
+        assert_equal(solution_cell.cell_type, "markdown", "cell_type is incorrect")
+
+    def test_save_code_grade_and_solution_cell(self):
+        cell = self._create_grade_and_solution_cell("hello", "code", "foo", 1)
+        nb = new_notebook()
+        nb.cells.append(cell)
+
+        nb, resources = self.preprocessor.preprocess(nb, self.resources)
+
+        gb = self.preprocessor.gradebook
+        grade_cell = gb.find_grade_cell("foo", "test", "ps0")
+        assert_equal(grade_cell.max_score, 1, "max_score is incorrect")
+        assert_equal(grade_cell.source, "hello", "source is incorrect")
+        assert_equal(grade_cell.checksum, cell.metadata.nbgrader["checksum"], "checksum is incorrect")
+        assert_equal(grade_cell.cell_type, "code", "cell_type is incorrect")
+
+        solution_cell = gb.find_solution_cell(0, "test", "ps0")
+        assert_equal(solution_cell.source, "hello", "source is incorrect")
+        assert_equal(solution_cell.checksum, cell.metadata.nbgrader["checksum"], "checksum is incorrect")
+        assert_equal(solution_cell.cell_type, "code", "cell_type is incorrect")
+
+    def test_save_markdown_grade_and_solution_cell(self):
+        cell = self._create_grade_and_solution_cell("hello", "markdown", "foo", 1)
+        nb = new_notebook()
+        nb.cells.append(cell)
+
+        nb, resources = self.preprocessor.preprocess(nb, self.resources)
+
+        gb = self.preprocessor.gradebook
+        grade_cell = gb.find_grade_cell("foo", "test", "ps0")
+        assert_equal(grade_cell.max_score, 1, "max_score is incorrect")
+        assert_equal(grade_cell.source, "hello", "source is incorrect")
+        assert_equal(grade_cell.checksum, cell.metadata.nbgrader["checksum"], "checksum is incorrect")
+        assert_equal(grade_cell.cell_type, "markdown", "cell_type is incorrect")
+        
+        solution_cell = gb.find_solution_cell(0, "test", "ps0")
+        assert_equal(solution_cell.source, "hello", "source is incorrect")
+        assert_equal(solution_cell.checksum, cell.metadata.nbgrader["checksum"], "checksum is incorrect")
+        assert_equal(solution_cell.cell_type, "markdown", "cell_type is incorrect")

--- a/nbgrader/tests/test_utils.py
+++ b/nbgrader/tests/test_utils.py
@@ -69,18 +69,42 @@ class TestUtils(TestBase):
         cell2 = self._create_grade_cell("hello ", "code", "foo", 1)
         assert_equal(utils.compute_checksum(cell1), utils.compute_checksum(cell2))
 
+        cell1 = self._create_grade_cell("hello", "markdown", "foo", 1)
+        cell2 = self._create_grade_cell("hello ", "markdown", "foo", 1)
+        assert_equal(utils.compute_checksum(cell1), utils.compute_checksum(cell2))
+
         cell1 = self._create_solution_cell("hello", "code")
         cell2 = self._create_solution_cell("hello ", "code")
         assert_equal(utils.compute_checksum(cell1), utils.compute_checksum(cell2))
 
+        cell1 = self._create_solution_cell("hello", "markdown")
+        cell2 = self._create_solution_cell("hello ", "markdown")
+        assert_equal(utils.compute_checksum(cell1), utils.compute_checksum(cell2))
+
     def test_compute_checksum_source(self):
         # does the source make a difference?
-        cell1 = self._create_grade_cell("hello", "code", "foo", 1)
-        cell2 = self._create_grade_cell("hello!", "code", "foo", 1)
+        cell1 = self._create_grade_cell("print('hello')", "code", "foo", 1)
+        cell2 = self._create_grade_cell("print( 'hello' )", "code", "foo", 1)
+        assert_equal(utils.compute_checksum(cell1), utils.compute_checksum(cell2))
+
+        cell1 = self._create_grade_cell("print('hello')", "code", "foo", 1)
+        cell2 = self._create_grade_cell("print( 'hello!' )", "code", "foo", 1)
         assert_not_equal(utils.compute_checksum(cell1), utils.compute_checksum(cell2))
 
-        cell1 = self._create_solution_cell("hello", "code")
-        cell2 = self._create_solution_cell("hello!", "code")
+        cell1 = self._create_grade_cell("print('hello')", "markdown", "foo", 1)
+        cell2 = self._create_grade_cell("print( 'hello' )", "markdown", "foo", 1)
+        assert_not_equal(utils.compute_checksum(cell1), utils.compute_checksum(cell2))
+
+        cell1 = self._create_solution_cell("print('hello')", "code")
+        cell2 = self._create_solution_cell("print( 'hello' )", "code")
+        assert_equal(utils.compute_checksum(cell1), utils.compute_checksum(cell2))
+
+        cell1 = self._create_solution_cell("print('hello')", "code")
+        cell2 = self._create_solution_cell("print( 'hello!' )", "code")
+        assert_not_equal(utils.compute_checksum(cell1), utils.compute_checksum(cell2))
+
+        cell1 = self._create_solution_cell("print('hello')", "markdown")
+        cell2 = self._create_solution_cell("print( 'hello' )", "markdown")
         assert_not_equal(utils.compute_checksum(cell1), utils.compute_checksum(cell2))
 
     def test_compute_checksum_points(self):

--- a/nbgrader/tests/test_utils.py
+++ b/nbgrader/tests/test_utils.py
@@ -1,4 +1,5 @@
 from IPython.nbformat.v4 import new_output
+from nose.tools import assert_equal, assert_not_equal
 from nbgrader import utils
 from .base import TestBase
 
@@ -41,3 +42,81 @@ class TestUtils(TestBase):
         cell.metadata['nbgrader']['grade'] = True
         cell.metadata['nbgrader']['points'] = 10
         assert utils.determine_grade(cell) == (None, 10)
+
+    def test_compute_checksum_identical(self):
+        # is the same for two identical cells?
+        cell1 = self._create_grade_cell("hello", "code", "foo", 1)
+        cell2 = self._create_grade_cell("hello", "code", "foo", 1)
+        assert_equal(utils.compute_checksum(cell1), utils.compute_checksum(cell2))
+
+        cell1 = self._create_solution_cell("hello", "code")
+        cell2 = self._create_solution_cell("hello", "code")
+        assert_equal(utils.compute_checksum(cell1), utils.compute_checksum(cell2))
+
+    def test_compute_checksum_cell_type(self):
+        # does the cell type make a difference?
+        cell1 = self._create_grade_cell("hello", "code", "foo", 1)
+        cell2 = self._create_grade_cell("hello", "markdown", "foo", 1)
+        assert_not_equal(utils.compute_checksum(cell1), utils.compute_checksum(cell2))
+
+        cell1 = self._create_solution_cell("hello", "code")
+        cell2 = self._create_solution_cell("hello", "markdown")
+        assert_not_equal(utils.compute_checksum(cell1), utils.compute_checksum(cell2))
+
+    def test_compute_checksum_whitespace(self):
+        # does whitespace make no difference?
+        cell1 = self._create_grade_cell("hello", "code", "foo", 1)
+        cell2 = self._create_grade_cell("hello ", "code", "foo", 1)
+        assert_equal(utils.compute_checksum(cell1), utils.compute_checksum(cell2))
+
+        cell1 = self._create_solution_cell("hello", "code")
+        cell2 = self._create_solution_cell("hello ", "code")
+        assert_equal(utils.compute_checksum(cell1), utils.compute_checksum(cell2))
+
+    def test_compute_checksum_source(self):
+        # does the source make a difference?
+        cell1 = self._create_grade_cell("hello", "code", "foo", 1)
+        cell2 = self._create_grade_cell("hello!", "code", "foo", 1)
+        assert_not_equal(utils.compute_checksum(cell1), utils.compute_checksum(cell2))
+
+        cell1 = self._create_solution_cell("hello", "code")
+        cell2 = self._create_solution_cell("hello!", "code")
+        assert_not_equal(utils.compute_checksum(cell1), utils.compute_checksum(cell2))
+
+    def test_compute_checksum_points(self):
+        # does the number of points make a difference (only for grade cells)?
+        cell1 = self._create_grade_cell("hello", "code", "foo", 2)
+        cell2 = self._create_grade_cell("hello", "code", "foo", 1)
+        assert_not_equal(utils.compute_checksum(cell1), utils.compute_checksum(cell2))
+
+        cell1 = self._create_grade_cell("hello", "code", "foo", 2)
+        cell2 = self._create_grade_cell("hello", "code", "foo", 1)
+        cell1.metadata.nbgrader["grade"] = False
+        cell2.metadata.nbgrader["grade"] = False
+        assert_equal(utils.compute_checksum(cell1), utils.compute_checksum(cell2))
+
+    def test_compute_checksum_grade_id(self):
+        # does the grade id make a difference (only for grade cells)?
+        cell1 = self._create_grade_cell("hello", "code", "foo", 1)
+        cell2 = self._create_grade_cell("hello", "code", "bar", 1)
+        assert_not_equal(utils.compute_checksum(cell1), utils.compute_checksum(cell2))
+
+        cell1 = self._create_grade_cell("hello", "code", "foo", 1)
+        cell2 = self._create_grade_cell("hello", "code", "bar", 1)
+        cell1.metadata.nbgrader["grade"] = False
+        cell2.metadata.nbgrader["grade"] = False
+        assert_equal(utils.compute_checksum(cell1), utils.compute_checksum(cell2))
+
+    def test_compute_checksum_grade_cell(self):
+        # does it make a difference if grade=True?
+        cell1 = self._create_grade_cell("hello", "code", "foo", 1)
+        cell2 = self._create_grade_cell("hello", "code", "foo", 1)
+        cell2.metadata.nbgrader["grade"] = False
+        assert_not_equal(utils.compute_checksum(cell1), utils.compute_checksum(cell2))
+
+    def test_compute_checksum_grade_cell(self):
+        # does it make a difference if solution=True?
+        cell1 = self._create_solution_cell("hello", "code")
+        cell2 = self._create_solution_cell("hello", "code")
+        cell2.metadata.nbgrader["solution"] = False
+        assert_not_equal(utils.compute_checksum(cell1), utils.compute_checksum(cell2))

--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -40,12 +40,13 @@ def compute_checksum(cell):
     # add the cell type
     m.update(str_to_bytes(cell.cell_type))
 
-    # include number of points that the cell is worth
-    if 'points' in cell.metadata.nbgrader:
-        m.update(str_to_bytes(str(float(cell.metadata.nbgrader['points']))))
+    # add whether it's a grade cell and/or solution cell
+    m.update(str_to_bytes(str(is_grade(cell))))
+    m.update(str_to_bytes(str(is_solution(cell))))
 
-    # include the grade_id
-    if 'grade_id' in cell.metadata.nbgrader:
+    # include the grade id and the number of points that the cell is worth
+    if is_grade(cell):
+        m.update(str_to_bytes(str(float(cell.metadata.nbgrader['points']))))
         m.update(str_to_bytes(cell.metadata.nbgrader['grade_id']))
 
     return m.hexdigest()

--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -33,9 +33,12 @@ def determine_grade(cell):
 def compute_checksum(cell):
     m = hashlib.md5()
 
-    # fix minor whitespace issues that might have been added and then
-    # add cell contents
-    m.update(str_to_bytes(autopep8.fix_code(cell.source).rstrip()))
+    # if it's a code cell, then fix minor whitespace issues that might have been 
+    # added and then add cell contents; otherwise just add cell contents
+    if cell.cell_type == "code":
+        m.update(str_to_bytes(autopep8.fix_code(cell.source).rstrip()))
+    else:
+        m.update(str_to_bytes(cell.source.strip()))
 
     # add the cell type
     m.update(str_to_bytes(cell.cell_type))


### PR DESCRIPTION
This updates the `SaveCells` preprocessor (formerly `SaveGradeCells`) to save the cell type of solution cells as well as grade cells, and updates the `OverwriteCells` preprocessor (formerly `OverwriteGradeCells`) to update the cell type of solutions cells. It also saves the source and checksum of solution cells, though nothing is (currently) done with that information.

* Fixes #116 
* Fixes #114 
* Fixes #107