### PR TITLE
Turn nbextension installation into an ipython app

### DIFF
--- a/nbgrader/install.py
+++ b/nbgrader/install.py
@@ -1,185 +1,190 @@
-from __future__ import print_function, absolute_import
+"""
+Misc utils to deals with installing nbgrader on a system
+"""
 
-"""
-Misc utils to deals wit installing nbgrader on a system
-"""
+from __future__ import print_function, absolute_import
 
 import sys
 import io
 import os.path
 import json
-import argparse
 
-import IPython.html.nbextensions as nbe
-from IPython.utils.path import locate_profile, get_ipython_dir
-from IPython.core.profiledir import ProfileDir
+from IPython.html.nbextensions import NBExtensionApp, flags as base_flags, aliases as base_aliases
+from IPython.utils.traitlets import Unicode, Bool
 from IPython.utils.py3compat import cast_unicode_py2
 
 
-def _get_profile_dir(profile, ipython_dir):
-    if not ipython_dir:
-        pdir = ProfileDir.find_profile_dir_by_name(get_ipython_dir(), profile).location
-    else:
-        ipython_dir = os.path.expanduser(ipython_dir)
-        pdir = ProfileDir.find_profile_dir_by_name(ipython_dir, profile).location
-    return pdir
+flags = {}
+flags.update(base_flags)
+del flags['symlink']
+del flags['s']
+del flags['user']
+flags.update({
+    "no-symlink" : (
+        {"NbGraderExtensionApp" : {"symlink" : False}},
+        "Copy files instead of creating symlink"
+    ),
+    "system" : (
+        {"NBExtensionApp" : {"user" : False}},
+        "Install to the system IPython directory"
+    ),
+    "install" : (
+        {"NbGraderExtensionApp" : {"install" : True}},
+        "Install the nbgrader nbextension"
+    ),
+    "activate" : (
+        {"NbGraderExtensionApp" : {"activate" : True}},
+        "Activate the nbgrader nbextension in the given profile (cannot be used with --deactivate)"
+    ),
+    "deactivate" : (
+        {"NbGraderExtensionApp" : {"deactivate" : True}},
+        "Deactivate the nbgrader nbextension in the given profile (cannot be used with --activate)"
+    ),
+})
 
-def install(profile, symlink=True, user=False, prefix=None,
-            verbose=False, ipython_dir=None):
-    """Install and activate nbgrader on a profile
+aliases = {}
+aliases.update(base_aliases)
+del aliases['destination']
+aliases.update({
+})
+
+class NbGraderExtensionApp(NBExtensionApp):
+
+    flags = flags
+    aliases = aliases
+
+    description = """Install nbgrader notebook extensions
+
+    Usage
+
+        python -m nbgrader [--install] [--activate] [--deactivate]
+
+    At least one of --install, --activate, or --deactivate must be given.
+
+    If the requested files are already up to date, no action is taken
+    unless --overwrite is specified.
     """
 
-    dname = os.path.dirname(__file__)
-    # might want to check if already installed and overwrite if exist
-    if symlink and verbose:
-        print('I will try to symlink the extension instead of copying files')
-    if prefix and verbose:
-        print("I will install in prefix:", prefix)
-    if not ipython_dir:
-        nbextensions_dir = None
-    else:
-        nbextensions_dir = os.path.join(ipython_dir,'nbextensions')
+    examples = """
+    To install without activating:
 
-    nbe.install_nbextension(os.path.join(dname, 'nbextensions', 'nbgrader'),
-                            user=user,
-                            prefix=prefix,
-                            symlink=symlink,
-                            nbextensions_dir=nbextensions_dir
-                            )
+        python -m nbgrader --install
 
+    To install and activate in the default profile:
 
-# TODO pass prefix as argument.
-def activate(profile, ipython_dir=None):
-    """
-    Manually modify the frontend json-config to load nbgrader extension.
+        python -m nbgrader --install --activate
+
+    To deactivate in the default profile:
+
+        python -m nbgrader --deactivate
+
     """
 
-    pdir = _get_profile_dir(profile, ipython_dir)
-    json_dir = os.path.join(pdir, 'nbconfig')
-    json_file = os.path.expanduser(os.path.join(json_dir, 'notebook.json'))
+    install = Bool(
+        False,
+        config=True,
+        help="Install the nbgrader nbextension")
 
-    try:
-        with io.open(json_file, 'r') as f:
-            config = json.loads(f.read())
-    except IOError:
-        # file doesn't exist yet. IPython might have never been launched.
-        config = {}
+    activate = Bool(
+        False,
+        config=True,
+        help="Activate the nbgrader nbextension in the given profile (incompatible with the `deactivate` option")
 
-    if not config.get('load_extensions', None):
-        config['load_extensions'] = {}
-    config['load_extensions']['nbgrader/create_assignment'] = True
+    deactivate = Bool(
+        False,
+        config=True,
+        help="Deactivate the nbgrader extension in the given profile (incompatible with the `activate` option)")
 
-    if not os.path.exists(json_dir):
-        os.mkdir(json_dir)
+    symlink = Bool(
+        True,
+        config=True,
+        help="Create symlinks instead of copying files")
 
-    with io.open(json_file, 'w+') as f:
-        f.write(cast_unicode_py2(json.dumps(config, indent=2), 'utf-8'))
+    user = Bool(
+        True,
+        config=True,
+        help="Whether to do a user install")
+
+    destination = Unicode('')
+
+    def start(self):
+        if self.activate and self.deactivate:
+            self.log.error("--activate and --deactivate cannot be used at the same time")
+            sys.exit(1)
+
+        if not self.activate and not self.deactivate and not self.install:
+            self.print_help()
+            sys.exit(1)
+
+        self.extra_args = [os.path.join(os.path.dirname(__file__), 'nbextensions', 'nbgrader')]
+        if self.install:
+            self.install_extensions()
+        if self.activate:
+            self.activate_extensions()
+        if self.deactivate:
+            self.deactivate_extensions()
+
+    def activate_extensions(self):
+        """
+        Manually modify the frontend json-config to load nbgrader extension.
+        """
+        if self.verbose >= 1:
+            print("activating nbextension for '%s' profile" % self.profile)
+
+        json_dir = os.path.join(self.profile_dir.location, 'nbconfig')
+        json_file = os.path.expanduser(os.path.join(json_dir, 'notebook.json'))
+
+        try:
+            with io.open(json_file, 'r') as f:
+                config = json.loads(f.read())
+        except IOError:
+            # file doesn't exist yet. IPython might have never been launched.
+            config = {}
+
+        if not config.get('load_extensions', None):
+            config['load_extensions'] = {}
+        config['load_extensions']['nbgrader/create_assignment'] = True
+
+        if not os.path.exists(json_dir):
+            os.mkdir(json_dir)
+
+        with io.open(json_file, 'w+') as f:
+            f.write(cast_unicode_py2(json.dumps(config, indent=2), 'utf-8'))
 
 
-def deactivate(profile, ipython_dir=None):
-    """
-    Manually modify the frontend json-config to load nbgrader extension.
-    """
+    def deactivate_extensions(self):
+        """
+        Manually modify the frontend json-config to load nbgrader extension.
+        """
+        json_dir = os.path.join(self.profile_dir.location, 'nbconfig')
+        json_file = os.path.expanduser(os.path.join(json_dir, 'notebook.json'))
 
-    pdir = _get_profile_dir(profile, ipython_dir)
-    json_dir = os.path.join(pdir, 'nbconfig')
-    json_file = os.path.expanduser(os.path.join(json_dir, 'notebook.json'))
+        try:
+            with io.open(json_file, 'r') as f:
+                config = json.loads(f.read())
+        except IOError:
+            # file doesn't exist yet. IPython might have never been launched.
+            return
 
-    try:
-        with io.open(json_file, 'r') as f:
-            config = json.loads(f.read())
-    except IOError:
-        # file doesn't exist yet. IPython might have never been launched.
-        return
+        if 'load_extensions' not in config:
+            return
+        if 'nbgrader/create_assignment' not in config['load_extensions']:
+            return
 
-    if 'load_extensions' not in config:
-        return
-    if 'nbgrader/create_assignment' not in config['load_extensions']:
-        return
+        if self.verbose >= 1:
+            print("deactivating nbextension for '%s' profile" % self.profile)
 
-    # deactivation require the delete the key.
-    del config['load_extensions']['nbgrader/create_assignment']
+        # deactivation require the delete the key.
+        del config['load_extensions']['nbgrader/create_assignment']
 
-    # prune if last extension.
-    if not config['load_extensions']:
-        del config['load_extensions']
+        # prune if last extension.
+        if not config['load_extensions']:
+            del config['load_extensions']
 
-    with io.open(json_file, 'w+') as f:
-        f.write(cast_unicode_py2(json.dumps(config, indent=2), 'utf-8'))
+        with io.open(json_file, 'w+') as f:
+            f.write(cast_unicode_py2(json.dumps(config, indent=2), 'utf-8'))
 
 
-def main(argv=None):
-    """Parse sys argv.args and install nbgrader extensions"""
+def main():
+    NbGraderExtensionApp.launch_instance()
 
-    # this is what argparse does if set to None, 
-    # and allows us to test this function with nose. 
-    if not argv:
-        argv = sys.argv[1:]
-
-    prog = '{} -m nbgrader'.format(os.path.basename(sys.executable))
-    parser = argparse.ArgumentParser(prog=prog,
-                description='''Install and activate nbgrader notebook extension for a given profile ''')
-    parser.add_argument('profile', nargs='?', default='default', metavar=('<profile_name>'))
-
-    parser.add_argument("--install", help="Install nbgrader notebook extension for given profile",
-                        action="store_true")
-
-    parser.add_argument("--activate", help="Activate nbgrader notebook extension for given profile",
-                        action="store_true")
-
-    parser.add_argument("--deactivate", help="Deactivate nbgrader extension for given profile",
-                        action="store_true")
-
-    parser.add_argument("-v", "--verbose", help="Increase verbosity",
-                        action='store_true')
-
-    parser.add_argument("--user", help="Force install in user land",
-                        action="store_true")
-
-    parser.add_argument("--no-symlink", help="Do not symlink at install time, but copy the files",
-                        action="store_false", dest='symlink', default=True)
-
-    parser.add_argument("--path", help="Explicit path to the ipython-dir to use",
-                        action='store', default=None)
-
-    parser.add_argument("--prefix", help="Prefix where to install extension",
-                        action='store', default=None)
-
-    args = parser.parse_args(argv)
-
-    help_and_exit = False
-    if args.activate and args.deactivate:
-        print("Cannot activate and deactivate extension as the same time", file=sys.stderr)
-        help_and_exit = True
-
-    if args.user and not args.install:
-        print("--user can only be used in conjunction with the --install flag.")
-        help_and_exit = True
-    
-    if not args.symlink and not args.install:
-        print("--no-symlink can only be used in conjunction with the --install flag.")
-        help_and_exit = True
-
-    if not (args.install or args.activate or args.deactivate):
-        print("\nUse one of `--activate`, `--deactivate` or `--install`. \n")
-        help_and_exit = True
-
-    if not args.profile or help_and_exit:
-        parser.print_help()
-        sys.exit(1)
-
-    if args.install:
-        install(     profile=args.profile,
-                 ipython_dir=args.path,
-                        user=args.user,
-                      prefix=args.prefix,
-                     symlink=args.symlink,
-                     verbose=args.verbose,
-                )
-
-    if args.activate :
-        activate(   profile=args.profile,
-                ipython_dir=args.path) 
-    if args.deactivate :
-        deactivate(     profile=args.profile,
-                    ipython_dir=args.path) 

--- a/nbgrader/tests/test_nbextension.py
+++ b/nbgrader/tests/test_nbextension.py
@@ -3,11 +3,10 @@ import tempfile
 import os
 import shutil
 import json
-from copy import copy
 
+from copy import copy
 from nose.tools import assert_equal, assert_raises
 from IPython.utils.py3compat import cast_unicode_py2
-
 
 from selenium import webdriver
 from selenium.webdriver.common.by import By
@@ -16,12 +15,14 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.keys import Keys
 
-from nbgrader.install import main
+from .base import TestBase
+
 
 def _assert_is_deactivated(config_file, key='nbgrader/create_assignment'):
     with open(config_file, 'r') as fh:
         config = json.load(fh)
-    assert_raises(KeyError, lambda:config['load_extensions'][key])
+    assert_raises(KeyError, lambda: config['load_extensions'][key])
+
 
 def _assert_is_activated(config_file, key='nbgrader/create_assignment'):
     with open(config_file, 'r') as fh:
@@ -29,7 +30,7 @@ def _assert_is_activated(config_file, key='nbgrader/create_assignment'):
     assert config['load_extensions'][key]
 
 
-class TestCreateAssignmentNbExtension(object):
+class TestCreateAssignmentNbExtension(TestBase):
 
     @classmethod
     def setup_class(cls):
@@ -125,14 +126,9 @@ class TestCreateAssignmentNbExtension(object):
         )
 
     def test_00_install_extension(self):
-        main([
-            '--install',
-            '--activate',
-            '--verbose',
-            '--no-symlink',
-            '--path={}'.format(self.ipythondir),
-            'default'
-        ])
+        self._run_command(
+            "python -m nbgrader --install --activate --no-symlink "
+            "--ipython-dir={}".format(self.ipythondir))
 
         # check the extension file were copied
         nbextension_dir = os.path.join(self.ipythondir, "nbextensions", "nbgrader")
@@ -142,7 +138,6 @@ class TestCreateAssignmentNbExtension(object):
         # check that it is activated
         config_file = os.path.join(self.ipythondir, 'profile_default', 'nbconfig', 'notebook.json')
         _assert_is_activated(config_file)
-
 
     def test_01_deactivate_extension(self):
         # check that it is activated
@@ -162,13 +157,9 @@ class TestCreateAssignmentNbExtension(object):
 
         _assert_is_activated(config_file, key=okey)
 
-
-        main([
-            '--deactivate',
-            '--verbose',
-            '--path={}'.format(self.ipythondir),
-            'default'
-        ])
+        self._run_command(
+            "python -m nbgrader --deactivate "
+            "--ipython-dir={}".format(self.ipythondir))
 
         # check that it is deactivated
         _assert_is_deactivated(config_file)
@@ -189,16 +180,12 @@ class TestCreateAssignmentNbExtension(object):
         config_file = os.path.join(self.ipythondir, 'profile_default', 'nbconfig', 'notebook.json')
         _assert_is_deactivated(config_file)
 
-        main([
-            '--activate',
-            '--verbose',
-            '--path={}'.format(self.ipythondir),
-            'default'
-        ])
+        self._run_command(
+            "python -m nbgrader --activate "
+            "--ipython-dir={}".format(self.ipythondir))
 
         # check that it is activated
         _assert_is_activated(config_file)
-
 
     def test_create_assignment(self):
         self._activate_toolbar()


### PR DESCRIPTION
This removes the argparse stuff for installing the nbextension and replaces it with a subclass of `NBExtensionApp`, so that it inherits all the functionality that IPython provides when installing nbextensions. The functions for activating and deactivating the extension are moved into this class.

* Fixes #206
* Fixes #205 

ping @ellisonbg @Carreau 