### PR TITLE
Save timestamps into database as UTC

### DIFF
--- a/nbgrader/apps/autogradeapp.py
+++ b/nbgrader/apps/autogradeapp.py
@@ -1,10 +1,9 @@
 import sys
 import os
-import dateutil.parser
 
 from textwrap import dedent
 
-from IPython.utils.traitlets import Unicode, List, Bool
+from IPython.utils.traitlets import List, Bool
 
 from nbgrader.api import Gradebook, MissingEntry
 from nbgrader.apps.baseapp import BaseNbConvertApp, nbconvert_aliases, nbconvert_flags
@@ -114,8 +113,6 @@ class AutogradeApp(BaseNbConvertApp):
         if os.path.exists(timestamp_path):
             with open(timestamp_path, 'r') as fh:
                 timestamp = fh.read().strip()
-            timestamp = dateutil.parser.parse(timestamp)
-            self.log.info("Submitted at %s", timestamp)
             resources['nbgrader']['timestamp'] = timestamp
 
         return resources

--- a/nbgrader/preprocessors/saveautogrades.py
+++ b/nbgrader/preprocessors/saveautogrades.py
@@ -27,8 +27,9 @@ class SaveAutoGrades(NbGraderPreprocessor):
             self.assignment_id, self.student_id, **kwargs)
 
         # if the submission is late, print out how many seconds late it is
+        self.log.info("%s submitted at %s", submission, timestamp)
         if timestamp and submission.total_seconds_late > 0:
-            self.log.info("%s is %s seconds late", submission, submission.total_seconds_late)
+            self.log.warning("%s is %s seconds late", submission, submission.total_seconds_late)
 
         self.comment_index = 0
 

--- a/nbgrader/tests/test_nbgrader_autograde.py
+++ b/nbgrader/tests/test_nbgrader_autograde.py
@@ -12,7 +12,7 @@ class TestNbgraderAutograde(TestBase):
     def _setup_db(self):
         dbpath = self._init_db()
         gb = Gradebook(dbpath)
-        gb.add_assignment("ps1", duedate=datetime.datetime.now())
+        gb.add_assignment("ps1", duedate="2015-02-02 14:58:23.948203 PST")
         gb.add_student("foo")
         gb.add_student("bar")
         return dbpath
@@ -116,12 +116,12 @@ class TestNbgraderAutograde(TestBase):
             os.makedirs('submitted/foo/ps1')
             shutil.move('submitted-unchanged.ipynb', 'submitted/foo/ps1/p1.ipynb')
             with open('submitted/foo/ps1/timestamp.txt', 'w') as fh:
-                fh.write(datetime.datetime.now().isoformat())
+                fh.write("2015-02-02 15:58:23.948203 PST")
 
             os.makedirs('submitted/bar/ps1')
             shutil.move('submitted-changed.ipynb', 'submitted/bar/ps1/p1.ipynb')
             with open('submitted/bar/ps1/timestamp.txt', 'w') as fh:
-                fh.write((datetime.datetime.now() - datetime.timedelta(days=1)).isoformat())
+                fh.write("2015-02-01 14:58:23.948203 PST")
 
             self._run_command('nbgrader autograde ps1 --db="{}"'.format(dbpath))
 
@@ -135,3 +135,6 @@ class TestNbgraderAutograde(TestBase):
             assert submission.total_seconds_late > 0
             submission = gb.find_submission('ps1', 'bar')
             assert submission.total_seconds_late == 0
+
+            # make sure it still works to run it a second time
+            self._run_command('nbgrader autograde ps1 --db="{}"'.format(dbpath))

--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -1,6 +1,6 @@
 import hashlib
 import autopep8
-import subprocess as sp
+import dateutil.parser
 
 from IPython.utils.py3compat import str_to_bytes
 
@@ -63,3 +63,11 @@ def compute_checksum(cell):
         m.update(str_to_bytes(cell.metadata.nbgrader['grade_id']))
 
     return m.hexdigest()
+
+def parse_utc(ts):
+    """Parses a timestamp into datetime format, converting it to UTC if necessary."""
+    if isinstance(ts, str):
+        ts = dateutil.parser.parse(ts)
+    if ts.tzinfo is not None:
+        ts = (ts - ts.utcoffset()).replace(tzinfo=None)
+    return ts


### PR DESCRIPTION
Currently the database will automatically remove any timezone info from datetime objects, without properly converting those objects to UTC first. This adds functionality to make sure all timestamps are properly converted to UTC before being saved into the database. This also fixes a bug where when you try to update the timestamp, you get a `TypeError: can't compare offset-naive and offset-aware datetimes` error.

This won't get around the possibility that you could still do something like:

```
assignment = gb.find_assignment("Problem Set 1")
assignment.duedate = dateutil.parser.parse("2015-02-02 14:58:23.948203 PST")
gb.db.commit()
```

in which case the PST timezone would just be removed. The correct way to do it would be:

```
gb.update_or_create_assignment("Problem Set 1", duedate="2015-02-02 14:58:23.948203 PST")
```

Unfortunately, I don't think there's a good way to catch the first one.