### PR TITLE
Run the notebook server with the same python version as nbgrader

### DIFF
--- a/nbgrader/auth/noauth.py
+++ b/nbgrader/auth/noauth.py
@@ -3,6 +3,7 @@ import socket
 import os
 import subprocess as sp
 import time
+import sys
 from IPython.utils.traitlets import Bool, Integer
 
 from .base import BaseAuth
@@ -32,11 +33,19 @@ class NoAuth(BaseAuth):
 
         # first launch a notebook server
         if self.start_nbserver:
+            if sys.version_info[0] == 2:
+                program = "python2"
+            elif sys.version_info[0] == 3:
+                program = "python3"
+
+            notebookapp = os.path.normpath(os.path.join(
+                os.path.dirname(__file__), "..", "apps", "notebookapp.py"))
+
             self._notebook_server_ip = self._ip
             self._notebook_server_port = str(self.nbserver_port)
             self._notebook_server = sp.Popen(
                 [
-                    "python", os.path.join(os.path.dirname(__file__), "..", "apps", "notebookapp.py"),
+                    program, notebookapp,
                     "--ip", self._notebook_server_ip,
                     "--port", self._notebook_server_port
                 ],


### PR DESCRIPTION
Otherwise, if nbgrader is installed with python3 and ipython is not installed on python2, then launching the notebook server for the formgrader will fail.