### PR TITLE
Remove autopep8 as a dependency

### DIFF
--- a/nbgrader/tests/utils/test_utils.py
+++ b/nbgrader/tests/utils/test_utils.py
@@ -116,26 +116,26 @@ def test_compute_checksum_whitespace():
     # does whitespace make no difference?
     cell1 = create_grade_cell("hello", "code", "foo", 1)
     cell2 = create_grade_cell("hello ", "code", "foo", 1)
-    assert utils.compute_checksum(cell1) == utils.compute_checksum(cell2)
+    assert utils.compute_checksum(cell1) != utils.compute_checksum(cell2)
 
     cell1 = create_grade_cell("hello", "markdown", "foo", 1)
     cell2 = create_grade_cell("hello ", "markdown", "foo", 1)
-    assert utils.compute_checksum(cell1) == utils.compute_checksum(cell2)
+    assert utils.compute_checksum(cell1) != utils.compute_checksum(cell2)
 
     cell1 = create_solution_cell("hello", "code")
     cell2 = create_solution_cell("hello ", "code")
-    assert utils.compute_checksum(cell1) == utils.compute_checksum(cell2)
+    assert utils.compute_checksum(cell1) != utils.compute_checksum(cell2)
 
     cell1 = create_solution_cell("hello", "markdown")
     cell2 = create_solution_cell("hello ", "markdown")
-    assert utils.compute_checksum(cell1) == utils.compute_checksum(cell2)
+    assert utils.compute_checksum(cell1) != utils.compute_checksum(cell2)
 
 
 def test_compute_checksum_source():
     # does the source make a difference?
     cell1 = create_grade_cell("print('hello')", "code", "foo", 1)
     cell2 = create_grade_cell("print( 'hello' )", "code", "foo", 1)
-    assert utils.compute_checksum(cell1) == utils.compute_checksum(cell2)
+    assert utils.compute_checksum(cell1) != utils.compute_checksum(cell2)
 
     cell1 = create_grade_cell("print('hello')", "code", "foo", 1)
     cell2 = create_grade_cell("print( 'hello!' )", "code", "foo", 1)
@@ -147,7 +147,7 @@ def test_compute_checksum_source():
 
     cell1 = create_solution_cell("print('hello')", "code")
     cell2 = create_solution_cell("print( 'hello' )", "code")
-    assert utils.compute_checksum(cell1) == utils.compute_checksum(cell2)
+    assert utils.compute_checksum(cell1) != utils.compute_checksum(cell2)
 
     cell1 = create_solution_cell("print('hello')", "code")
     cell2 = create_solution_cell("print( 'hello!' )", "code")

--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -45,7 +45,7 @@ def determine_grade(cell):
 def compute_checksum(cell):
     m = hashlib.md5()
     # add the cell source and type
-    m.update(cell.source)
+    m.update(str_to_bytes(cell.source))
     m.update(str_to_bytes(cell.cell_type))
 
     # add whether it's a grade cell and/or solution cell

--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -1,6 +1,5 @@
 import os
 import hashlib
-import autopep8
 import dateutil.parser
 import pwd
 import glob
@@ -45,15 +44,8 @@ def determine_grade(cell):
 
 def compute_checksum(cell):
     m = hashlib.md5()
-
-    # if it's a code cell, then fix minor whitespace issues that might have been 
-    # added and then add cell contents; otherwise just add cell contents
-    if cell.cell_type == "code":
-        m.update(str_to_bytes(autopep8.fix_code(cell.source).rstrip()))
-    else:
-        m.update(str_to_bytes(cell.source.strip()))
-
-    # add the cell type
+    # add the cell source and type
+    m.update(cell.source)
     m.update(str_to_bytes(cell.cell_type))
 
     # add whether it's a grade cell and/or solution cell

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 ipython>3.0
 sqlalchemy
 Flask
-autopep8
 python-dateutil


### PR DESCRIPTION
Fixes #134 

Ping @ellisonbg because this will break stuff for your students if you are having them use `nbgrader validate`. Let me know if it is ok to merge this (e.g. if you aren't planning on upgrading your version of nbgrader before the class is over, then it should be fine I think).