### PR TITLE
Fix checksums in nbgrader validate

### DIFF
--- a/nbgrader/preprocessors/displayautogrades.py
+++ b/nbgrader/preprocessors/displayautogrades.py
@@ -129,7 +129,7 @@ class DisplayAutoGrades(Preprocessor):
             return cell, resources
 
         # verify checksums of cells
-        if not utils.is_solution(cell):
+        if not utils.is_solution(cell) and 'checksum' in cell.metadata.nbgrader:
             old_checksum = cell.metadata.nbgrader['checksum']
             new_checksum = utils.compute_checksum(cell)
             if old_checksum != new_checksum:

--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -31,7 +31,7 @@ def determine_grade(cell):
         # if it's a solution cell and the checksum hasn't changed, that means
         # they didn't provide a response, so we can automatically give this a
         # zero grade
-        if cell.metadata.nbgrader["checksum"] == compute_checksum(cell):
+        if "checksum" in cell.metadata.nbgrader and cell.metadata.nbgrader["checksum"] == compute_checksum(cell):
             return 0, max_points
         else:
             return None, max_points


### PR DESCRIPTION
`nbgrader validate` should still work, even if there are no checksums in the cell metadata.