### PR TITLE
Making profile='default' the default for activate/deactivate.

### DIFF
--- a/nbgrader/install.py
+++ b/nbgrader/install.py
@@ -49,7 +49,7 @@ def install(profile='default', symlink=True, user=False, prefix=None,
 
 
 # TODO pass prefix as argument.
-def activate(profile=None, ipython_dir=None):
+def activate(profile='default', ipython_dir=None):
     """
     Manually modify the frontend json-config to load nbgrader extension.
     """
@@ -76,7 +76,7 @@ def activate(profile=None, ipython_dir=None):
         f.write(cast_unicode_py2(json.dumps(config, indent=2), 'utf-8'))
 
 
-def deactivate(profile=None, ipython_dir=None):
+def deactivate(profile='default', ipython_dir=None):
     """
     Manually modify the frontend json-config to load nbgrader extension.
     """


### PR DESCRIPTION
Right now if you run `nbgrader.install.activate|deactivate` from Python it fails if you don't pass a profile. Like the `install` function, these should have a default profile of `default`. I didn't test the command line operation - it looks like the default for profile there is `None`, which will cause similar problems. But this is one of the weaknesses of argparse over the traitlets command line stuff - you have to maintain defaults in both your functions/classes and in the command line parser.