### PR TITLE
Better full/no credit button colors

### DIFF
--- a/nbgrader/html/static/css/formgrade.css
+++ b/nbgrader/html/static/css/formgrade.css
@@ -125,3 +125,27 @@ div.nbgrader_cell .input_area {
 .panel-heading {
     overflow: hidden;
 }
+
+.scoring-buttons button {
+  background-color: #337ab7;
+}
+
+.scoring-buttons button.btn-success {
+  background-color: rgba(92, 184, 92, .1);
+  border-color: rgb(47, 92, 47);
+}
+
+.scoring-buttons button.btn-success:hover {
+  background-color: #5cb85c;
+  border-color: #4cae4c;
+}
+
+.scoring-buttons button.btn-danger {
+  background-color: rgba(217, 83, 79, .2);
+  border-color: rgb(120, 45, 45);
+}
+
+.scoring-buttons button.btn-danger:hover {
+  background-color: #d9534f;
+  border-color: #d43f3a;
+}

--- a/nbgrader/html/templates/formgrade.tpl
+++ b/nbgrader/html/templates/formgrade.tpl
@@ -70,6 +70,8 @@ window.MathJax = {
   <div class="pull-right">
     <span class="btn-group btn-group-sm scoring-buttons" role="group">
       <button type="button" class="btn btn-success" id="{{ cell.metadata.nbgrader.grade_id }}-full-credit">Full credit</button>
+    </span>
+    <span class="btn-group btn-group-sm scoring-buttons" role="group">
       <button type="button" class="btn btn-danger" id="{{ cell.metadata.nbgrader.grade_id }}-no-credit">No credit</button>
     </span>
     <span>


### PR DESCRIPTION
Fixes #122 and looks like this:

![image](https://cloud.githubusercontent.com/assets/83444/7826332/7aa82bae-03cd-11e5-940e-cdd87b8a19e3.png)

When you hover over the buttons they go back to their original colors.