### PR TITLE
Overwrite files with master version when autograding

### DIFF
--- a/nbgrader/apps/autogradeapp.py
+++ b/nbgrader/apps/autogradeapp.py
@@ -1,13 +1,15 @@
 import os
-import dateutil.parser
+import sys
 
 from textwrap import dedent
 
 from IPython.utils.traitlets import List, Bool
+from IPython.utils.path import link_or_copy
 
-from nbgrader.api import Gradebook, MissingEntry
 from nbgrader.apps.baseapp import BaseNbConvertApp, nbconvert_aliases, nbconvert_flags
-from nbgrader.preprocessors import SaveAutoGrades, Execute, OverwriteCells, ClearOutput
+from nbgrader.preprocessors import ClearOutput, OverwriteCells, SaveAutoGrades, Execute
+from nbgrader.api import Gradebook, MissingEntry
+from nbgrader import utils
 
 aliases = {}
 aliases.update(nbconvert_aliases)
@@ -76,9 +78,14 @@ class AutogradeApp(BaseNbConvertApp):
         )
     )
 
+    _sanitizing = True
+
     @property
     def _input_directory(self):
-        return self.submitted_directory
+        if self._sanitizing:
+            return self.submitted_directory
+        else:
+            return self.autograded_directory
 
     @property
     def _output_directory(self):
@@ -86,12 +93,15 @@ class AutogradeApp(BaseNbConvertApp):
 
     export_format = 'notebook'
 
-    preprocessors = List([
+    sanitize_preprocessors = List([
         ClearOutput,
-        OverwriteCells,
+        OverwriteCells
+    ])
+    autograde_preprocessors = List([
         Execute,
         SaveAutoGrades
     ])
+    preprocessors = List([])
 
     def init_assignment(self, assignment_id, student_id):
         super(AutogradeApp, self).init_assignment(assignment_id, student_id)
@@ -122,3 +132,43 @@ class AutogradeApp(BaseNbConvertApp):
 
         else:
             submission = gb.update_or_create_submission(assignment_id, student_id)
+
+        # copy files over from the source directory
+        if self._sanitizing:
+            dest_path = self._format_dest(assignment_id, student_id)
+
+            # find all the files in the source directory
+            source_path = self.directory_structure.format(
+                nbgrader_step=self.source_directory,
+                student_id='.',
+                assignment_id=assignment_id)
+            source_files = utils.find_all_files(source_path, self.ignore + ["*.ipynb"])
+
+            # copy them to the build directory
+            for filename in source_files:
+                dest = os.path.join(dest_path, os.path.relpath(filename, source_path))
+                path = os.path.dirname(dest)
+                self.writer._makedir(path)
+                if not os.path.normpath(dest) == os.path.normpath(filename):
+                    self.log.info("Linking %s -> %s", filename, dest)
+                    link_or_copy(filename, dest)
+
+    def _init_preprocessors(self):
+        self.exporter._preprocessors = []
+        if self._sanitizing:
+            preprocessors = self.sanitize_preprocessors
+        else:
+            preprocessors = self.autograde_preprocessors
+
+        for pp in preprocessors:
+            self.exporter.register_preprocessor(pp)
+
+    def convert_single_notebook(self, notebook_filename):
+        self._sanitizing = True
+        self._init_preprocessors()
+        super(AutogradeApp, self).convert_single_notebook(notebook_filename)
+
+        notebook_filename = os.path.join(self.writer.build_directory, os.path.basename(notebook_filename))
+        self._sanitizing = False
+        self._init_preprocessors()
+        super(AutogradeApp, self).convert_single_notebook(notebook_filename)

--- a/nbgrader/tests/base.py
+++ b/nbgrader/tests/base.py
@@ -131,8 +131,8 @@ print("hello")
         proc = cls._start_subprocess(command)
         true_retcode = proc.wait()
         output = proc.communicate()[0].decode()
+        print(output)
         if true_retcode != retcode:
-            print(output)
             raise AssertionError(
                 "process returned an unexpected return code: {}".format(true_retcode))
         cls._copy_coverage_files()

--- a/nbgrader/tests/test_nbgrader_autograde.py
+++ b/nbgrader/tests/test_nbgrader_autograde.py
@@ -239,3 +239,35 @@ class TestNbgraderAutograde(TestBase):
             assert not os.path.isfile("autograded/foo/ps1/foo.txt")
             assert os.path.isfile("autograded/foo/ps1/data/bar.txt")
             assert not os.path.isfile("autograded/foo/ps1/blah.pyc")
+
+    def test_grade_overwrite_files(self):
+        """Are dependent files properly linked and overwritten?"""
+        with self._temp_cwd(["files/submitted-unchanged.ipynb"]):
+            dbpath = self._setup_db()
+
+            os.makedirs('source/ps1')
+            shutil.copy('submitted-unchanged.ipynb', 'source/ps1/p1.ipynb')
+            with open("source/ps1/data.csv", "w") as fh:
+                fh.write("some,data\n")
+            self._run_command('nbgrader assign ps1 --db="{}" '.format(dbpath))
+
+            os.makedirs('submitted/foo/ps1')
+            shutil.move('submitted-unchanged.ipynb', 'submitted/foo/ps1/p1.ipynb')
+            with open('submitted/foo/ps1/timestamp.txt', 'w') as fh:
+                fh.write("2015-02-02 15:58:23.948203 PST")
+            with open("submitted/foo/ps1/data.csv", "w") as fh:
+                fh.write("some,other,data\n")
+            self._run_command('nbgrader autograde ps1 --db="{}"'.format(dbpath))
+
+            print(os.listdir("autograded/foo/ps1"))
+            assert os.path.isfile("autograded/foo/ps1/p1.ipynb")
+            assert os.path.isfile("autograded/foo/ps1/timestamp.txt")
+            assert os.path.isfile("autograded/foo/ps1/data.csv")
+
+            with open("autograded/foo/ps1/timestamp.txt", "r") as fh:
+                contents = fh.read()
+            assert_equal(contents, "2015-02-02 15:58:23.948203 PST")
+
+            with open("autograded/foo/ps1/data.csv", "r") as fh:
+                contents = fh.read()
+            assert_equal(contents, "some,data\n")

--- a/nbgrader/tests/test_nbgrader_autograde.py
+++ b/nbgrader/tests/test_nbgrader_autograde.py
@@ -177,6 +177,7 @@ class TestNbgraderAutograde(TestBase):
             assert os.path.isfile("autograded/foo/ps1/foo.txt")
 
             # force overwrite
+            os.remove("source/ps1/foo.txt")
             os.remove("submitted/foo/ps1/foo.txt")
             self._run_command('nbgrader autograde ps1 --db="{}" --force'.format(dbpath))
             assert os.path.isfile("autograded/foo/ps1/p1.ipynb")


### PR DESCRIPTION
This replaces files with their master versions (if they exist in the source directory) when running `nbgrader autograde`. It does this by breaking up the autograding into two steps: first, a "sanitize" step that replaces files, clears outputs, and replaces cells, and second, the actual autograding step where the notebooks are executed and the grades saved into the database.

Fixes #170 

ping @ellisonbg , as I don't want to merge this if it is going to cause any problems for you.

