### PR TITLE
Check cell types

### DIFF
--- a/nbgrader/apps/assignapp.py
+++ b/nbgrader/apps/assignapp.py
@@ -12,7 +12,7 @@ from nbgrader.preprocessors import (
     LockCells,
     ComputeChecksums,
     SaveCells,
-    CheckGradeIds
+    CheckCellMetadata
 )
 
 aliases = {}
@@ -88,10 +88,10 @@ class AssignApp(BaseNbConvertApp):
         classes = super(AssignApp, self)._classes_default()
         classes.extend([
             IncludeHeaderFooter,
-            CheckGradeIds,
             LockCells,
             ClearSolutions,
             ClearOutputPreprocessor,
+            CheckCellMetadata,
             ComputeChecksums,
             SaveCells
         ])
@@ -101,10 +101,10 @@ class AssignApp(BaseNbConvertApp):
         self.extra_config = Config()
         self.extra_config.Exporter.preprocessors = [
             'nbgrader.preprocessors.IncludeHeaderFooter',
-            'nbgrader.preprocessors.CheckGradeIds',
             'nbgrader.preprocessors.LockCells',
             'nbgrader.preprocessors.ClearSolutions',
             'IPython.nbconvert.preprocessors.ClearOutputPreprocessor',
+            'nbgrader.preprocessors.CheckCellMetadata',
             'nbgrader.preprocessors.ComputeChecksums'
         ]
         if self.save_cells:

--- a/nbgrader/preprocessors/__init__.py
+++ b/nbgrader/preprocessors/__init__.py
@@ -7,6 +7,6 @@ from .displayautogrades import DisplayAutoGrades
 from .computechecksums import ComputeChecksums
 from .savecells import SaveCells
 from .overwritecells import OverwriteCells
-from .checkgradeids import CheckGradeIds
+from .checkcellmetadata import CheckCellMetadata
 from .execute import Execute
 from .getgrades import GetGrades

--- a/nbgrader/preprocessors/checkcellmetadata.py
+++ b/nbgrader/preprocessors/checkcellmetadata.py
@@ -1,12 +1,12 @@
 from IPython.nbconvert.preprocessors import Preprocessor
 from nbgrader import utils
 
-class CheckGradeIds(Preprocessor):
+class CheckCellMetadata(Preprocessor):
     """A preprocessor for checking that grade ids are unique."""
 
     def preprocess(self, nb, resources):
         resources['grade_ids'] = ids = []
-        nb, resources = super(CheckGradeIds, self).preprocess(nb, resources)
+        nb, resources = super(CheckCellMetadata, self).preprocess(nb, resources)
 
         id_set = set([])
         for grade_id in ids:
@@ -18,11 +18,13 @@ class CheckGradeIds(Preprocessor):
 
     def preprocess_cell(self, cell, resources, cell_index):
         if utils.is_grade(cell):
+            # check for blank grade ids
             grade_id = cell.metadata.nbgrader.get("grade_id", "")
             if grade_id == "":
                 raise RuntimeError("Blank grade id!")
             resources['grade_ids'].append(grade_id)
 
+            # check for valid points
             points = cell.metadata.nbgrader.get("points", "")
             try:
                 points = float(points)
@@ -30,5 +32,21 @@ class CheckGradeIds(Preprocessor):
                 raise RuntimeError(
                     "Point value for grade cell {} is invalid: {}".format(
                         grade_id, points))
+
+        # check that code cells are grade OR solution (not both)
+        if cell.cell_type == "code" and utils.is_grade(cell) and utils.is_solution(cell):
+            raise RuntimeError(
+                "Code grade cell '{}' is also marked as a solution cell".format(
+                    grade_id))
+
+        # check that markdown cells are grade AND solution (not either/or)
+        if cell.cell_type == "markdown" and utils.is_grade(cell) and not utils.is_solution(cell):
+            raise RuntimeError(
+                "Markdown grade cell '{}' is not marked as a solution cell".format(
+                    grade_id))
+        if cell.cell_type == "markdown" and not utils.is_grade(cell) and utils.is_solution(cell):
+            raise RuntimeError(
+                "Markdown solution cell (index {}) is not marked as a grade cell".format(
+                    cell_index))
 
         return cell, resources

--- a/nbgrader/preprocessors/clearsolutions.py
+++ b/nbgrader/preprocessors/clearsolutions.py
@@ -98,4 +98,11 @@ class ClearSolutions(Preprocessor):
             else:
                 cell.source = self.text_stub
 
+        # if we replaced a solution region, then make sure the cell is marked
+        # as a solution cell
+        if replaced_solution:
+            if 'nbgrader' not in cell.metadata:
+                cell.metadata.nbgrader = {}
+            cell.metadata.nbgrader['solution'] = True
+
         return cell, resources

--- a/nbgrader/tests/files/bad-code-cell.ipynb
+++ b/nbgrader/tests/files/bad-code-cell.ipynb
@@ -1,0 +1,32 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false,
+    "nbgrader": {
+     "grade": true,
+     "solution": true,
+     "grade_id": "foo",
+     "points": 1
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "this is a cell\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"this is a code cell\")"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/nbgrader/tests/files/bad-markdown-cell-1.ipynb
+++ b/nbgrader/tests/files/bad-markdown-cell-1.ipynb
@@ -1,0 +1,21 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "nbgrader": {
+     "grade": true,
+     "grade_id": "foo",
+     "points": 1
+    }
+   },
+   "source": [
+    "this is a markdown cell"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/nbgrader/tests/files/bad-markdown-cell-2.ipynb
+++ b/nbgrader/tests/files/bad-markdown-cell-2.ipynb
@@ -1,0 +1,19 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "nbgrader": {
+     "solution": true
+    }
+   },
+   "source": [
+    "this is a markdown cell"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/nbgrader/tests/test_checkcellmetadata.py
+++ b/nbgrader/tests/test_checkcellmetadata.py
@@ -1,14 +1,14 @@
 from nose.tools import assert_raises
-from nbgrader.preprocessors import CheckGradeIds
+from nbgrader.preprocessors import CheckCellMetadata
 
 from .base import TestBase
 
 
-class TestCheckGradeIds(TestBase):
+class TestCheckCellMetadata(TestBase):
 
     def setup(self):
-        super(TestCheckGradeIds, self).setup()
-        self.preprocessor = CheckGradeIds()
+        super(TestCheckCellMetadata, self).setup()
+        self.preprocessor = CheckCellMetadata()
 
     def test_duplicate_grade_ids(self):
         """Check that an error is raised when there are duplicate grade ids"""
@@ -16,7 +16,6 @@ class TestCheckGradeIds(TestBase):
             RuntimeError, 
             self.preprocessor.preprocess, 
             self.nbs["duplicate-grade-ids.ipynb"], {})
-
 
     def test_blank_grade_id(self):
         """Check that an error is raised when the grade id is blank"""
@@ -35,3 +34,24 @@ class TestCheckGradeIds(TestBase):
     def test_no_duplicate_grade_ids(self):
         """Check that no errors are raised when grade ids are unique and not blank"""
         self.preprocessor.preprocess(self.nbs["test.ipynb"], {})
+
+    def test_code_cell_solution_grade(self):
+        """Check that an error is raised when a code cell is marked as both solution and grade"""
+        assert_raises(
+            RuntimeError,
+            self.preprocessor.preprocess,
+            self.nbs["bad-code-cell.ipynb"], {})
+
+    def test_markdown_cell_grade(self):
+        """Check that an error is raised when a markdown cell is only marked as grade"""
+        assert_raises(
+            RuntimeError,
+            self.preprocessor.preprocess,
+            self.nbs["bad-markdown-cell-1.ipynb"], {})
+
+    def test_markdown_cell_solution(self):
+        """Check that an error is raised when a markdown cell is only marked as solution"""
+        assert_raises(
+            RuntimeError,
+            self.preprocessor.preprocess,
+            self.nbs["bad-markdown-cell-2.ipynb"], {})


### PR DESCRIPTION
This checks that code cells are either solution or grade cells (but not both) and that markdown cells are both solution and grade (or neither). It also adds functionality to mark cells with solution regions as solution cells in `nbgrader assign`.

* Fixes #69 
* Fixes #110 
