### PR TITLE
Fix formgrader to work with 0.0.0.0

### DIFF
--- a/nbgrader/auth/base.py
+++ b/nbgrader/auth/base.py
@@ -10,7 +10,7 @@ class BaseAuth(LoggingConfigurable):
         self._app = app
         self._ip = ip
         self._port = port
-        self._base_url = 'http://{}:{}'.format(ip, port)
+        self._base_url = ''
         self._base_directory = base_directory
 
     @property

--- a/nbgrader/auth/hubauth.py
+++ b/nbgrader/auth/hubauth.py
@@ -84,7 +84,7 @@ class HubAuth(BaseAuth):
         # Register self as a route of the configurable-http-proxy and then
         # update the base_url to point to the new path.
         response = self._proxy_request('/api/routes' + self.remap_url, method='POST', body={
-            'target': self._base_url
+            'target': 'http://{}:{}'.format(self._ip, self._port)
         })
         if response.status_code != 201:
             raise Exception('Error while trying to add JupyterHub route. {}: {}'.format(response.status_code, response.text))

--- a/nbgrader/auth/noauth.py
+++ b/nbgrader/auth/noauth.py
@@ -4,7 +4,8 @@ import os
 import subprocess as sp
 import time
 import sys
-from IPython.utils.traitlets import Bool, Integer
+from textwrap import dedent
+from IPython.utils.traitlets import Bool, Integer, Unicode
 
 from .base import BaseAuth
 
@@ -40,6 +41,13 @@ class NoAuth(BaseAuth):
 
             notebookapp = os.path.normpath(os.path.join(
                 os.path.dirname(__file__), "..", "apps", "notebookapp.py"))
+
+            if self._ip == "0.0.0.0":
+                self.log.warning(
+                    "I will launch the notebook server on '0.0.0.0'. Note that this may prevent "
+                    "access to the notebooks because 0.0.0.0 is usually not an accessible "
+                    "IP address. You probably want to set the formgrader IP to something that "
+                    "is accessible from the outside world.")
 
             self._notebook_server_ip = self._ip
             self._notebook_server_port = str(self.nbserver_port)


### PR DESCRIPTION
Fixes #231 

This makes it possible to use `0.0.0.0` for a formgrader running on a remote server. In such a case, the live notebook server won't work, so this additionally prints a warning saying as much and advising the user to change the IP to something that is accessible.