### PR TITLE
make profile ags mandatory + docs

### DIFF
--- a/docs/user_guide/1 - Installing.ipynb
+++ b/docs/user_guide/1 - Installing.ipynb
@@ -30,7 +30,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To additionally install the assignment toolbar notebook extension:"
+    "To additionally install, activate or deactivate the assignment toolbar notebook extension:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To get help and see all the options you can pass while installing/activating nbgrader, use:"
    ]
   },
   {
@@ -38,8 +45,23 @@
    "metadata": {},
    "source": [
     "```bash\n",
-    "cp nbextensions/* $(ipython locate)/nbextensions/\n",
+    "python -m nbgrader --help\n",
     "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can install and activate nbgrader assignment toolbar extension with:\n",
+    "\n",
+    "```bash\n",
+    "python -m nbgrader --install --activate <profilename>\n",
+    "```\n",
+    "\n",
+    "Where `<profilename>` is the name of the profile you want to use for creating assignments. \n",
+    "By default the extension will by symlink, so you shouldn't need to reinstalling it after upgrading nbgrader. \n",
+    "use `--no-symlink` to actually copy the file."
    ]
   }
  ],

--- a/docs/user_guide/1 - Installing.ipynb
+++ b/docs/user_guide/1 - Installing.ipynb
@@ -72,15 +72,6 @@
     "%%bash\n",
     "python -m nbgrader --help"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {},

--- a/docs/user_guide/1 - Installing.ipynb
+++ b/docs/user_guide/1 - Installing.ipynb
@@ -30,7 +30,28 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To additionally install, activate or deactivate the assignment toolbar notebook extension:"
+    "You can install and activate nbgrader assignment toolbar extension with:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "python -m nbgrader --install --activate default"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Where `default` is the name of the profile you want to use for creating assignments. \n",
+    "By default the extension will by symlink, so you shouldn't need to reinstalling it after upgrading nbgrader. \n",
+    "Use `--no-symlink` to actually copy the file."
    ]
   },
   {
@@ -41,28 +62,25 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
    "source": [
-    "```bash\n",
-    "python -m nbgrader --help\n",
-    "```"
+    "%%bash\n",
+    "python -m nbgrader --help"
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "You can install and activate nbgrader assignment toolbar extension with:\n",
-    "\n",
-    "```bash\n",
-    "python -m nbgrader --install --activate <profilename>\n",
-    "```\n",
-    "\n",
-    "Where `<profilename>` is the name of the profile you want to use for creating assignments. \n",
-    "By default the extension will by symlink, so you shouldn't need to reinstalling it after upgrading nbgrader. \n",
-    "use `--no-symlink` to actually copy the file."
-   ]
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {},

--- a/nbgrader/install.py
+++ b/nbgrader/install.py
@@ -160,6 +160,10 @@ def main(argv=None):
         print("--no-symlink can only be used in conjunction with the --install flag.")
         help_and_exit = True
 
+    if not (args.install or args.activate or args.deactivate):
+        print("\nUse one of `--activate`, `--deactivate` or `--install`. \n")
+        help_and_exit = True
+
     if not args.profile or help_and_exit:
         parser.print_help()
         sys.exit(1)

--- a/nbgrader/install.py
+++ b/nbgrader/install.py
@@ -119,7 +119,7 @@ def main(argv=None):
     prog = '{} -m nbgrader'.format(os.path.basename(sys.executable))
     parser = argparse.ArgumentParser(prog=prog,
                 description='''Install and activate nbgrader notebook extension for a given profile ''')
-    parser.add_argument('profile', nargs='?', default=None, metavar=('<profile_name>'))
+    parser.add_argument('profile', nargs='?', default='default', metavar=('<profile_name>'))
 
     parser.add_argument("--install", help="Install nbgrader notebook extension for given profile",
                         action="store_true")

--- a/nbgrader/install.py
+++ b/nbgrader/install.py
@@ -24,7 +24,7 @@ def _get_profile_dir(profile, ipython_dir):
         pdir = ProfileDir.find_profile_dir_by_name(ipython_dir, profile).location
     return pdir
 
-def install(profile='default', symlink=True, user=False, prefix=None,
+def install(profile, symlink=True, user=False, prefix=None,
             verbose=False, ipython_dir=None):
     """Install and activate nbgrader on a profile
     """
@@ -49,7 +49,7 @@ def install(profile='default', symlink=True, user=False, prefix=None,
 
 
 # TODO pass prefix as argument.
-def activate(profile=None, ipython_dir=None):
+def activate(profile, ipython_dir=None):
     """
     Manually modify the frontend json-config to load nbgrader extension.
     """
@@ -76,7 +76,7 @@ def activate(profile=None, ipython_dir=None):
         f.write(cast_unicode_py2(json.dumps(config, indent=2), 'utf-8'))
 
 
-def deactivate(profile=None, ipython_dir=None):
+def deactivate(profile, ipython_dir=None):
     """
     Manually modify the frontend json-config to load nbgrader extension.
     """
@@ -165,17 +165,17 @@ def main(argv=None):
         sys.exit(1)
 
     if args.install:
-        install( ipython_dir=args.path,
+        install(     profile=args.profile,
+                 ipython_dir=args.path,
                         user=args.user,
                       prefix=args.prefix,
-                     profile=args.profile,
                      symlink=args.symlink,
                      verbose=args.verbose,
                 )
 
     if args.activate :
-        activate( ipython_dir=args.path,
-                      profile=args.profile) 
+        activate(   profile=args.profile,
+                ipython_dir=args.path) 
     if args.deactivate :
-        deactivate( ipython_dir=args.path,
-                        profile=args.profile) 
+        deactivate(     profile=args.profile,
+                    ipython_dir=args.path) 


### PR DESCRIPTION
make `profile` first positional arg, + add docs on installing.

It occurred to me that install might not actually require a profile name as it can install globally on the system.