### PR TITLE
Manually set 'needs manual grade?'

### DIFF
--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -3,7 +3,7 @@ from __future__ import division
 from nbgrader import utils
 
 from sqlalchemy import (create_engine, ForeignKey, Column, String, Text,
-    DateTime, Interval, Float, Enum, UniqueConstraint)
+    DateTime, Interval, Float, Enum, UniqueConstraint, Boolean)
 from sqlalchemy.orm import sessionmaker, scoped_session, relationship, column_property
 from sqlalchemy.orm.exc import NoResultFound, FlushError
 from sqlalchemy.ext.declarative import declarative_base
@@ -599,6 +599,9 @@ class Grade(Base):
     #: Score assigned by a human grader
     manual_score = Column(Float())
 
+    #: Whether a score needs to be assigned manually. This is True by default.
+    needs_manual_grade = Column(Boolean, default=True, nullable=False)
+
     #: The overall score, computed automatically from the
     #: :attr:`~nbgrader.api.Grade.auto_score` and :attr:`~nbgrader.api.Grade.manual_score`
     #: values. If neither are set, the score is zero. If both are set, then the
@@ -615,13 +618,6 @@ class Grade(Base):
     #: The maximum possible score that can be assigned, inherited from
     #: :class:`~nbgrader.api.GradeCell`
     max_score = None
-
-    #: Whether a score needs to be assigned manually. This is automatically computed
-    #: from the :attr:`~nbgrader.api.Grade.auto_score` and :attr:`~nbgrader.api.Grade.manual_score`
-    #: attributes: if neither is defined, then this value is True, otherwise it is
-    #: False.
-    needs_manual_grade = column_property(
-        (auto_score == None) & (manual_score == None))
 
     #: Whether the autograded score is a result of failed autograder tests. This
     #: is True if the autograder score is zero and the cell type is "code", and

--- a/nbgrader/html/formgrade.py
+++ b/nbgrader/html/formgrade.py
@@ -404,6 +404,10 @@ def get_grade(_id):
 
     if request.method == "PUT":
         grade.manual_score = request.json.get("manual_score", None)
+        if grade.manual_score is None and grade.auto_score is None:
+            grade.needs_manual_grade = True
+        else:
+            grade.needs_manual_grade = False
         app.gradebook.db.commit()
 
     return json.dumps(grade.to_dict())

--- a/nbgrader/html/static/css/formgrade.css
+++ b/nbgrader/html/static/css/formgrade.css
@@ -83,11 +83,6 @@ div.nbgrader_cell {
     width: 100%;
 }
 
-/*div.nbgrader_cell .panel-heading {
-    padding: 0.4em 0.6em;
-    height: 37px;
-}*/
-
 div.nbgrader_cell .panel-footer {
     padding: 0.4em 0.6em;
 }
@@ -112,6 +107,15 @@ div.nbgrader_cell .input_area {
     margin-left: 1em;
     border-width: 1px;
     border-color: white;
+}
+
+.needs_manual_grade {
+  background-color: #f2dede;
+  border-color: #d43f3a;
+}
+
+.mark-graded {
+  display: none;
 }
 
 .nbgrader-label {
@@ -150,6 +154,16 @@ div.nbgrader_cell .input_area {
 .scoring-buttons button.btn-danger:hover {
   background-color: #d9534f;
   border-color: #d43f3a;
+}
+
+.scoring-buttons button.btn-warning {
+  background-color: rgba(240, 173, 78, 0.2);
+  border-color: #7C4F0E;
+}
+
+.scoring-buttons button.btn-warning:hover {
+  background-color: #f0ad4e;
+  border-color: #eea236;
 }
 
 .help {

--- a/nbgrader/html/static/js/models.js
+++ b/nbgrader/html/static/js/models.js
@@ -3,12 +3,14 @@ var GradeUI = Backbone.View.extend({
     events: {
         "change .score": "save",
         "click .full-credit": "assignFullCredit",
-        "click .no-credit": "assignNoCredit"
+        "click .no-credit": "assignNoCredit",
+        "click .mark-graded": "save"
     },
 
     initialize: function () {
         this.$glyph = this.$el.find(".score-saved");
         this.$score = this.$el.find(".score");
+        this.$mark_graded = this.$el.find(".mark-graded");
 
         this.listenTo(this.model, "change", this.render);
         this.listenTo(this.model, "request", this.animateSaving);
@@ -20,6 +22,15 @@ var GradeUI = Backbone.View.extend({
 
     render: function () {
         this.$score.val(this.model.get("manual_score"));
+        if (this.model.get("needs_manual_grade")) {
+            this.$score.addClass("needs_manual_grade");
+            if (this.model.get("manual_score") !== null) {
+                this.$mark_graded.show();
+            }
+        } else {
+            this.$score.removeClass("needs_manual_grade");
+            this.$mark_graded.hide();
+        }
     },
 
     save: function () {
@@ -38,6 +49,8 @@ var GradeUI = Backbone.View.extend({
                 this.model.save({"manual_score": val});
             }
         }
+
+        this.render();
     },
 
     animateSaving: function () {

--- a/nbgrader/html/templates/assignment_notebooks.tpl
+++ b/nbgrader/html/templates/assignment_notebooks.tpl
@@ -20,7 +20,7 @@
     <th class="center">Avg. Score</th>
     <th class="center">Avg. Code Score</th>
     <th class="center">Avg. Written Score</th>
-    <th class="center">Manual grade?</th>
+    <th class="center">Needs manual grade?</th>
   </tr>
 </thead>
 <tbody>

--- a/nbgrader/html/templates/formgrade.tpl
+++ b/nbgrader/html/templates/formgrade.tpl
@@ -70,9 +70,8 @@ window.MathJax = {
   <span class="glyphicon glyphicon-ok save-icon score-saved"></span>
   <div class="pull-right">
     <span class="btn-group btn-group-sm scoring-buttons" role="group">
+      <button type="button" class="btn btn-warning mark-graded">Resolve</button>
       <button type="button" class="btn btn-success full-credit">Full credit</button>
-    </span>
-    <span class="btn-group btn-group-sm scoring-buttons" role="group">
       <button type="button" class="btn btn-danger no-credit">No credit</button>
     </span>
     <span>

--- a/nbgrader/html/templates/notebook_submissions.tpl
+++ b/nbgrader/html/templates/notebook_submissions.tpl
@@ -22,7 +22,7 @@
     <th class="center">Overall Score</th>
     <th class="center">Code Score</th>
     <th class="center">Written Score</th>
-    <th class="center">Manual grade?</th>
+    <th class="center">Needs manual grade?</th>
     <th class="center">Tests failed?</th>
   </tr>
 </thead>

--- a/nbgrader/html/templates/student_assignments.tpl
+++ b/nbgrader/html/templates/student_assignments.tpl
@@ -19,7 +19,7 @@
     <th class="center">Overall Score</th>
     <th class="center">Code Score</th>
     <th class="center">Written Score</th>
-    <th class="center">Manual grade?</th>
+    <th class="center">Needs manual grade?</th>
   </tr>
 </thead>
 <tbody>

--- a/nbgrader/html/templates/student_submissions.tpl
+++ b/nbgrader/html/templates/student_submissions.tpl
@@ -20,7 +20,7 @@
     <th class="center">Overall Score</th>
     <th class="center">Code Score</th>
     <th class="center">Written Score</th>
-    <th class="center">Manual grade?</th>
+    <th class="center">Needs manual grade?</th>
     <th class="center">Tests failed?</th>
   </tr>
 </thead>

--- a/nbgrader/preprocessors/saveautogrades.py
+++ b/nbgrader/preprocessors/saveautogrades.py
@@ -38,8 +38,16 @@ class SaveAutoGrades(NbGraderPreprocessor):
             self.student_id)
 
         # determine what the grade is
-        auto_score, max_score = utils.determine_grade(cell)
+        auto_score, _ = utils.determine_grade(cell)
         grade.auto_score = auto_score
+
+        # if there was previously a manual grade, or if there is no autograder
+        # score, then we should mark this as needing review
+        if (grade.manual_score is not None) or (grade.auto_score is None):
+            grade.needs_manual_grade = True
+        else:
+            grade.needs_manual_grade = False
+
         self.gradebook.db.commit()
         self.log.debug(grade)
 

--- a/nbgrader/tests/api/test_models.py
+++ b/nbgrader/tests/api/test_models.py
@@ -358,9 +358,9 @@ def test_create_code_grade(db):
     assert g.student == s
     assert g.max_score == 10
 
-    assert not g.needs_manual_grade
-    assert not sn.needs_manual_grade
-    assert not sa.needs_manual_grade
+    assert g.needs_manual_grade
+    assert sn.needs_manual_grade
+    assert sa.needs_manual_grade
 
     assert g.score == 5
     assert sn.score == 5
@@ -374,9 +374,9 @@ def test_create_code_grade(db):
     g.manual_score = 7.5
     db.commit()
 
-    assert not g.needs_manual_grade
-    assert not sn.needs_manual_grade
-    assert not sa.needs_manual_grade
+    assert g.needs_manual_grade
+    assert sn.needs_manual_grade
+    assert sa.needs_manual_grade
 
     assert g.score == 7.5
     assert sn.score == 7.5
@@ -386,6 +386,13 @@ def test_create_code_grade(db):
     assert sa.code_score == 7.5
     assert sa.written_score == 0
     assert s.score == 7.5
+
+    g.needs_manual_grade = False
+    db.commit()
+
+    assert not g.needs_manual_grade
+    assert not sn.needs_manual_grade
+    assert not sa.needs_manual_grade
 
     assert repr(g) == "Grade<foo/blah/foo for 12345>"
 
@@ -428,9 +435,9 @@ def test_create_written_grade(db):
     g.manual_score = 7.5
     db.commit()
 
-    assert not g.needs_manual_grade
-    assert not sn.needs_manual_grade
-    assert not sa.needs_manual_grade
+    assert g.needs_manual_grade
+    assert sn.needs_manual_grade
+    assert sa.needs_manual_grade
 
     assert g.score == 7.5
     assert sn.score == 7.5
@@ -440,6 +447,13 @@ def test_create_written_grade(db):
     assert sa.code_score == 0
     assert sa.written_score == 7.5
     assert s.score == 7.5
+
+    g.needs_manual_grade = False
+    db.commit()
+
+    assert not g.needs_manual_grade
+    assert not sn.needs_manual_grade
+    assert not sa.needs_manual_grade
 
     assert repr(g) == "Grade<foo/blah/foo for 12345>"
 
@@ -516,6 +530,51 @@ def test_query_needs_manual_grade_autograded(submissions):
         grade.auto_score = grade.max_score
     db.commit()
 
+    # do all the cells need grading?
+    a = db.query(api.Grade)\
+        .filter(api.Grade.needs_manual_grade)\
+        .order_by(api.Grade.id)\
+        .all()
+    b = db.query(api.Grade)\
+        .order_by(api.Grade.id)\
+        .all()
+    assert a == b
+
+    # do all the submitted notebooks need grading?
+    a = db.query(api.SubmittedNotebook)\
+        .filter(api.SubmittedNotebook.needs_manual_grade)\
+        .order_by(api.SubmittedNotebook.id)\
+        .all()
+    b = db.query(api.SubmittedNotebook)\
+        .order_by(api.SubmittedNotebook.id)\
+        .all()
+    assert a == b
+
+    # do all the notebooks need grading?
+    a = db.query(api.Notebook)\
+        .filter(api.Notebook.needs_manual_grade)\
+        .order_by(api.Notebook.id)\
+        .all()
+    b = db.query(api.Notebook)\
+        .order_by(api.Notebook.id)\
+        .all()
+    assert a == b
+
+    # do all the assignments need grading?
+    a = db.query(api.SubmittedAssignment)\
+        .join(api.SubmittedNotebook, api.Grade)\
+        .filter(api.SubmittedNotebook.needs_manual_grade)\
+        .order_by(api.SubmittedAssignment.id)\
+        .all()
+    b = db.query(api.SubmittedAssignment)\
+        .order_by(api.SubmittedAssignment.id)\
+        .all()
+    assert a == b
+
+    for grade in grades:
+        grade.needs_manual_grade = False
+    db.commit()
+
     # do none of the cells need grading?
     assert [] == db.query(api.Grade)\
         .filter(api.Grade.needs_manual_grade)\
@@ -543,6 +602,51 @@ def test_query_needs_manual_grade_manualgraded(submissions):
     for grade in grades:
         grade.auto_score = None
         grade.manual_score = grade.max_score / 2.0
+    db.commit()
+
+    # do all the cells need grading?
+    a = db.query(api.Grade)\
+        .filter(api.Grade.needs_manual_grade)\
+        .order_by(api.Grade.id)\
+        .all()
+    b = db.query(api.Grade)\
+        .order_by(api.Grade.id)\
+        .all()
+    assert a == b
+
+    # do all the submitted notebooks need grading?
+    a = db.query(api.SubmittedNotebook)\
+        .filter(api.SubmittedNotebook.needs_manual_grade)\
+        .order_by(api.SubmittedNotebook.id)\
+        .all()
+    b = db.query(api.SubmittedNotebook)\
+        .order_by(api.SubmittedNotebook.id)\
+        .all()
+    assert a == b
+
+    # do all the notebooks need grading?
+    a = db.query(api.Notebook)\
+        .filter(api.Notebook.needs_manual_grade)\
+        .order_by(api.Notebook.id)\
+        .all()
+    b = db.query(api.Notebook)\
+        .order_by(api.Notebook.id)\
+        .all()
+    assert a == b
+
+    # do all the assignments need grading?
+    a = db.query(api.SubmittedAssignment)\
+        .join(api.SubmittedNotebook, api.Grade)\
+        .filter(api.SubmittedNotebook.needs_manual_grade)\
+        .order_by(api.SubmittedAssignment.id)\
+        .all()
+    b = db.query(api.SubmittedAssignment)\
+        .order_by(api.SubmittedAssignment.id)\
+        .all()
+    assert a == b
+
+    for grade in grades:
+        grade.needs_manual_grade = False
     db.commit()
 
     # do none of the cells need grading?

--- a/nbgrader/tests/formgrader/test_formgrader_js.py
+++ b/nbgrader/tests/formgrader/test_formgrader_js.py
@@ -40,6 +40,9 @@ class TestFormgraderJS(BaseTestFormgrade):
         WebDriverWait(self.browser, 30).until(lambda browser: glyph.is_displayed())
         WebDriverWait(self.browser, 30).until(lambda browser: not glyph.is_displayed())
 
+    def _get_needs_manual_grade(self, index):
+        return self.browser.execute_script('return formgrader.grades.at({:d}).get("needs_manual_grade");'.format(index))
+
     def _get_active_element(self):
         return self.browser.execute_script("return document.activeElement;")
 
@@ -255,13 +258,12 @@ class TestFormgraderJS(BaseTestFormgrade):
     @pytest.mark.parametrize("index", range(4))
     def test_save_comment(self, index):
         self._load_formgrade()
-
         elem = self._get_comment_box(index)
+
         if elem.get_attribute("value") != "":
             elem.click()
             elem.clear()
             self._save_comment(index)
-
             self._load_formgrade()
             elem = self._get_comment_box(index)
             assert elem.get_attribute("value") == ""
@@ -279,24 +281,46 @@ class TestFormgraderJS(BaseTestFormgrade):
     @pytest.mark.parametrize("index", range(6))
     def test_save_score(self, index):
         self._load_formgrade()
-
         elem = self._get_score_box(index)
+
         if elem.get_attribute("value") != "":
             elem.click()
             elem.clear()
             self._save_score(index)
-
             self._load_formgrade()
             elem = self._get_score_box(index)
             assert elem.get_attribute("value") == ""
 
+            # check whether it needs manual grading
+            if elem.get_attribute("placeholder") != "":
+                assert not self._get_needs_manual_grade(index)
+            else:
+                assert self._get_needs_manual_grade(index)
+
+        # set the grade
         elem.click()
         elem.send_keys("{}".format((index + 1) / 10.0))
         self._save_score(index)
-
         self._load_formgrade()
         elem = self._get_score_box(index)
         assert elem.get_attribute("value") == "{}".format((index + 1) / 10.0)
+
+        # check whether it needs manual grading
+        assert not self._get_needs_manual_grade(index)
+
+        # clear the grade
+        elem.click()
+        elem.clear()
+        self._save_score(index)
+        self._load_formgrade()
+        elem = self._get_score_box(index)
+        assert elem.get_attribute("value") == ""
+
+        # check whether it needs manual grading
+        if elem.get_attribute("placeholder") != "":
+            assert not self._get_needs_manual_grade(index)
+        else:
+            assert self._get_needs_manual_grade(index)
 
     def test_same_part_navigation(self):
         problem = self.gradebook.find_notebook("Problem 1", "Problem Set 1")

--- a/nbgrader/tests/formgrader/test_formgrader_js.py
+++ b/nbgrader/tests/formgrader/test_formgrader_js.py
@@ -291,11 +291,13 @@ class TestFormgraderJS(BaseTestFormgrade):
             elem = self._get_score_box(index)
             assert elem.get_attribute("value") == ""
 
-            # check whether it needs manual grading
-            if elem.get_attribute("placeholder") != "":
-                assert not self._get_needs_manual_grade(index)
-            else:
-                assert self._get_needs_manual_grade(index)
+        # check whether it needs manual grading
+        if elem.get_attribute("placeholder") != "":
+            assert not self._get_needs_manual_grade(index)
+            assert "needs_manual_grade" not in elem.get_attribute("class").split(" ")
+        else:
+            assert self._get_needs_manual_grade(index)
+            assert "needs_manual_grade" in elem.get_attribute("class").split(" ")
 
         # set the grade
         elem.click()
@@ -307,6 +309,7 @@ class TestFormgraderJS(BaseTestFormgrade):
 
         # check whether it needs manual grading
         assert not self._get_needs_manual_grade(index)
+        assert "needs_manual_grade" not in elem.get_attribute("class").split(" ")
 
         # clear the grade
         elem.click()
@@ -319,8 +322,10 @@ class TestFormgraderJS(BaseTestFormgrade):
         # check whether it needs manual grading
         if elem.get_attribute("placeholder") != "":
             assert not self._get_needs_manual_grade(index)
+            assert "needs_manual_grade" not in elem.get_attribute("class").split(" ")
         else:
             assert self._get_needs_manual_grade(index)
+            assert "needs_manual_grade" in elem.get_attribute("class").split(" ")
 
     def test_same_part_navigation(self):
         problem = self.gradebook.find_notebook("Problem 1", "Problem Set 1")


### PR DESCRIPTION
This renames the columns in the formgrader to make it a little clearer what "manual grade?" means, which is that there is a part of the assignment that needs grading.

Edit: this also make the `needs_manual_grade` attribute of the database models be a real column in the database, and modifies the relevant aspects in `nbgrader autograde` and `nbgrader formgrade` to set it.

cc @ellisonbg 