### PR TITLE
Don't scroll until mathjax is loaded

### DIFF
--- a/nbgrader/html/static/js/formgrade.js
+++ b/nbgrader/html/static/js/formgrade.js
@@ -118,7 +118,7 @@ var selectNext = function (target, shift) {
 };
 
 var scrollTo = function (elem) {
-    var target = elem.closest(".nbgrader_cell");
+    var target = elem.parents(".nbgrader_cell");
     return target.offset().top - $(window).height() * 0.33 + 60;
 };
 
@@ -206,8 +206,13 @@ $(window).load(function () {
             selectNext(last_selected, e.shiftKey);
         } else if (keyCode === 13) { // enter
             if (last_selected[0] !== document.activeElement) {
-                last_selected.select();
-                last_selected.focus();
+                $("body, html").scrollTop(scrollTo(last_selected));
+                MathJax.Hub.Startup.signal.Interest(function (message) {
+                    if (message === "End") {
+                        last_selected.select();
+                        last_selected.focus();
+                    }
+                });
             }
         } else if (keyCode == 39 && e.shiftKey && e.ctrlKey) { // shift + control + right arrow
             save_and_navigate(nextIncorrectAssignment);


### PR DESCRIPTION
The scrolling in the formgrader can be a bit frustrating if there is a lot of math in the notebook, and mathjax hasn't finished loading yet -- it will execute the scroll, but then the math will finish loading, thus causing the scroll position to be off. This makes it so that the scrolling only happens after mathjax is fully loaded.