### PR TITLE
Fix hubauth to work with current jupyterhub

### DIFF
--- a/nbgrader/auth/hubauth.py
+++ b/nbgrader/auth/hubauth.py
@@ -109,7 +109,6 @@ class HubAuth(BaseAuth):
 
             #  Auth information recieved.
             data = response.json()
-            self.log.info(data)
             if 'name' in data:
                 user = data['name']
 

--- a/nbgrader/auth/hubauth.py
+++ b/nbgrader/auth/hubauth.py
@@ -109,8 +109,9 @@ class HubAuth(BaseAuth):
 
             #  Auth information recieved.
             data = response.json()
-            if 'user' in data:
-                user = data['user']
+            self.log.info(data)
+            if 'name' in data:
+                user = data['name']
 
                 # Check if the user name is registered as a grader.
                 if user in self.graders:


### PR DESCRIPTION
Recent changes to JupyterHub have renamed the `user` key to `name` in the response json. This updates the JupyterHub authentication to use `name` instead of `user`.

Ping @ellisonbg and @jdfreder , just FYI. I need to make this change so the tests on travis will pass, but wanted you to be aware of it.