### PR TITLE
Unpinning ipython version to allow to work with 3.0 and 3.1, etc.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ipython==4.0.0-dev
+ipython
 sqlalchemy
 Flask
 autopep8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ipython
+ipython>=3.0
 sqlalchemy
 Flask
 autopep8


### PR DESCRIPTION
Solves #183