### PR TITLE
Add submission flags

### DIFF
--- a/docs/source/api/models.rst
+++ b/docs/source/api/models.rst
@@ -198,6 +198,8 @@ Submitted assignments
 
     .. autoattribute:: student
 
+    .. autoattribute:: flagged
+
     .. autoattribute:: score
 
     .. autoattribute:: max_score

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -470,7 +470,6 @@ class SubmittedNotebook(Base):
 
     #: Unique id of :attr:`~nbgrader.api.SubmittedNotebook.assignment`
     assignment_id = Column(String(32), ForeignKey('submitted_assignment.id'))
-    flagged = Column(Boolean, default=False)
 
     #: The master version of this notebook, represesnted by a
     #: :class:`~nbgrader.api.Notebook` object
@@ -490,6 +489,9 @@ class SubmittedNotebook(Base):
     #: The student who submitted this notebook, represented by a
     #: :class:`~nbgrader.api.Student` object
     student = association_proxy('assignment', 'student')
+
+    #: Whether this assignment has been flagged by a human grader
+    flagged = Column(Boolean, default=False)
 
     #: The score assigned to this notebook, automatically calculated from the
     #: :attr:`~nbgrader.api.Grade.score` of each grade cell within

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -470,6 +470,7 @@ class SubmittedNotebook(Base):
 
     #: Unique id of :attr:`~nbgrader.api.SubmittedNotebook.assignment`
     assignment_id = Column(String(32), ForeignKey('submitted_assignment.id'))
+    flagged = Column(Boolean, default=False)
 
     #: The master version of this notebook, represesnted by a
     #: :class:`~nbgrader.api.Notebook` object
@@ -544,7 +545,8 @@ class SubmittedNotebook(Base):
             "written_score": self.written_score,
             "max_written_score": self.max_written_score,
             "needs_manual_grade": self.needs_manual_grade,
-            "failed_tests": self.failed_tests
+            "failed_tests": self.failed_tests,
+            "flagged": self.flagged
         }
 
     def __repr__(self):
@@ -2131,7 +2133,8 @@ class Gradebook(object):
             code_scores.c.code_score, code_scores.c.max_code_score,
             written_scores.c.written_score, written_scores.c.max_written_score,
             func.coalesce(manual_grade.c.needs_manual_grade, False),
-            func.coalesce(failed_tests.c.failed_tests, False)
+            func.coalesce(failed_tests.c.failed_tests, False),
+            SubmittedNotebook.flagged
         ).join(SubmittedAssignment, Notebook, Assignment, Student, Grade, GradeCell)\
          .outerjoin(code_scores, SubmittedNotebook.id == code_scores.c.id)\
          .outerjoin(written_scores, SubmittedNotebook.id == written_scores.c.id)\
@@ -2153,6 +2156,6 @@ class Gradebook(object):
             "code_score", "max_code_score", 
             "written_score", "max_written_score",
             "needs_manual_grade",
-            "failed_tests"
+            "failed_tests", "flagged"
         ]
         return [dict(zip(keys, x)) for x in submissions]

--- a/nbgrader/html/formgrade.py
+++ b/nbgrader/html/formgrade.py
@@ -428,6 +428,20 @@ def get_comment(_id):
     return json.dumps(comment.to_dict())
 
 
+@blueprint.route("/api/submission/<submission_id>/flag")
+@auth
+def flag_submission(submission_id):
+    try:
+        submission = app.gradebook.find_submission_notebook_by_id(submission_id)
+    except MissingEntry:
+        abort(404)
+
+    submission.flagged = not submission.flagged
+    app.gradebook.db.commit()
+
+    return json.dumps(submission.to_dict())
+
+
 app.register_blueprint(blueprint, url_defaults={'name': ''})
 if __name__ == "__main__":
     app.run(debug=True)

--- a/nbgrader/html/static/css/formgrade.css
+++ b/nbgrader/html/static/css/formgrade.css
@@ -132,6 +132,7 @@ div.nbgrader_cell .input_area {
     overflow: hidden;
 }
 
+<<<<<<< HEAD
 .scoring-buttons button {
   background-color: #337ab7;
 }
@@ -203,4 +204,14 @@ div.nbgrader_cell .input_area {
   bottom: 0;
   position: fixed;
   z-index: 1040;
+}
+
+#statusmessage {
+    position: fixed;
+    top: 40%;
+    width: 100%;
+    z-index: 9999;
+    font-size: 3em;
+    text-align: center;
+    font-weight: bold;
 }

--- a/nbgrader/html/static/js/formgrade.js
+++ b/nbgrader/html/static/js/formgrade.js
@@ -68,7 +68,7 @@ FormGrader.prototype.init = function () {
     });
     this.keyboard_manager.register({
         "handler": _.bind(this.flag, this),
-        "keybinding": "control+shift+f",
+        "keybinding": "control-shift-f",
         "help": "Flag the submission"
     });
 };

--- a/nbgrader/html/static/js/formgrade.js
+++ b/nbgrader/html/static/js/formgrade.js
@@ -66,6 +66,11 @@ FormGrader.prototype.init = function () {
         "keybinding": "control-shift-,",
         "help": "Move to the same score or comment input of the previous submission with failed tests"
     });
+    this.keyboard_manager.register({
+        "handler": _.bind(this.flag, this),
+        "keybinding": "control+shift+f",
+        "help": "Flag the submission"
+    });
 };
 
 FormGrader.prototype.loadGrades = function () {
@@ -286,6 +291,32 @@ FormGrader.prototype.configureScrolling = function () {
             that.last_selected.focus();
             MathJax.loaded = true;
             that.scrollToLastSelected();
+        }
+    });
+};
+
+FormGrader.prototype.flag = function () {
+    $.ajax({
+        'url': base_url + '/api/submission/' + submission_id + '/flag',
+        'success': function (data, status, xhr) {
+            var elem = $("#statusmessage");
+            data = JSON.parse(data);
+            if (data.flagged) {
+                elem.text("Submission flagged");
+                elem.css({
+                    'color': 'rgba(255, 0, 0, 0.6)'
+                });
+                elem.show();
+            } else {
+                elem.text("Submission unflagged");
+                elem.css({
+                    'color': 'rgba(0, 100, 0, 0.6)'
+                });
+                elem.show();
+            }
+            setTimeout(function () {
+                elem.fadeOut(500);
+            }, 500);
         }
     });
 };

--- a/nbgrader/html/static/js/keyboardmanager.js
+++ b/nbgrader/html/static/js/keyboardmanager.js
@@ -5,6 +5,7 @@ function KeyboardManager () {
         13: 'enter',
         190: '.',
         188: ','
+        70: 'f'
     };
 
     this.handlers = new Object();

--- a/nbgrader/html/static/js/keyboardmanager.js
+++ b/nbgrader/html/static/js/keyboardmanager.js
@@ -4,7 +4,7 @@ function KeyboardManager () {
         27: 'escape',
         13: 'enter',
         190: '.',
-        188: ','
+        188: ',',
         70: 'f'
     };
 

--- a/nbgrader/html/templates/formgrade.tpl
+++ b/nbgrader/html/templates/formgrade.tpl
@@ -59,6 +59,7 @@ window.MathJax = {
     </div>
   </div>
   <div class="help"><span class="glyphicon glyphicon-question-sign"></span></div>
+  <div id="statusmessage"></div>
 </body>
 {%- endblock body %}
 

--- a/nbgrader/html/templates/notebook_submissions.tpl
+++ b/nbgrader/html/templates/notebook_submissions.tpl
@@ -24,6 +24,7 @@
     <th class="center">Written Score</th>
     <th class="center">Needs manual grade?</th>
     <th class="center">Tests failed?</th>
+    <th class="center">Flagged?</th>
   </tr>
 </thead>
 <tbody>
@@ -47,6 +48,11 @@
     <td class="center">
       {%- if submission.failed_tests -%}
       <span class="glyphicon glyphicon-ok"></span>
+      {%- endif -%}
+    </td>
+    <td class="center">
+      {%- if submission.flagged -%}
+      <span class="glyphicon glyphicon-flag"></span>
       {%- endif -%}
     </td>
   </tr>

--- a/nbgrader/html/templates/student_submissions.tpl
+++ b/nbgrader/html/templates/student_submissions.tpl
@@ -22,6 +22,7 @@
     <th class="center">Written Score</th>
     <th class="center">Needs manual grade?</th>
     <th class="center">Tests failed?</th>
+    <th class="center">Flagged?</th>
   </tr>
 </thead>
 <tbody>
@@ -43,6 +44,11 @@
     <td class="center">
       {%- if submission.failed_tests -%}
       <span class="glyphicon glyphicon-ok"></span>
+      {%- endif -%}
+    </td>
+    <td class="center">
+      {%- if submission.flagged -%}
+      <span class="glyphicon glyphicon-flag"></span>
       {%- endif -%}
     </td>
   </tr>

--- a/nbgrader/tests/api/test_gradebook.py
+++ b/nbgrader/tests/api/test_gradebook.py
@@ -628,8 +628,10 @@ def test_student_dicts(assignment):
 def test_notebook_submission_dicts(assignment):
     assignment.add_student('hacker123')
     assignment.add_student('bitdiddle')
-    assignment.add_submission('foo', 'hacker123')
-    assignment.add_submission('foo', 'bitdiddle')
+    s1 = assignment.add_submission('foo', 'hacker123')
+    s2 = assignment.add_submission('foo', 'bitdiddle')
+    s1.flagged = True
+    s2.flagged = False
 
     g1 = assignment.find_grade("test1", "p1", "foo", "hacker123")
     g2 = assignment.find_grade("test2", "p1", "foo", "hacker123")

--- a/nbgrader/tests/api/test_models.py
+++ b/nbgrader/tests/api/test_models.py
@@ -1086,7 +1086,7 @@ def test_submittednotebook_to_dict(submissions):
     assert set(snd.keys()) == {
         'id', 'name', 'student', 'score', 'max_score', 'code_score',
         'max_code_score', 'written_score', 'max_written_score',
-        'needs_manual_grade', 'failed_tests'}
+        'needs_manual_grade', 'failed_tests', 'flagged'}
 
     assert snd['id'] == sn.id
     assert snd['name'] == 'blah'
@@ -1099,6 +1099,7 @@ def test_submittednotebook_to_dict(submissions):
     assert snd['max_written_score'] == 10
     assert snd['needs_manual_grade']
     assert not snd['failed_tests']
+    assert not snd['flagged']
 
     # make sure it can be JSONified
     json.dumps(snd)

--- a/nbgrader/tests/formgrader/test_formgrader_js.py
+++ b/nbgrader/tests/formgrader/test_formgrader_js.py
@@ -43,6 +43,13 @@ class TestFormgraderJS(BaseTestFormgrade):
     def _get_needs_manual_grade(self, index):
         return self.browser.execute_script('return formgrader.grades.at({:d}).get("needs_manual_grade");'.format(index))
 
+    def _flag(self):
+        self._send_keys_to_body(Keys.SHIFT, Keys.CONTROL, "f")
+        message = self.browser.find_element_by_id("statusmessage")
+        WebDriverWait(self.browser, 10).until(lambda browser: message.is_displayed())
+        WebDriverWait(self.browser, 10).until(lambda browser: not message.is_displayed())
+        return self.browser.execute_script("return $('#statusmessage').text();")
+
     def _get_active_element(self):
         return self.browser.execute_script("return document.activeElement;")
 
@@ -371,3 +378,15 @@ class TestFormgraderJS(BaseTestFormgrade):
         self._click_element("#help-dialog button.btn-primary")
         modal_not_present = lambda browser: browser.execute_script("""return $("#help-dialog").length === 0;""")
         WebDriverWait(self.browser, 30).until(modal_not_present)
+
+    def test_flag(self):
+        self._load_formgrade()
+
+        # mark as flagged
+        assert self._flag() == "Submission flagged"
+
+        # mark as unflagged
+        assert self._flag() == "Submission unflagged"
+
+        # mark as flagged
+        assert self._flag() == "Submission flagged"

--- a/nbgrader/tests/formgrader/test_formgrader_js.py
+++ b/nbgrader/tests/formgrader/test_formgrader_js.py
@@ -390,3 +390,6 @@ class TestFormgraderJS(BaseTestFormgrade):
 
         # mark as flagged
         assert self._flag() == "Submission flagged"
+
+        # mark as unflagged
+        assert self._flag() == "Submission unflagged"


### PR DESCRIPTION
This adds the ability to flag submissions in the formgrader. I tried to make this as generic as possible, so that instructors can apply whatever meaning they want to the idea of a flag -- e.g., suspicious submission, need someone else to look at it, come back to it later, etc.

Ping @ellisonbg and @jdfreder as this requires adding a new column to one of the database tables. I won't merge this until I have your +1 since I don't want to break stuff for you.