### PR TITLE
Make the remapped sub-url configurable.

### DIFF
--- a/nbgrader/auth/hubauth.py
+++ b/nbgrader/auth/hubauth.py
@@ -34,6 +34,8 @@ class HubAuth(BaseAuth):
     notebook_url_prefix = Unicode(None, config=True, allow_none=True, help="""
         Relative path of the formgrader with respect to the hub's user base
         directory.  No trailing slash. i.e. "Documents" or "Documents/notebooks". """)
+    def _notebook_url_prefix_changed(self, name, old, new):
+        self.notebook_url_prefix = new.strip('/')
     
     hub_base_url = Unicode(config=True, help="Base URL of the hub server.")
     def _hub_base_url_default(self):
@@ -69,6 +71,8 @@ class HubAuth(BaseAuth):
         instance.""")
     def _remap_url_default(self):
         return '/hub/' + self.config.course_id
+    def _remap_url_changed(self, name, old, new):
+        self.remap_url = new.rstrip('/')
 
     def __init__(self, *args, **kwargs):
         super(HubAuth, self).__init__(*args, **kwargs)

--- a/nbgrader/auth/hubauth.py
+++ b/nbgrader/auth/hubauth.py
@@ -70,7 +70,7 @@ class HubAuth(BaseAuth):
         plan on running more than one formgrade server behind one JupyterHub
         instance.""")
     def _remap_url_default(self):
-        return '/hub/' + self.parent.course_id
+        return '/hub/nbgrader/' + self.parent.course_id
     def _remap_url_changed(self, name, old, new):
         self.remap_url = new.rstrip('/')
 

--- a/nbgrader/auth/hubauth.py
+++ b/nbgrader/auth/hubauth.py
@@ -70,7 +70,7 @@ class HubAuth(BaseAuth):
         plan on running more than one formgrade server behind one JupyterHub
         instance.""")
     def _remap_url_default(self):
-        return '/hub/' + self.config.course_id
+        return '/hub/' + self.parent.course_id
     def _remap_url_changed(self, name, old, new):
         self.remap_url = new.rstrip('/')
 

--- a/nbgrader/auth/hubauth.py
+++ b/nbgrader/auth/hubauth.py
@@ -62,10 +62,13 @@ class HubAuth(BaseAuth):
     def _proxy_token_default(self):
         return os.environ.get('CONFIGPROXY_AUTH_TOKEN', '')
 
-    remap_url = Unicode('/hub/formgrade', config=True, help="""Suffix appened to 
+    remap_url = Unicode(config=True, help="""Suffix appened to 
         `HubAuth.hub_base_url` to form the full URL to the formgrade server.  By
-        default this is '/hub/formgrade'.  Change this if you plan on running
-        more than one formgrade server behind one JupyterHub instance.""")
+        default this is '/hub/{{NbGraderConfig.course_id}}'.  Change this if you
+        plan on running more than one formgrade server behind one JupyterHub
+        instance.""")
+    def _remap_url_default(self):
+        return '/hub/' + self.config.course_id
 
     def __init__(self, *args, **kwargs):
         super(HubAuth, self).__init__(*args, **kwargs)

--- a/nbgrader/tests/test_nbgrader_formgrade_hubauth.py
+++ b/nbgrader/tests/test_nbgrader_formgrade_hubauth.py
@@ -9,7 +9,7 @@ from .test_nbgrader_formgrade import TestNbgraderFormgrade
 
 class TestNbgraderFormgradeHubAuth(TestNbgraderFormgrade):
 
-    base_formgrade_url = "http://localhost:8000/hub/formgrade/"
+    base_formgrade_url = "http://localhost:8000/hub/course123ABC/"
     base_notebook_url = "http://localhost:8000/user/foobar/notebooks/class_files/"
 
     @classmethod
@@ -19,6 +19,7 @@ class TestNbgraderFormgradeHubAuth(TestNbgraderFormgrade):
             fh.write(dedent(
                 """
                 c = get_config()
+                c.NbGraderConfig.course_id = 'course123ABC'
                 c.FormgradeApp.port = 9000
                 c.FormgradeApp.authenticator_class = "nbgrader.auth.hubauth.HubAuth"
                 c.HubAuth.graders = ["foobar"]
@@ -102,6 +103,7 @@ class TestNbgraderHubToken(TestNbgraderFormgradeHubAuth):
             fh.write(dedent(
                 """
                 c = get_config()
+                c.NbGraderConfig.course_id = 'course123ABC'
                 c.FormgradeApp.port = 9000
                 c.FormgradeApp.authenticator_class = "nbgrader.auth.hubauth.HubAuth"
                 c.HubAuth.graders = ["foobar"]
@@ -119,9 +121,30 @@ class TestNbgraderHubToken(TestNbgraderFormgradeHubAuth):
         super(TestNbgraderFormgradeHubAuth, cls)._start_formgrader()
 
 
+class TestFormgradeCustomHubURL(TestNbgraderFormgradeHubAuth):
+
+    base_formgrade_url = "http://localhost:8000/hub/grader/"
+
+    @classmethod
+    def _setup_formgrade_config(cls):
+        # create config file
+        with open("nbgrader_config.py", "w") as fh:
+            fh.write(dedent(
+                """
+                c = get_config()
+                c.NbGraderConfig.course_id = 'course123ABC'
+                c.FormgradeApp.port = 9000
+                c.FormgradeApp.authenticator_class = "nbgrader.auth.hubauth.HubAuth"
+                c.HubAuth.graders = ["foobar"]
+                c.HubAuth.notebook_url_prefix = "class_files"
+                c.HubAuth.remap_url = '/hub/grader'
+                """
+            ))
+
 del TestNbgraderFormgrade
 
 # don't run tests if it's not python 3
 if sys.version_info[0] != 3:
     del TestNbgraderFormgradeHubAuth
     del TestNbgraderHubToken
+    del TestFormgradeCustomHubURL

--- a/nbgrader/tests/test_nbgrader_formgrade_hubauth.py
+++ b/nbgrader/tests/test_nbgrader_formgrade_hubauth.py
@@ -9,7 +9,7 @@ from .test_nbgrader_formgrade import TestNbgraderFormgrade
 
 class TestNbgraderFormgradeHubAuth(TestNbgraderFormgrade):
 
-    base_formgrade_url = "http://localhost:8000/hub/course123ABC/"
+    base_formgrade_url = "http://localhost:8000/hub/nbgrader/course123ABC/"
     base_notebook_url = "http://localhost:8000/user/foobar/notebooks/class_files/"
 
     @classmethod


### PR DESCRIPTION
Changes the default formgrade hub url to `/hub/{{course_id}}`.
Allows more than one formgrade to run behind JupyterHub.  

URL can also be set explicitly.
i.e.  
`https://myhub.com/hub/{{course_id}}` can be changed to  
`https://myhub.com/hub/bgranger-grading` so more classes like  
`https://myhub.com/hub/jhamrick-grading` can be added.  
  
cc @ellisonbg   

EDIT: 4/6/2015 to reflect current state.