### PR TITLE
Make it possible to navigate to the next/prev incorrect code response

### DIFF
--- a/nbgrader/html/formgrade.py
+++ b/nbgrader/html/formgrade.py
@@ -207,17 +207,32 @@ def view_submission(submission_id):
         abort(404)
 
     submissions = app.gradebook.notebook_submissions(notebook_id, assignment_id)
-    submissions = sorted([x.id for x in submissions])
 
-    ix = submissions.index(submission.id)
+    # find previous and next submission
+    submission_ids = sorted([x.id for x in submissions])
+    ix = submission_ids.index(submission.id)
     if ix == 0:
         prev_submission = None
     else:
-        prev_submission = submissions[ix - 1]
+        prev_submission = submission_ids[ix - 1]
     if ix == (len(submissions) - 1):
         next_submission = None
     else:
-        next_submission = submissions[ix + 1]
+        next_submission = submission_ids[ix + 1]
+
+    # find previous and next incorrect submission
+    incorrect_ids = set([x.id for x in submissions if x.code_score < x.max_code_score])
+    incorrect_ids.add(submission.id)
+    incorrect_ids = sorted(incorrect_ids)
+    ix_incorrect = incorrect_ids.index(submission.id)
+    if ix_incorrect == 0:
+        prev_incorrect = None
+    else:
+        prev_incorrect = incorrect_ids[ix_incorrect - 1]
+    if ix_incorrect == (len(incorrect_ids) - 1):
+        next_incorrect = None
+    else:
+        next_incorrect = incorrect_ids[ix_incorrect + 1]
 
     server_exists = app.auth.notebook_server_exists()
     resources = {
@@ -226,6 +241,8 @@ def view_submission(submission_id):
         'submission_id': submission.id,
         'next': next_submission,
         'prev': prev_submission,
+        'next_incorrect': next_incorrect,
+        'prev_incorrect': prev_incorrect,
         'index': ix,
         'total': len(submissions),
         'notebook_server_exists': server_exists,

--- a/nbgrader/html/formgrade.py
+++ b/nbgrader/html/formgrade.py
@@ -221,7 +221,7 @@ def view_submission(submission_id):
         next_submission = submission_ids[ix + 1]
 
     # find previous and next incorrect submission
-    incorrect_ids = set([x.id for x in submissions if x.code_score < x.max_code_score])
+    incorrect_ids = set([x.id for x in submissions if x.failed_tests])
     incorrect_ids.add(submission.id)
     incorrect_ids = sorted(incorrect_ids)
     ix_incorrect = incorrect_ids.index(submission.id)

--- a/nbgrader/html/static/js/formgrade.js
+++ b/nbgrader/html/static/js/formgrade.js
@@ -121,13 +121,36 @@ var nextAssignment = function () {
     }
 };
 
+var nextIncorrectAssignment = function () {
+    if (next_incorrect_href) {
+        window.location = next_incorrect_href + "#" + getIndex(last_selected);
+    }
+};
+
 var prevAssignment = function () {
     href = $("li.previous a").attr("href");
     if (href) {
         window.location = href + "#" + getIndex(last_selected);
     }
 };
-    
+
+var prevIncorrectAssignment = function () {
+    if (prev_incorrect_href) {
+        window.location = prev_incorrect_href + "#" + getIndex(last_selected);
+    }
+};
+
+var save_and_navigate = function(callback) {
+    elem = document.activeElement;
+    if (elem.tagName === "INPUT" || elem.tagName === "TEXTAREA") {
+        $(document).on("finished_saving", callback);
+        $(elem).blur();
+        $(elem).trigger("change");
+    } else {
+        callback();
+    }
+};
+
 $(window).load(function () {
     grades = new Grades();
     grades.fetch({
@@ -150,14 +173,14 @@ $(window).load(function () {
     // disable link selection on tabs
     $('a').attr('tabindex', '-1');
 
-    $("input, textarea").on('keydown', function(e) { 
+    $("input, textarea").on('keydown', function(e) {
         var keyCode = e.keyCode || e.which;
 
         if (keyCode === 9) { // tab
             e.preventDefault();
             e.stopPropagation();
             selectNext(e.currentTarget, e.shiftKey);
-            
+
         } else if (keyCode === 27) { // escape
             $(e.currentTarget).blur();
         }
@@ -171,29 +194,16 @@ $(window).load(function () {
         if (keyCode === 9) { // tab
             e.preventDefault();
             selectNext(last_selected, e.shiftKey);
-
         } else if (keyCode === 13) { // enter
             last_selected.select();
-
+        } else if (keyCode == 39 && e.shiftKey && e.ctrlKey) { // shift + control + right arrow
+            save_and_navigate(nextIncorrectAssignment);
+        } else if (keyCode == 37 && e.shiftKey && e.ctrlKey) { // shift + control + left arrow
+            save_and_navigate(prevIncorrectAssignment);
         } else if (keyCode == 39 && e.shiftKey) { // shift + right arrow
-            elem = document.activeElement;
-            if (elem.tagName === "INPUT" || elem.tagName === "TEXTAREA") {
-                $(document).on("finished_saving", nextAssignment);
-                $(elem).blur();
-                $(elem).trigger("change");
-            } else {
-                nextAssignment();
-            }
-
+            save_and_navigate(nextAssignment);
         } else if (keyCode == 37 && e.shiftKey) { // shift + left arrow
-            elem = document.activeElement;
-            if (elem.tagName === "INPUT" || elem.tagName === "TEXTAREA") {
-                $(document).on("finished_saving", prevAssignment);
-                $(elem).blur();
-                $(elem).trigger("change");
-            } else {
-                prevAssignment();
-            }
+            save_and_navigate(prevAssignment);
         }
     });
 

--- a/nbgrader/html/templates/formgrade.tpl
+++ b/nbgrader/html/templates/formgrade.tpl
@@ -19,6 +19,18 @@ var submission_id = "{{ resources.submission_id }}";
 var notebook_id = "{{ resources.notebook_id }}";
 var assignment_id = "{{ resources.assignment_id }}";
 var base_url = "{{resources.base_url}}";
+
+{%- if resources.next_incorrect -%}
+var next_incorrect_href = "{{resources.base_url}}/submissions/{{ resources.next_incorrect }}";
+{%- else -%}
+var next_incorrect_href;
+{%- endif -%}
+
+{%- if resources.prev_incorrect -%}
+var prev_incorrect_href = "{{resources.base_url}}/submissions/{{ resources.prev_incorrect }}";
+{%- else -%}
+var prev_incorrect_href;
+{%- endif -%}
 </script>
 
 <script src="{{resources.base_url}}/static/js/formgrade.js"></script>

--- a/nbgrader/html/templates/notebook_submissions.tpl
+++ b/nbgrader/html/templates/notebook_submissions.tpl
@@ -23,6 +23,7 @@
     <th class="center">Code Score</th>
     <th class="center">Written Score</th>
     <th class="center">Manual grade?</th>
+    <th class="center">Tests failed?</th>
   </tr>
 </thead>
 <tbody>
@@ -40,6 +41,11 @@
     </td>
     <td class="center">
       {%- if submission.needs_manual_grade -%}
+      <span class="glyphicon glyphicon-ok"></span>
+      {%- endif -%}
+    </td>
+    <td class="center">
+      {%- if submission.failed_tests -%}
       <span class="glyphicon glyphicon-ok"></span>
       {%- endif -%}
     </td>

--- a/nbgrader/html/templates/student_submissions.tpl
+++ b/nbgrader/html/templates/student_submissions.tpl
@@ -21,6 +21,7 @@
     <th class="center">Code Score</th>
     <th class="center">Written Score</th>
     <th class="center">Manual grade?</th>
+    <th class="center">Tests failed?</th>
   </tr>
 </thead>
 <tbody>
@@ -36,6 +37,11 @@
     <td class="center">{{ submission.written_score | float | round(2) }} / {{ submission.max_written_score | float | round(2) }}</td>
     <td class="center">
       {%- if submission.needs_manual_grade -%}
+      <span class="glyphicon glyphicon-ok"></span>
+      {%- endif -%}
+    </td>
+    <td class="center">
+      {%- if submission.failed_tests -%}
       <span class="glyphicon glyphicon-ok"></span>
       {%- endif -%}
     </td>


### PR DESCRIPTION
If students lose points on the code from the autograder, it is nice to be able to give them partial credit. However, if most students got it, then this means you have to navigate through a lot of submissions to get to the ones that lost points. This PR adds a keyboard shortcut (Ctrl+Shift+arrow) to navigate to the next or previous submission that lost points on the coding parts of the problem.

Edit: I also added in a new field to the api indicating whether any tests failed, and then also added a column the formgrader indicating as such.

Fixes #158 
Fixes #95

ping @suchow