### PR TITLE
Improve tabbing experience

### DIFF
--- a/nbgrader/html/static/js/formgrade.js
+++ b/nbgrader/html/static/js/formgrade.js
@@ -93,7 +93,7 @@ var Comments = Backbone.Collection.extend({
 
 var getIndex = function (elem) {
     if (elem !== undefined) {
-        var elems = $("input, textarea");
+        var elems = $(".tabbable");
         return elems.index(elem);
     } else {
         return parseInt(document.URL.split('#')[1]) || 0;
@@ -102,7 +102,7 @@ var getIndex = function (elem) {
 
 var selectNext = function (target, shift) {
     var index, elems;
-    elems = $("input, textarea");
+    elems = $(".tabbable");
     if (shift) {
         index = getIndex(target) - 1;
     } else {
@@ -119,7 +119,11 @@ var selectNext = function (target, shift) {
 
 var scrollTo = function (elem) {
     var target = elem.parents(".nbgrader_cell");
-    return target.offset().top - $(window).height() * 0.33 + 60;
+    if (target.length == 0) {
+        return $("body").offset().top;
+    } else {
+        return target.offset().top - $(window).height() * 0.33 + 60;
+    }
 };
 
 var grades;
@@ -181,9 +185,9 @@ $(window).load(function () {
     $("li.live-notebook a").tooltip({container: 'body'});
 
     // disable link selection on tabs
-    $('a').attr('tabindex', '-1');
+    $('a:not(.tabbable)').attr('tabindex', '-1');
 
-    $("input, textarea").on('keydown', function(e) {
+    $(".tabbable").on('keydown', function(e) {
         var keyCode = e.keyCode || e.which;
 
         if (keyCode === 9) { // tab
@@ -225,7 +229,7 @@ $(window).load(function () {
         }
     });
 
-    $("input, textarea").focus(function (event) {
+    $(".tabbable").focus(function (event) {
         last_selected = $(event.currentTarget);
         $("body, html").stop().animate({
             scrollTop: scrollTo(last_selected)
@@ -235,8 +239,8 @@ $(window).load(function () {
     var index = parseInt(document.URL.split('#')[1]) || 0;
     if (index < 0) { index = 0; }
 
-    if ($("input, textarea").length > index) {
-        last_selected = $($("input, textarea")[index]);
+    if ($(".tabbable").length > index) {
+        last_selected = $($(".tabbable")[index]);
         last_selected.select();
         last_selected.focus();
     }

--- a/nbgrader/html/templates/formgrade.tpl
+++ b/nbgrader/html/templates/formgrade.tpl
@@ -73,7 +73,7 @@ window.MathJax = {
       <button type="button" class="btn btn-danger" id="{{ cell.metadata.nbgrader.grade_id }}-no-credit">No credit</button>
     </span>
     <span>
-      <input class="score" id="{{ cell.metadata.nbgrader.grade_id }}" style="width: 4em;" type="number" /> / {{ cell.metadata.nbgrader.points | float | round(2) }}
+      <input class="score tabbable" id="{{ cell.metadata.nbgrader.grade_id }}" style="width: 4em;" type="number" /> / {{ cell.metadata.nbgrader.points | float | round(2) }}
     </span>
   </div>
 {%- endmacro %}
@@ -97,7 +97,7 @@ window.MathJax = {
 {% macro nbgrader_footer(cell) -%}
 {%- if cell.metadata.nbgrader.solution -%}
 <div class="panel-footer">
-  <div><textarea class="comment" placeholder="Comments"></textarea></div>
+  <div><textarea class="comment tabbable" placeholder="Comments"></textarea></div>
 </div>
 {%- endif -%}
 {%- endmacro %}

--- a/nbgrader/html/templates/formgrade_macros.tpl
+++ b/nbgrader/html/templates/formgrade_macros.tpl
@@ -25,7 +25,7 @@ var base_url = "{{resources.base_url}}";
       <div class="col-md-2">
         <ul class="nav navbar-nav navbar-left">
           <li class="previous">
-            <a data-toggle="tooltip" data-placement="right" title="{{ resources.index }} remaining" href="{{resources.base_url}}/submissions/{{ resources.submission_id }}/prev">
+            <a data-toggle="tooltip" data-trigger="hover" data-placement="right" title="{{ resources.index }} remaining" href="{{resources.base_url}}/submissions/{{ resources.submission_id }}/prev">
             &larr; Prev
             </a>
           </li>
@@ -52,7 +52,7 @@ var base_url = "{{resources.base_url}}";
       <div class="col-md-2">
         <ul class="nav navbar-nav navbar-right">
           <li class="next">
-            <a data-toggle="tooltip" data-placement="left" title="{{ resources.total - (resources.index + 1) }} remaining" href="{{resources.base_url}}/submissions/{{ resources.submission_id }}/next">
+            <a class="tabbable" data-trigger="hover" data-toggle="tooltip" data-placement="left" title="{{ resources.total - (resources.index + 1) }} remaining" href="{{resources.base_url}}/submissions/{{ resources.submission_id }}/next">
             Next &rarr;
             </a>
           </li>

--- a/nbgrader/tests/formgrader/test_formgrader.py
+++ b/nbgrader/tests/formgrader/test_formgrader.py
@@ -16,6 +16,9 @@ class TestFormgrader(BaseTestFormgrade):
     def _click_element(self, name):
         self.browser.find_element_by_css_selector(name).click()
 
+    def _get_next_arrow(self):
+        return self.browser.find_element_by_css_selector(".next a")
+
     def _get_comment_box(self, index):
         return self.browser.find_elements_by_css_selector(".comment")[index]
 
@@ -197,7 +200,11 @@ class TestFormgrader(BaseTestFormgrade):
     def test_tabbing(self):
         self._load_formgrade()
 
+        # check that the next arrow is selected
+        assert self._get_active_element() == self._get_next_arrow()
+
         # check that the first comment box is selected
+        self._send_keys_to_body(Keys.TAB)
         assert self._get_active_element() == self._get_comment_box(0)
 
         # tab to the next and check that the first points is selected
@@ -228,9 +235,9 @@ class TestFormgrader(BaseTestFormgrade):
         self._send_keys_to_body(Keys.TAB)
         assert self._get_active_element() == self._get_comment_box(2)
 
-        # tab to the next and check that the first comment is selected
+        # tab to the next and check that the next arrow is selected
         self._send_keys_to_body(Keys.TAB)
-        assert self._get_active_element() == self._get_comment_box(0)
+        assert self._get_active_element() == self._get_next_arrow()
 
     @pytest.mark.parametrize("index", range(3))
     def test_save_comment(self, index):


### PR DESCRIPTION
Fixes #88 and fixes #83

This allows you to tab to the "next" arrow, and also bring you to the very top of the document, rather than to the first comment/score field.