### PR TITLE
Skip already processed assignments

### DIFF
--- a/nbgrader/apps/assignapp.py
+++ b/nbgrader/apps/assignapp.py
@@ -128,14 +128,10 @@ class AssignApp(BaseNbConvertApp):
         extra_config.NbGraderConfig.student_id = '.'
         return extra_config
 
-    def init_single_notebook_resources(self, notebook_filename):
-        resources = super(AssignApp, self).init_single_notebook_resources(notebook_filename)
-
+    def init_assignment(self, assignment_id, student_id):
         # try to get the assignment from the database, and throw an error if it
         # doesn't exist
-        db_url = resources['nbgrader']['db_url']
-        assignment_id = resources['nbgrader']['assignment']
-        gb = Gradebook(db_url)
+        gb = Gradebook(self.db_url)
         try:
             gb.find_assignment(assignment_id)
         except MissingEntry:
@@ -144,5 +140,3 @@ class AssignApp(BaseNbConvertApp):
                 gb.add_assignment(assignment_id)
             else:
                 self.fail("No assignment called '%s' exists in the database", assignment_id)
-
-        return resources

--- a/nbgrader/apps/assignapp.py
+++ b/nbgrader/apps/assignapp.py
@@ -21,6 +21,8 @@ from nbgrader.preprocessors import (
 
 aliases = {}
 aliases.update(nbconvert_aliases)
+del aliases['student']
+del aliases['notebook']
 aliases.update({
 })
 
@@ -126,6 +128,7 @@ class AssignApp(BaseNbConvertApp):
     def build_extra_config(self):
         extra_config = super(AssignApp, self).build_extra_config()
         extra_config.NbGraderConfig.student_id = '.'
+        extra_config.NbGraderConfig.notebook_id = '*'
         return extra_config
 
     def init_assignment(self, assignment_id, student_id):

--- a/nbgrader/apps/assignapp.py
+++ b/nbgrader/apps/assignapp.py
@@ -35,10 +35,6 @@ flags.update({
         {'AssignApp': {'create_assignment': True}},
         "Create an entry for the assignment in the database, if one does not already exist."
     ),
-    'force': (
-        {'AssignApp': {'force': True}},
-        "Overwrite an existing assignment if it already exists."
-    ),
 })
 
 class AssignApp(BaseNbConvertApp):
@@ -107,16 +103,6 @@ class AssignApp(BaseNbConvertApp):
         )
     )
 
-    force = Bool(
-        False, config=True,
-        help=dedent(
-            """
-            If the assignment already exists in the release directory, force
-            overwriting it completely.
-            """
-        )
-    )
-
     @property
     def _input_directory(self):
         return self.source_directory
@@ -160,19 +146,3 @@ class AssignApp(BaseNbConvertApp):
                 self.fail("No assignment called '%s' exists in the database", assignment_id)
 
         return resources
-
-    def convert_notebooks(self):
-        dest_path = self.directory_structure.format(
-            nbgrader_step=self._output_directory,
-            student_id=self.student_id,
-            assignment_id=self.assignment_id
-        )
-
-        if os.path.exists(dest_path):
-            if self.force:
-                self.log.warning("Removing existing directory %s", dest_path)
-                shutil.rmtree(dest_path)
-            else:
-                self.fail("Assignment already exists, use --force to overwrite: %s", dest_path)
-
-        super(AssignApp, self).convert_notebooks()

--- a/nbgrader/apps/assignapp.py
+++ b/nbgrader/apps/assignapp.py
@@ -129,6 +129,8 @@ class AssignApp(BaseNbConvertApp):
         return extra_config
 
     def init_assignment(self, assignment_id, student_id):
+        super(AssignApp, self).init_assignment(assignment_id, student_id)
+
         # try to get the assignment from the database, and throw an error if it
         # doesn't exist
         gb = Gradebook(self.db_url)

--- a/nbgrader/apps/autogradeapp.py
+++ b/nbgrader/apps/autogradeapp.py
@@ -119,3 +119,6 @@ class AutogradeApp(BaseNbConvertApp):
             # if the submission is late, print out how many seconds late it is
             if timestamp and submission.total_seconds_late > 0:
                 self.log.warning("%s is %s seconds late", submission, submission.total_seconds_late)
+
+        else:
+            submission = gb.update_or_create_submission(assignment_id, student_id)

--- a/nbgrader/apps/autogradeapp.py
+++ b/nbgrader/apps/autogradeapp.py
@@ -94,6 +94,8 @@ class AutogradeApp(BaseNbConvertApp):
     ])
 
     def init_assignment(self, assignment_id, student_id):
+        super(AutogradeApp, self).init_assignment(assignment_id, student_id)
+
         # try to get the student from the database, and throw an error if it
         # doesn't exist
         gb = Gradebook(self.db_url)
@@ -107,11 +109,7 @@ class AutogradeApp(BaseNbConvertApp):
                 self.fail("No student with ID '%s' exists in the database", student_id)
 
         # try to read in a timestamp from file
-        src_path = self.directory_structure.format(
-            nbgrader_step=self._input_directory,
-            assignment_id=assignment_id,
-            student_id=student_id)
-
+        src_path = self._format_source(assignment_id, student_id)
         timestamp = self._get_existing_timestamp(src_path)
         if timestamp:
             submission = gb.update_or_create_submission(

--- a/nbgrader/apps/baseapp.py
+++ b/nbgrader/apps/baseapp.py
@@ -458,13 +458,13 @@ class BaseNbConvertApp(BaseNbGraderApp, NbConvertApp):
         # detect other files in the source directory
         for filename in find_all_files(source, self.ignore + ["*.ipynb"]):
             # Make sure folder exists.
-            dest = os.path.join(dest, os.path.relpath(filename, source))
-            ensure_dir_exists(os.path.dirname(dest))
+            path = os.path.join(dest, os.path.relpath(filename, source))
+            ensure_dir_exists(os.path.dirname(path))
 
             # Copy if destination is different.
-            if not os.path.normpath(dest) == os.path.normpath(filename):
-                self.log.info("Linking %s -> %s", filename, dest)
-                link_or_copy(filename, dest)
+            if not os.path.normpath(path) == os.path.normpath(filename):
+                self.log.info("Linking %s -> %s", filename, path)
+                link_or_copy(filename, path)
 
     def convert_notebooks(self):
         for assignment in self.assignments:

--- a/nbgrader/apps/baseapp.py
+++ b/nbgrader/apps/baseapp.py
@@ -406,7 +406,7 @@ class BaseNbConvertApp(BaseNbGraderApp, NbConvertApp):
         initialization was successful).
 
         """
-        dest = self._format_dest(assignment_id, student_id)
+        dest = os.path.normpath(self._format_dest(assignment_id, student_id))
 
         # the destination doesn't exist, so we haven't processed it
         if not os.path.exists(dest):

--- a/nbgrader/apps/collectapp.py
+++ b/nbgrader/apps/collectapp.py
@@ -111,16 +111,6 @@ class CollectApp(TransferApp):
         if not os.path.isdir(submit_dir):
             os.mkdir(submit_dir)
 
-    def _get_existing_timestamp(self, dest_path):
-        """Get the timestamp, as a datetime object, of an existing submission."""
-        timestamp_path = os.path.join(dest_path, 'timestamp.txt')
-        if os.path.exists(timestamp_path):
-            with open(timestamp_path, 'r') as fh:
-                timestamp = fh.read().strip()
-            return parse_utc(timestamp)
-        else:
-            return None
-            
     def copy_files(self):
         for rec in self.src_records:
             student_id = rec['username']

--- a/nbgrader/preprocessors/saveautogrades.py
+++ b/nbgrader/preprocessors/saveautogrades.py
@@ -13,24 +13,8 @@ class SaveAutoGrades(NbGraderPreprocessor):
         self.student_id = resources['nbgrader']['student']
         self.db_url = resources['nbgrader']['db_url']
 
-        # get the timestamp
-        timestamp = resources['nbgrader'].get('timestamp', None)
-        if timestamp:
-            kwargs = {'timestamp': timestamp}
-        else:
-            kwargs = {}
-
         # connect to the database
         self.gradebook = Gradebook(self.db_url)
-
-        submission = self.gradebook.update_or_create_submission(
-            self.assignment_id, self.student_id, **kwargs)
-
-        # if the submission is late, print out how many seconds late it is
-        self.log.info("%s submitted at %s", submission, timestamp)
-        if timestamp and submission.total_seconds_late > 0:
-            self.log.warning("%s is %s seconds late", submission, submission.total_seconds_late)
-
         self.comment_index = 0
 
         # process the cells

--- a/nbgrader/tests/test_getgrades.py
+++ b/nbgrader/tests/test_getgrades.py
@@ -33,6 +33,7 @@ class TestGetGrades(TestBase):
         nb = new_notebook()
         nb.cells.append(cell)
         self.preprocessor1.preprocess(nb, self.resources)
+        self.gb.add_submission("ps0", "bar")
         self.preprocessor2.preprocess(nb, self.resources)
         self.preprocessor3.preprocess(nb, self.resources)
 
@@ -47,6 +48,7 @@ class TestGetGrades(TestBase):
         nb = new_notebook()
         nb.cells.append(cell)
         self.preprocessor1.preprocess(nb, self.resources)
+        self.gb.add_submission("ps0", "bar")
         self.preprocessor2.preprocess(nb, self.resources)
         self.preprocessor3.preprocess(nb, self.resources)
 
@@ -60,6 +62,7 @@ class TestGetGrades(TestBase):
         nb = new_notebook()
         nb.cells.append(cell)
         self.preprocessor1.preprocess(nb, self.resources)
+        self.gb.add_submission("ps0", "bar")
         self.preprocessor2.preprocess(nb, self.resources)
         self.preprocessor3.preprocess(nb, self.resources)
 
@@ -73,6 +76,7 @@ class TestGetGrades(TestBase):
         nb = new_notebook()
         nb.cells.append(cell)
         self.preprocessor1.preprocess(nb, self.resources)
+        self.gb.add_submission("ps0", "bar")
         cell.source = "hello!"
         self.preprocessor2.preprocess(nb, self.resources)
         self.preprocessor3.preprocess(nb, self.resources)
@@ -87,6 +91,7 @@ class TestGetGrades(TestBase):
         nb = new_notebook()
         nb.cells.append(cell)
         self.preprocessor1.preprocess(nb, self.resources)
+        self.gb.add_submission("ps0", "bar")
         self.preprocessor2.preprocess(nb, self.resources)
         self.preprocessor3.preprocess(nb, self.resources)
 
@@ -103,6 +108,7 @@ class TestGetGrades(TestBase):
         nb = new_notebook()
         nb.cells.append(cell)
         self.preprocessor1.preprocess(nb, self.resources)
+        self.gb.add_submission("ps0", "bar")
         cell.source = "hello!"
         self.preprocessor2.preprocess(nb, self.resources)
         self.preprocessor3.preprocess(nb, self.resources)

--- a/nbgrader/tests/test_nbgrader_assign.py
+++ b/nbgrader/tests/test_nbgrader_assign.py
@@ -88,20 +88,34 @@ class TestNbgraderAssign(TestBase):
     def test_force(self):
         """Ensure the force option works properly"""
         with self._temp_cwd(["files/test.ipynb"]):
-            os.makedirs('source/ps1')
+            os.makedirs('source/ps1/data')
             shutil.move("test.ipynb", "source/ps1/test.ipynb")
             with open("source/ps1/foo.txt", "w") as fh:
                 fh.write("foo")
+            with open("source/ps1/data/bar.txt", "w") as fh:
+                fh.write("bar")
+            with open("source/ps1/blah.pyc", "w") as fh:
+                fh.write("asdf")
 
             self._run_command('nbgrader assign ps1 --create')
             assert os.path.isfile("release/ps1/test.ipynb")
             assert os.path.isfile("release/ps1/foo.txt")
+            assert os.path.isfile("release/ps1/data/bar.txt")
+            assert not os.path.isfile("release/ps1/blah.pyc")
 
-            # this should fail, because it already exists
-            self._run_command('nbgrader assign ps1', 1)
+            # check that it skips the existing directory
+            os.remove("release/ps1/foo.txt")
+            self._run_command('nbgrader assign ps1')
+            assert not os.path.isfile("release/ps1/foo.txt")
+
+            # force overwrite the supplemental files
+            self._run_command('nbgrader assign ps1 --force')
+            assert os.path.isfile("release/ps1/foo.txt")
 
             # force overwrite
             os.remove("source/ps1/foo.txt")
             self._run_command('nbgrader assign ps1 --force')
             assert os.path.isfile("release/ps1/test.ipynb")
+            assert os.path.isfile("release/ps1/data/bar.txt")
             assert not os.path.isfile("release/ps1/foo.txt")
+            assert not os.path.isfile("release/ps1/blah.pyc")

--- a/nbgrader/tests/test_nbgrader_feedback.py
+++ b/nbgrader/tests/test_nbgrader_feedback.py
@@ -33,3 +33,50 @@ class TestNbgraderFeedback(TestBase):
             self._run_command('nbgrader feedback ps1 --db="{}" '.format(dbpath))
 
             assert os.path.exists('feedback/foo/ps1/p1.html')
+
+    def test_force(self):
+        """Ensure the force option works properly"""
+        with self._temp_cwd(["files/submitted-unchanged.ipynb"]):
+            dbpath = self._setup_db()
+
+            os.makedirs('source/ps1/data')
+            shutil.copy('submitted-unchanged.ipynb', 'source/ps1/p1.ipynb')
+            with open("source/ps1/foo.txt", "w") as fh:
+                fh.write("foo")
+            with open("source/ps1/data/bar.txt", "w") as fh:
+                fh.write("bar")
+            self._run_command('nbgrader assign ps1 --db="{}" '.format(dbpath))
+
+            os.makedirs('submitted/foo/ps1/data')
+            shutil.move('submitted-unchanged.ipynb', 'submitted/foo/ps1/p1.ipynb')
+            with open("submitted/foo/ps1/foo.txt", "w") as fh:
+                fh.write("foo")
+            with open("submitted/foo/ps1/data/bar.txt", "w") as fh:
+                fh.write("bar")
+            self._run_command('nbgrader autograde ps1 --db="{}"'.format(dbpath))
+
+            with open("autograded/foo/ps1/blah.pyc", "w") as fh:
+                fh.write("asdf")
+            self._run_command('nbgrader feedback ps1 --db="{}"'.format(dbpath))
+
+            assert os.path.isfile("feedback/foo/ps1/p1.html")
+            assert os.path.isfile("feedback/foo/ps1/foo.txt")
+            assert os.path.isfile("feedback/foo/ps1/data/bar.txt")
+            assert not os.path.isfile("feedback/foo/ps1/blah.pyc")
+
+            # check that it skips the existing directory
+            os.remove("feedback/foo/ps1/foo.txt")
+            self._run_command('nbgrader feedback ps1 --db="{}"'.format(dbpath))
+            assert not os.path.isfile("feedback/foo/ps1/foo.txt")
+
+            # force overwrite the supplemental files
+            self._run_command('nbgrader feedback ps1 --db="{}" --force'.format(dbpath))
+            assert os.path.isfile("feedback/foo/ps1/foo.txt")
+
+            # force overwrite
+            os.remove("autograded/foo/ps1/foo.txt")
+            self._run_command('nbgrader feedback ps1 --db="{}" --force'.format(dbpath))
+            assert os.path.isfile("feedback/foo/ps1/p1.html")
+            assert not os.path.isfile("feedback/foo/ps1/foo.txt")
+            assert os.path.isfile("feedback/foo/ps1/data/bar.txt")
+            assert not os.path.isfile("feedback/foo/ps1/blah.pyc")

--- a/nbgrader/tests/test_saveautogrades.py
+++ b/nbgrader/tests/test_saveautogrades.py
@@ -32,6 +32,7 @@ class TestSaveAutoGrades(TestBase):
         nb = new_notebook()
         nb.cells.append(cell)
         self.preprocessor1.preprocess(nb, self.resources)
+        self.gb.add_submission("ps0", "bar")
         self.preprocessor2.preprocess(nb, self.resources)
 
         grade_cell = self.gb.find_grade("foo", "test", "ps0", "bar")
@@ -48,6 +49,7 @@ class TestSaveAutoGrades(TestBase):
         nb = new_notebook()
         nb.cells.append(cell)
         self.preprocessor1.preprocess(nb, self.resources)
+        self.gb.add_submission("ps0", "bar")
         self.preprocessor2.preprocess(nb, self.resources)
 
         grade_cell = self.gb.find_grade("foo", "test", "ps0", "bar")
@@ -63,6 +65,7 @@ class TestSaveAutoGrades(TestBase):
         nb = new_notebook()
         nb.cells.append(cell)
         self.preprocessor1.preprocess(nb, self.resources)
+        self.gb.add_submission("ps0", "bar")
         self.preprocessor2.preprocess(nb, self.resources)
 
         grade_cell = self.gb.find_grade("foo", "test", "ps0", "bar")
@@ -78,6 +81,7 @@ class TestSaveAutoGrades(TestBase):
         nb = new_notebook()
         nb.cells.append(cell)
         self.preprocessor1.preprocess(nb, self.resources)
+        self.gb.add_submission("ps0", "bar")
         cell.source = "hello!"
         self.preprocessor2.preprocess(nb, self.resources)
 
@@ -94,6 +98,7 @@ class TestSaveAutoGrades(TestBase):
         nb = new_notebook()
         nb.cells.append(cell)
         self.preprocessor1.preprocess(nb, self.resources)
+        self.gb.add_submission("ps0", "bar")
         self.preprocessor2.preprocess(nb, self.resources)
 
         comment = self.gb.find_comment(0, "test", "ps0", "bar")
@@ -105,6 +110,7 @@ class TestSaveAutoGrades(TestBase):
         nb = new_notebook()
         nb.cells.append(cell)
         self.preprocessor1.preprocess(nb, self.resources)
+        self.gb.add_submission("ps0", "bar")
         cell.source = "hello!"
         self.preprocessor2.preprocess(nb, self.resources)
 
@@ -117,6 +123,7 @@ class TestSaveAutoGrades(TestBase):
         nb = new_notebook()
         nb.cells.append(cell)
         self.preprocessor1.preprocess(nb, self.resources)
+        self.gb.add_submission("ps0", "bar")
         self.preprocessor2.preprocess(nb, self.resources)
 
         comment = self.gb.find_comment(0, "test", "ps0", "bar")
@@ -128,6 +135,7 @@ class TestSaveAutoGrades(TestBase):
         nb = new_notebook()
         nb.cells.append(cell)
         self.preprocessor1.preprocess(nb, self.resources)
+        self.gb.add_submission("ps0", "bar")
         cell.source = "hello!"
         self.preprocessor2.preprocess(nb, self.resources)
 


### PR DESCRIPTION
This makes it possible for all steps of the nbgrader pipeline that inherit from `BaseNbConvertApp` to skip processing an assignment if it's already been processed. Additionally, this adds a `--force` flag to all these steps so that the assignment can be overwritten if so desired. This PR also centralizes some of stuff that only needs to happen once per assignment -- for example, extra files should be copied over once for the whole assignment, rather than per notebook.

Fixes #173