### PR TITLE
Make input and output directories depend on a common config

### DIFF
--- a/nbgrader/apps/assignapp.py
+++ b/nbgrader/apps/assignapp.py
@@ -101,28 +101,13 @@ class AssignApp(BaseNbConvertApp):
         )
     )
 
-    nbgrader_input_step_name = Unicode(
-        "source",
-        config=True,
-        help=dedent(
-            """
-            The input directory for this step of the grading process. This
-            corresponds to the `nbgrader_step` variable in the path defined by
-            `NbGraderConfig.directory_structure`.
-            """
-        )
-    )
-    nbgrader_output_step_name = Unicode(
-        "release",
-        config=True,
-        help=dedent(
-            """
-            The output directory for this step of the grading process. This
-            corresponds to the `nbgrader_step` variable in the path defined by
-            `NbGraderConfig.directory_structure`.
-            """
-        )
-    )
+    @property
+    def _input_directory(self):
+        return self.source_directory
+
+    @property
+    def _output_directory(self):
+        return self.release_directory
 
     export_format = 'notebook'
 

--- a/nbgrader/apps/autogradeapp.py
+++ b/nbgrader/apps/autogradeapp.py
@@ -74,28 +74,13 @@ class AutogradeApp(BaseNbConvertApp):
         )
     )
 
-    nbgrader_input_step_name = Unicode(
-        "submitted",
-        config=True,
-        help=dedent(
-            """
-            The input directory for this step of the grading process. This
-            corresponds to the `nbgrader_step` variable in the path defined by
-            `NbGraderConfig.directory_structure`.
-            """
-        )
-    )
-    nbgrader_output_step_name = Unicode(
-        "autograded",
-        config=True,
-        help=dedent(
-            """
-            The output directory for this step of the grading process. This
-            corresponds to the `nbgrader_step` variable in the path defined by
-            `NbGraderConfig.directory_structure`.
-            """
-        )
-    )
+    @property
+    def _input_directory(self):
+        return self.submitted_directory
+
+    @property
+    def _output_directory(self):
+        return self.autograded_directory
 
     export_format = 'notebook'
 

--- a/nbgrader/apps/baseapp.py
+++ b/nbgrader/apps/baseapp.py
@@ -135,10 +135,6 @@ class BaseNbGraderApp(BaseApp):
     aliases = nbgrader_aliases
     flags = nbgrader_flags
 
-    # must be overwritten by subclasses
-    nbgrader_input_step_name = Unicode()
-    nbgrader_output_step_name = Unicode()
-
     # these must be defined, but then will actually be populated with values from
     # the NbGraderConfig instance
     db_url = Unicode()
@@ -146,6 +142,11 @@ class BaseNbGraderApp(BaseApp):
     assignment_id = Unicode()
     notebook_id = Unicode()
     directory_structure = Unicode()
+    source_directory = Unicode()
+    release_directory = Unicode()
+    submitted_directory = Unicode()
+    autograded_directory = Unicode()
+    feedback_directory = Unicode()
 
     # nbgrader configuration instance
     _nbgrader_config = Instance(NbGraderConfig)
@@ -189,6 +190,14 @@ class BaseNbConvertApp(BaseNbGraderApp, NbConvertApp):
                 classes.append(pp)
         return classes
 
+    @property
+    def _input_directory(self):
+        raise NotImplementedError
+
+    @property
+    def _output_directory(self):
+        raise NotImplementedError
+
     def build_extra_config(self):
         extra_config = super(BaseNbConvertApp, self).build_extra_config()
         extra_config.Exporter.default_preprocessors = self.preprocessors
@@ -210,7 +219,7 @@ class BaseNbConvertApp(BaseNbGraderApp, NbConvertApp):
 
         directory_structure = os.path.join(self.directory_structure, self.notebook_id + ".ipynb")
         fullglob = directory_structure.format(
-            nbgrader_step=self.nbgrader_input_step_name,
+            nbgrader_step=self._input_directory,
             student_id=self.student_id,
             assignment_id=self.assignment_id,
             notebook_id=self.notebook_id
@@ -224,7 +233,7 @@ class BaseNbConvertApp(BaseNbGraderApp, NbConvertApp):
     def init_single_notebook_resources(self, notebook_filename):
         directory_structure = os.path.join(self.directory_structure, "(?P<notebook_id>.*).ipynb")
         regexp = directory_structure.format(
-            nbgrader_step=self.nbgrader_input_step_name,
+            nbgrader_step=self._input_directory,
             student_id="(?P<student_id>.*)",
             assignment_id="(?P<assignment_id>.*)",
         )
@@ -264,7 +273,7 @@ class BaseNbConvertApp(BaseNbGraderApp, NbConvertApp):
 
         # configure the writer build directory
         self.writer.build_directory = self.directory_structure.format(
-            nbgrader_step=self.nbgrader_output_step_name,
+            nbgrader_step=self._output_directory,
             student_id=resources['nbgrader']['student'],
             assignment_id=resources['nbgrader']['assignment'],
         )

--- a/nbgrader/apps/feedbackapp.py
+++ b/nbgrader/apps/feedbackapp.py
@@ -51,28 +51,13 @@ class FeedbackApp(BaseNbConvertApp):
             nbgrader feedback "Problem Set 1" --notebook "1*"
         """
 
-    nbgrader_input_step_name = Unicode(
-        "autograded",
-        config=True,
-        help=dedent(
-            """
-            The input directory for this step of the grading process. This
-            corresponds to the `nbgrader_step` variable in the path defined by
-            `NbGraderConfig.directory_structure`.
-            """
-        )
-    )
-    nbgrader_output_step_name = Unicode(
-        "feedback",
-        config=True,
-        help=dedent(
-            """
-            The output directory for this step of the grading process. This
-            corresponds to the `nbgrader_step` variable in the path defined by
-            `NbGraderConfig.directory_structure`.
-            """
-        )
-    )
+    @property
+    def _input_directory(self):
+        return self.autograded_directory
+
+    @property
+    def _output_directory(self):
+        return self.feedback_directory
 
     preprocessors = List([
         GetGrades

--- a/nbgrader/apps/formgradeapp.py
+++ b/nbgrader/apps/formgradeapp.py
@@ -63,18 +63,6 @@ class FormgradeApp(BaseNbGraderApp):
             nbgrader formgrade --port 5001
         """
 
-    nbgrader_input_step_name = Unicode(
-        "autograded",
-        config=True,
-        help=dedent(
-            """
-            The input directory for this step of the grading process. This
-            corresponds to the `nbgrader_step` variable in the path defined by
-            `NbGraderConfig.directory_structure`.
-            """
-        )
-    )
-
     ip = Unicode("localhost", config=True, help="IP address for the server")
     port = Integer(5000, config=True, help="Port for the server")
     authenticator_class = Type(NoAuth, klass=BaseAuth, config=True, help="""
@@ -123,7 +111,7 @@ class FormgradeApp(BaseNbGraderApp):
         # now launch the formgrader
         app.notebook_dir = self.base_directory
         app.notebook_dir_format = self.directory_structure
-        app.nbgrader_step = self.nbgrader_input_step_name
+        app.nbgrader_step = self.autograded_directory
         app.exporter = HTMLExporter(config=self.config)
 
         url = "http://{:s}:{:d}/".format(self.ip, self.port)

--- a/nbgrader/config.py
+++ b/nbgrader/config.py
@@ -140,3 +140,64 @@ class NbGraderConfig(LinkedConfig):
             """
         )
     )
+
+    source_directory = Unicode(
+        'source',
+        config=True,
+        help=dedent(
+            """
+            The name of the directory that contains the master/instructor
+            version of assignments. This corresponds to the `nbgrader_step`
+            variable in the `directory_structure` config option.
+            """
+        )
+    )
+
+    release_directory = Unicode(
+        'release',
+        config=True,
+        help=dedent(
+            """
+            The name of the directory that contains the version of the
+            assignment that will be released to students. This corresponds to
+            the `nbgrader_step` variable in the `directory_structure` config
+            option.
+            """
+        )
+    )
+
+    submitted_directory = Unicode(
+        'submitted',
+        config=True,
+        help=dedent(
+            """
+            The name of the directory that contains assignments that have been
+            submitted by students for grading. This corresponds to the
+            `nbgrader_step` variable in the `directory_structure` config option.
+            """
+        )
+    )
+
+    autograded_directory = Unicode(
+        'autograded',
+        config=True,
+        help=dedent(
+            """
+            The name of the directory that contains assignment submissions after
+            they have been autograded. This corresponds to the `nbgrader_step`
+            variable in the `directory_structure` config option.
+            """
+        )
+    )
+
+    feedback_directory = Unicode(
+        'feedback',
+        config=True,
+        help=dedent(
+            """
+            The name of the directory that contains assignment feedback after
+            grading has been completed. This corresponds to the `nbgrader_step`
+            variable in the `directory_structure` config option.
+            """
+        )
+    )


### PR DESCRIPTION
Rather than having the apps have `nbgrader_input_step_name` and `nbgrader_output_step_name` config variables, make a config options in `NbGraderConfig` for the common set of directories:

* `source_directory`
* `release_directory`
* `submitted_directory`
* `autograded_directory`
* `feedback_directory`

That way if the directory name is changed, all the apps that rely on that directory will know about it. For example, apps that inherit from `BaseNbConvertApp` can define `_input_directory` and `_output_directory` properties that return one of these common directories. 

ping @ellisonbg 