### PR TITLE
Only scroll to tabbable when it is different from before

### DIFF
--- a/nbgrader/html/static/js/formgrade.js
+++ b/nbgrader/html/static/js/formgrade.js
@@ -225,17 +225,22 @@ FormGrader.prototype.setCurrentIndex = function (index) {
     }
 };
 
+FormGrader.prototype.scrollToLastSelected = function () {
+    this.setCurrentIndex();
+    history.replaceState(history.state, "", this.navigateTo(""));
+
+    var that = this
+    $("body, html").stop().animate({
+        scrollTop: that.getScrollPosition()
+    }, 500);
+}
+
 FormGrader.prototype.configureScrolling = function () {
     var that = this;
-
     $(".tabbable").focus(function (event) {
         if (that.last_selected[0] !== event.currentTarget) {
             that.last_selected = $(event.currentTarget);
-            that.setCurrentIndex();
-            history.replaceState(history.state, "", that.navigateTo(""));
-            $("body, html").stop().animate({
-                scrollTop: that.getScrollPosition()
-            }, 500);
+            that.scrollToLastSelected();
         }
     });
 
@@ -247,6 +252,7 @@ FormGrader.prototype.configureScrolling = function () {
             that.last_selected.select();
             that.last_selected.focus();
             MathJax.loaded = true;
+            that.scrollToLastSelected();
         }
     });
 };

--- a/nbgrader/html/static/js/formgrade.js
+++ b/nbgrader/html/static/js/formgrade.js
@@ -229,12 +229,14 @@ FormGrader.prototype.configureScrolling = function () {
     var that = this;
 
     $(".tabbable").focus(function (event) {
-        that.last_selected = $(event.currentTarget);
-        that.setCurrentIndex();
-        history.replaceState(history.state, "", that.navigateTo(""));
-        $("body, html").stop().animate({
-            scrollTop: that.getScrollPosition()
-        }, 500);
+        if (that.last_selected[0] !== event.currentTarget) {
+            that.last_selected = $(event.currentTarget);
+            that.setCurrentIndex();
+            history.replaceState(history.state, "", that.navigateTo(""));
+            $("body, html").stop().animate({
+                scrollTop: that.getScrollPosition()
+            }, 500);
+        }
     });
 
     this.setIndexFromUrl();


### PR DESCRIPTION
This should fix issues with scrolling to a different part of the page, tabbing to a different window, and tabbing back and then having the formgrader scroll back to the input, which is annoying.