### PR TITLE
Add force flag to overwrite assignments

### DIFF
--- a/nbgrader/apps/assignapp.py
+++ b/nbgrader/apps/assignapp.py
@@ -173,7 +173,6 @@ class AssignApp(BaseNbConvertApp):
                 self.log.warning("Removing existing directory %s", dest_path)
                 shutil.rmtree(dest_path)
             else:
-                self.log.error("Assignment already exists, use --force to overwrite: %s", dest_path)
-                sys.exit(1)
+                self.fail("Assignment already exists, use --force to overwrite: %s", dest_path)
 
         super(AssignApp, self).convert_notebooks()

--- a/nbgrader/tests/test_nbgrader_assign.py
+++ b/nbgrader/tests/test_nbgrader_assign.py
@@ -84,3 +84,24 @@ class TestNbgraderAssign(TestBase):
 
             notebook = gb.find_notebook("test", "ps1")
             assert_equal(len(notebook.grade_cells), 8)
+
+    def test_force(self):
+        """Ensure the force option works properly"""
+        with self._temp_cwd(["files/test.ipynb"]):
+            os.makedirs('source/ps1')
+            shutil.move("test.ipynb", "source/ps1/test.ipynb")
+            with open("source/ps1/foo.txt", "w") as fh:
+                fh.write("foo")
+
+            self._run_command('nbgrader assign ps1 --create')
+            assert os.path.isfile("release/ps1/test.ipynb")
+            assert os.path.isfile("release/ps1/foo.txt")
+
+            # this should fail, because it already exists
+            self._run_command('nbgrader assign ps1', 1)
+
+            # force overwrite
+            os.remove("source/ps1/foo.txt")
+            self._run_command('nbgrader assign ps1 --force')
+            assert os.path.isfile("release/ps1/test.ipynb")
+            assert not os.path.isfile("release/ps1/foo.txt")


### PR DESCRIPTION
Fixes #171

This should probably use the `self.fail` function that will be added by #200 , so either this should wait for that to be merged, or #200 will need to make some further changes to use `self.fail`.