### PR TITLE
Add an additional "locked" cell type

### DIFF
--- a/docs/source/api/gradebook.rst
+++ b/docs/source/api/gradebook.rst
@@ -45,6 +45,12 @@ Gradebook
 
     .. automethod:: update_or_create_solution_cell
 
+    .. automethod:: add_source_cell
+
+    .. automethod:: find_source_cell
+
+    .. automethod:: update_or_create_source_cell
+
     .. automethod:: add_submission
 
     .. automethod:: find_submission

--- a/docs/source/api/models.rst
+++ b/docs/source/api/models.rst
@@ -68,6 +68,8 @@ Master version of an assignment
 
     .. autoattribute:: solution_cells
 
+    .. autoattribute:: source_cells
+
     .. autoattribute:: submissions
 
     .. autoattribute:: num_submissions
@@ -92,10 +94,6 @@ Master version of an assignment
 
     .. autoattribute:: cell_type
 
-    .. autoattribute:: source
-
-    .. autoattribute:: checksum
-
     .. autoattribute:: notebook
         :annotation:
 
@@ -113,6 +111,23 @@ Master version of an assignment
 
     .. autoattribute:: name
 
+    .. autoattribute:: notebook
+        :annotation:
+
+    .. autoattribute:: notebook_id
+
+    .. autoattribute:: assignment
+
+    .. autoattribute:: comments
+
+    .. automethod:: to_dict
+
+.. autoclass:: SourceCell
+
+    .. autoattribute:: id
+
+    .. autoattribute:: name
+
     .. autoattribute:: cell_type
 
     .. autoattribute:: source
@@ -125,8 +140,6 @@ Master version of an assignment
     .. autoattribute:: notebook_id
 
     .. autoattribute:: assignment
-
-    .. autoattribute:: comments
 
     .. automethod:: to_dict
 

--- a/docs/source/user_guide/source/Problem Set 1/Problem 1.ipynb
+++ b/docs/source/user_guide/source/Problem Set 1/Problem 1.ipynb
@@ -5,6 +5,8 @@
    "metadata": {
     "nbgrader": {
      "grade": false,
+     "grade_id": "jupyter",
+     "locked": true,
      "solution": false
     }
    },
@@ -19,6 +21,7 @@
    "metadata": {
     "nbgrader": {
      "grade": false,
+     "locked": false,
      "solution": false
     }
    },

--- a/docs/source/user_guide/submitted/Bitdiddle/Problem Set 1/Problem 1.ipynb
+++ b/docs/source/user_guide/submitted/Bitdiddle/Problem Set 1/Problem 1.ipynb
@@ -46,7 +46,10 @@
    "cell_type": "markdown",
    "metadata": {
     "nbgrader": {
+     "checksum": "535c21960d4663d5edac398cb445d087",
      "grade": false,
+     "grade_id": "jupyter",
+     "locked": true,
      "solution": false
     }
    },
@@ -78,7 +81,7 @@
     "collapsed": false,
     "deletable": false,
     "nbgrader": {
-     "checksum": "18ab30fa59a366bcd2af9ee4f3ae7cbc",
+     "checksum": "8f1eab8d02a9520920aa06f8a86a2492",
      "grade_id": "squares",
      "solution": true
     }
@@ -132,10 +135,10 @@
     "collapsed": false,
     "deletable": false,
     "nbgrader": {
-     "checksum": "65496e181719e53fb2b9a303dae1b1bd",
+     "checksum": "8e029652317e6c6a37a72710dc8d2429",
      "grade": true,
      "grade_id": "correct_squares",
-     "points": "1"
+     "points": 1
     }
    },
    "outputs": [],
@@ -155,10 +158,10 @@
     "collapsed": false,
     "deletable": false,
     "nbgrader": {
-     "checksum": "7c2679674a6b1457fae88421ecdd899b",
+     "checksum": "c6ff383fa27ce1c2eb97789816c93069",
      "grade": true,
      "grade_id": "squares_invalid_input",
-     "points": "1"
+     "points": 1
     }
    },
    "outputs": [],
@@ -187,7 +190,7 @@
     "collapsed": false,
     "deletable": false,
     "nbgrader": {
-     "checksum": "42eee7284aa64fedb82159a7a661d861",
+     "checksum": "166e1abc6621f93f8084ec312c49f757",
      "grade_id": "sum_of_squares",
      "solution": true
     }
@@ -237,7 +240,7 @@
     "collapsed": false,
     "deletable": false,
     "nbgrader": {
-     "checksum": "de2bd33d17ff32289f49d0e6f5a45484",
+     "checksum": "8cd2b086064694cb2352074a421b8964",
      "grade": true,
      "grade_id": "correct_sum_of_squares",
      "points": 0.5
@@ -259,7 +262,7 @@
     "collapsed": false,
     "deletable": false,
     "nbgrader": {
-     "checksum": "9d796ac5c24b88205f730c4d6dda9df7",
+     "checksum": "b1e1ec376ddc63d803b109befacde06a",
      "grade": true,
      "grade_id": "sum_of_squares_uses_squares",
      "points": 0.5
@@ -298,10 +301,10 @@
    "metadata": {
     "deletable": false,
     "nbgrader": {
-     "checksum": "2ddc632366e550a0b05ac0b1c725f67d",
+     "checksum": "f3cc38a3e522c0be10852ebbe2a638b7",
      "grade": true,
      "grade_id": "sum_of_squares_equation",
-     "points": "1",
+     "points": 1,
      "solution": true
     }
    },
@@ -331,7 +334,7 @@
     "collapsed": true,
     "deletable": false,
     "nbgrader": {
-     "checksum": "e246dca8082319480e84e3b3d8d13042",
+     "checksum": "5a96910dbc324f5565edf92f5c98af1b",
      "grade": true,
      "grade_id": "sum_of_squares_application",
      "points": 2,

--- a/docs/source/user_guide/submitted/Bitdiddle/Problem Set 1/Problem 2.ipynb
+++ b/docs/source/user_guide/submitted/Bitdiddle/Problem Set 1/Problem 2.ipynb
@@ -81,10 +81,10 @@
    "metadata": {
     "deletable": false,
     "nbgrader": {
-     "checksum": "d5195f7155d796b2e140f0d7acacd726",
+     "checksum": "6d5a9eb99c3e76354b6e360ce228580a",
      "grade": true,
      "grade_id": "part-a",
-     "points": "1",
+     "points": 1,
      "solution": true
     }
    },
@@ -112,7 +112,7 @@
    "metadata": {
     "deletable": false,
     "nbgrader": {
-     "checksum": "7db9f6daad99bf6132cea53381d2f7a8",
+     "checksum": "789281f32aa7a8d789bd9f18de9efd00",
      "grade": true,
      "grade_id": "part-b",
      "points": 2,

--- a/docs/source/user_guide/submitted/Hacker/Problem Set 1/Problem 1.ipynb
+++ b/docs/source/user_guide/submitted/Hacker/Problem Set 1/Problem 1.ipynb
@@ -46,7 +46,10 @@
    "cell_type": "markdown",
    "metadata": {
     "nbgrader": {
+     "checksum": "535c21960d4663d5edac398cb445d087",
      "grade": false,
+     "grade_id": "jupyter",
+     "locked": true,
      "solution": false
     }
    },
@@ -78,7 +81,7 @@
     "collapsed": false,
     "deletable": false,
     "nbgrader": {
-     "checksum": "18ab30fa59a366bcd2af9ee4f3ae7cbc",
+     "checksum": "8f1eab8d02a9520920aa06f8a86a2492",
      "grade_id": "squares",
      "solution": true
     }
@@ -129,10 +132,10 @@
     "collapsed": false,
     "deletable": false,
     "nbgrader": {
-     "checksum": "65496e181719e53fb2b9a303dae1b1bd",
+     "checksum": "8e029652317e6c6a37a72710dc8d2429",
      "grade": true,
      "grade_id": "correct_squares",
-     "points": "1"
+     "points": 1
     }
    },
    "outputs": [],
@@ -152,10 +155,10 @@
     "collapsed": false,
     "deletable": false,
     "nbgrader": {
-     "checksum": "7c2679674a6b1457fae88421ecdd899b",
+     "checksum": "c6ff383fa27ce1c2eb97789816c93069",
      "grade": true,
      "grade_id": "squares_invalid_input",
-     "points": "1"
+     "points": 1
     }
    },
    "outputs": [],
@@ -189,7 +192,7 @@
     "collapsed": false,
     "deletable": false,
     "nbgrader": {
-     "checksum": "42eee7284aa64fedb82159a7a661d861",
+     "checksum": "166e1abc6621f93f8084ec312c49f757",
      "grade_id": "sum_of_squares",
      "solution": true
     }
@@ -235,7 +238,7 @@
     "collapsed": false,
     "deletable": false,
     "nbgrader": {
-     "checksum": "de2bd33d17ff32289f49d0e6f5a45484",
+     "checksum": "8cd2b086064694cb2352074a421b8964",
      "grade": true,
      "grade_id": "correct_sum_of_squares",
      "points": 0.5
@@ -257,7 +260,7 @@
     "collapsed": false,
     "deletable": false,
     "nbgrader": {
-     "checksum": "9d796ac5c24b88205f730c4d6dda9df7",
+     "checksum": "b1e1ec376ddc63d803b109befacde06a",
      "grade": true,
      "grade_id": "sum_of_squares_uses_squares",
      "points": 0.5
@@ -296,10 +299,10 @@
    "metadata": {
     "deletable": false,
     "nbgrader": {
-     "checksum": "2ddc632366e550a0b05ac0b1c725f67d",
+     "checksum": "f3cc38a3e522c0be10852ebbe2a638b7",
      "grade": true,
      "grade_id": "sum_of_squares_equation",
-     "points": "1",
+     "points": 1,
      "solution": true
     }
    },
@@ -329,7 +332,7 @@
     "collapsed": true,
     "deletable": false,
     "nbgrader": {
-     "checksum": "e246dca8082319480e84e3b3d8d13042",
+     "checksum": "5a96910dbc324f5565edf92f5c98af1b",
      "grade": true,
      "grade_id": "sum_of_squares_application",
      "points": 2,

--- a/docs/source/user_guide/submitted/Hacker/Problem Set 1/Problem 2.ipynb
+++ b/docs/source/user_guide/submitted/Hacker/Problem Set 1/Problem 2.ipynb
@@ -81,10 +81,10 @@
    "metadata": {
     "deletable": false,
     "nbgrader": {
-     "checksum": "d5195f7155d796b2e140f0d7acacd726",
+     "checksum": "6d5a9eb99c3e76354b6e360ce228580a",
      "grade": true,
      "grade_id": "part-a",
-     "points": "1",
+     "points": 1,
      "solution": true
     }
    },
@@ -112,7 +112,7 @@
    "metadata": {
     "deletable": false,
     "nbgrader": {
-     "checksum": "7db9f6daad99bf6132cea53381d2f7a8",
+     "checksum": "789281f32aa7a8d789bd9f18de9efd00",
      "grade": true,
      "grade_id": "part-b",
      "points": 2,

--- a/nbgrader/nbextensions/nbgrader/create_assignment.js
+++ b/nbgrader/nbextensions/nbgrader/create_assignment.js
@@ -22,6 +22,7 @@ define([
     "use strict";
 
     var nbgrader_preset_name = "Create Assignment";
+    var nbgrader_highlight_cls = "nbgrader-highlight";
     var nbgrader_cls = "nbgrader-cell";
     var warning;
 
@@ -70,6 +71,9 @@ define([
     events.on("global_hide.CellToolbar toolbar_rebuild.CellToolbar", function (evt, cell) {
         if (cell.element && cell.element.hasClass(nbgrader_cls)) {
             cell.element.removeClass(nbgrader_cls);
+        }
+        if (cell.element && cell.element.hasClass(nbgrader_highlight_cls)) {
+            cell.element.removeClass(nbgrader_highlight_cls);
         }
     });
 
@@ -256,8 +260,15 @@ define([
      * nbgrader cell type.
      */
     var display_cell = function (cell) {
-        if (cell.element && (is_grade(cell) || is_solution(cell)) && !cell.element.hasClass(nbgrader_cls)) {
-            cell.element.addClass(nbgrader_cls);
+        if (is_grade(cell) || is_solution(cell)) {
+            if (cell.element && !cell.element.hasClass(nbgrader_highlight_cls)) {
+                cell.element.addClass(nbgrader_highlight_cls);
+            }
+        }
+        if (is_grade(cell) || is_solution(cell) || is_locked(cell)) {
+            if (cell.element && !cell.element.hasClass(nbgrader_cls)) {
+                cell.element.addClass(nbgrader_cls);
+            }
         }
     };
 

--- a/nbgrader/nbextensions/nbgrader/create_assignment.js
+++ b/nbgrader/nbextensions/nbgrader/create_assignment.js
@@ -346,7 +346,6 @@ define([
                 update_total();
                 display_cell(cell);
                 validate_ids();
-                IPython.notebook.save_checkpoint();
             });
             display_cell(cell);
             $(div).append($('<span/>').append(select));
@@ -371,7 +370,6 @@ define([
         text.change(function () {
             set_grade_id(cell, text.val());
             validate_ids();
-            IPython.notebook.save_checkpoint();
         });
 
         local_div.addClass('nbgrader-id');
@@ -402,7 +400,6 @@ define([
             set_points(cell, text.val());
             text.val(get_points(cell));
             update_total();
-            IPython.notebook.save_checkpoint();
         });
 
         local_div.addClass('nbgrader-points');

--- a/nbgrader/nbextensions/nbgrader/nbgrader.css
+++ b/nbgrader/nbextensions/nbgrader/nbgrader.css
@@ -25,13 +25,13 @@ input.nbgrader-id-input {
     margin-right: 0.3em;
 }
 
-div.nbgrader-cell div.celltoolbar {
+div.nbgrader-highlight div.celltoolbar {
     color: white;
     background-color: #337ab7;
     border: 1px solid #337ab7;
 }
 
-div.nbgrader-cell div.text_cell_render, div.nbgrader-cell div.input_area {
+div.nbgrader-highlight div.text_cell_render, div.nbgrader-highlight div.input_area {
     border: 1px solid #337ab7 !important;
 }
 
@@ -49,7 +49,7 @@ div.lock-cell-container {
 a.lock-button {
     color: black
 }
-div.nbgrader-cell a.lock-button {
+div.nbgrader-highlight a.lock-button {
     color: white;
 }
 

--- a/nbgrader/nbextensions/nbgrader/nbgrader.css
+++ b/nbgrader/nbextensions/nbgrader/nbgrader.css
@@ -34,3 +34,25 @@ div.nbgrader-cell div.celltoolbar {
 div.nbgrader-cell div.text_cell_render, div.nbgrader-cell div.input_area {
     border: 1px solid #337ab7 !important;
 }
+
+div.lock-cell-container {
+    margin-right: auto;
+    padding-left: 0.5em;
+    line-height: 25px;
+    font-size: 1.4em;
+}
+
+.tooltip-inner {
+    max-width: 300px;
+}
+
+a.lock-button {
+    color: black
+}
+div.nbgrader-cell a.lock-button {
+    color: white;
+}
+
+a.lock-editable:hover {
+    cursor: pointer;
+}

--- a/nbgrader/preprocessors/computechecksums.py
+++ b/nbgrader/preprocessors/computechecksums.py
@@ -6,7 +6,7 @@ class ComputeChecksums(NbGraderPreprocessor):
 
     def preprocess_cell(self, cell, resources, cell_index):
         # compute checksums of grade cell and solution cells
-        if utils.is_grade(cell) or utils.is_solution(cell):
+        if utils.is_grade(cell) or utils.is_solution(cell) or utils.is_locked(cell):
             checksum = utils.compute_checksum(cell)
             cell.metadata.nbgrader['checksum'] = checksum
 

--- a/nbgrader/preprocessors/lockcells.py
+++ b/nbgrader/preprocessors/lockcells.py
@@ -8,6 +8,7 @@ class LockCells(NbGraderPreprocessor):
 
     lock_solution_cells = Bool(True, config=True, help="Whether solution cells are undeletable")
     lock_grade_cells = Bool(True, config=True, help="Whether grade cells are undeletable")
+    lock_readonly_cells = Bool(True, config=True, help="Whether readonly cells are undeletable")
     lock_all_cells = Bool(False, config=True, help="Whether all assignment cells are undeletable")
 
     def preprocess_cell(self, cell, resources, cell_index):
@@ -16,5 +17,7 @@ class LockCells(NbGraderPreprocessor):
         elif self.lock_grade_cells and utils.is_grade(cell):
             cell.metadata['deletable'] = False
         elif self.lock_solution_cells and utils.is_solution(cell):
+            cell.metadata['deletable'] = False
+        elif self.lock_readonly_cells and utils.is_locked(cell):
             cell.metadata['deletable'] = False
         return cell, resources

--- a/nbgrader/preprocessors/savecells.py
+++ b/nbgrader/preprocessors/savecells.py
@@ -31,33 +31,39 @@ class SaveCells(NbGraderPreprocessor):
         if utils.is_grade(cell):
             max_score = float(cell.metadata.nbgrader['points'])
             cell_type = cell.cell_type
-            source = cell.source
-            checksum = cell.metadata.nbgrader.get('checksum', None)
 
             grade_cell = self.gradebook.update_or_create_grade_cell(
                 cell.metadata.nbgrader['grade_id'],
                 self.notebook_id,
                 self.assignment_id,
                 max_score=max_score,
-                source=source,
-                checksum=checksum,
                 cell_type=cell_type)
 
             self.log.debug("Recorded grade cell %s into database", grade_cell)
 
         if utils.is_solution(cell):
+            solution_cell = self.gradebook.update_or_create_solution_cell(
+                cell.metadata.nbgrader['grade_id'],
+                self.notebook_id,
+                self.assignment_id)
+
+            self.log.debug("Recorded solution cell %s into database", solution_cell)
+
+        if utils.is_grade(cell) or utils.is_solution(cell) or utils.is_locked(cell):
             cell_type = cell.cell_type
+            locked = utils.is_locked(cell)
             source = cell.source
             checksum = cell.metadata.nbgrader.get('checksum', None)
 
-            solution_cell = self.gradebook.update_or_create_solution_cell(
+            source_cell = self.gradebook.update_or_create_source_cell(
                 cell.metadata.nbgrader['grade_id'],
                 self.notebook_id,
                 self.assignment_id,
                 cell_type=cell_type,
+                locked=locked,
                 source=source,
                 checksum=checksum)
 
-            self.log.debug("Recorded solution cell %s into database", solution_cell)
+            self.log.debug("Recorded source cell %s into database", source_cell)
 
         return cell, resources

--- a/nbgrader/tests/__init__.py
+++ b/nbgrader/tests/__init__.py
@@ -35,7 +35,6 @@ def create_grade_cell(source, cell_type, grade_id, points):
     cell.metadata.nbgrader["grade"] = True
     cell.metadata.nbgrader["grade_id"] = grade_id
     cell.metadata.nbgrader["points"] = points
-    cell.metadata.nbgrader["checksum"] = compute_checksum(cell)
 
     return cell
 
@@ -51,7 +50,21 @@ def create_solution_cell(source, cell_type, grade_id):
     cell.metadata.nbgrader = {}
     cell.metadata.nbgrader["solution"] = True
     cell.metadata.nbgrader["grade_id"] = grade_id
-    cell.metadata.nbgrader["checksum"] = compute_checksum(cell)
+
+    return cell
+
+
+def create_locked_cell(source, cell_type, grade_id):
+    if cell_type == "markdown":
+        cell = new_markdown_cell(source=source)
+    elif cell_type == "code":
+        cell = new_code_cell(source=source)
+    else:
+        raise ValueError("invalid cell type: {}".format(cell_type))
+
+    cell.metadata.nbgrader = {}
+    cell.metadata.nbgrader["locked"] = True
+    cell.metadata.nbgrader["grade_id"] = grade_id
 
     return cell
 
@@ -69,7 +82,6 @@ def create_grade_and_solution_cell(source, cell_type, grade_id, points):
     cell.metadata.nbgrader["grade"] = True
     cell.metadata.nbgrader["grade_id"] = grade_id
     cell.metadata.nbgrader["points"] = points
-    cell.metadata.nbgrader["checksum"] = compute_checksum(cell)
 
     return cell
 

--- a/nbgrader/tests/apps/files/submitted-changed.ipynb
+++ b/nbgrader/tests/apps/files/submitted-changed.ipynb
@@ -7,7 +7,7 @@
     "collapsed": true,
     "deletable": false,
     "nbgrader": {
-     "checksum": "3f6c8864859cbb5805a0024cdaadbbb2",
+     "checksum": "3d6aac4236f8e1ec85380e692dcc51b1",
      "grade_id": "set_a",
      "solution": true
     }
@@ -25,7 +25,7 @@
     "collapsed": true,
     "deletable": false,
     "nbgrader": {
-     "checksum": "3c49ba2e8db33c0c516fcad78864348a",
+     "checksum": "8bb5c7c6f388fae724e5ef53dc4deeb2",
      "grade": true,
      "grade_id": "foo",
      "points": 1
@@ -43,7 +43,7 @@
     "collapsed": true,
     "deletable": false,
     "nbgrader": {
-     "checksum": "48b3696993dd34d7a54250f26f67acc9",
+     "checksum": "75d78cdf605a339809ceaace462c5f33",
      "grade": true,
      "grade_id": "bar",
      "points": 1
@@ -59,7 +59,7 @@
    "metadata": {
     "deletable": false,
     "nbgrader": {
-     "checksum": "81dd7bc31e1c965b55508d5ad09f1545",
+     "checksum": "9e51fd0022c24c4105e38369d2f9d751",
      "grade": true,
      "grade_id": "baz",
      "points": 2,
@@ -76,7 +76,7 @@
    "metadata": {
     "collapsed": true,
     "nbgrader": {
-     "checksum": "1fb404d0e07daf29d82af5e26ef051f4",
+     "checksum": "5a193c164d7b444efe9a3612bee09f4c",
      "grade": true,
      "grade_id": "quux",
      "points": 3,
@@ -87,6 +87,39 @@
    "source": [
     "# YOUR CODE HERE\n",
     "b = 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "nbgrader": {
+     "checksum": "86f5f877fe95faac003fcd4b8d43d093",
+     "grade": false,
+     "grade_id": "ro1",
+     "locked": true,
+     "solution": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print(\"Don't change this cell!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nbgrader": {
+     "checksum": "0122b50e5eaf367b9874d07ebaf80521",
+     "grade": false,
+     "grade_id": "ro2",
+     "locked": true,
+     "solution": false
+    }
+   },
+   "source": [
+    "This cell shouldn't be changed."
    ]
   }
  ],

--- a/nbgrader/tests/apps/files/submitted-grade-cell-changed.ipynb
+++ b/nbgrader/tests/apps/files/submitted-grade-cell-changed.ipynb
@@ -7,7 +7,7 @@
     "collapsed": true,
     "deletable": false,
     "nbgrader": {
-     "checksum": "3f6c8864859cbb5805a0024cdaadbbb2",
+     "checksum": "3d6aac4236f8e1ec85380e692dcc51b1",
      "grade_id": "set_a",
      "solution": true
     }
@@ -25,7 +25,7 @@
     "collapsed": true,
     "deletable": false,
     "nbgrader": {
-     "checksum": "3c49ba2e8db33c0c516fcad78864348a",
+     "checksum": "8bb5c7c6f388fae724e5ef53dc4deeb2",
      "grade": true,
      "grade_id": "foo",
      "points": 1
@@ -43,7 +43,7 @@
     "collapsed": true,
     "deletable": false,
     "nbgrader": {
-     "checksum": "48b3696993dd34d7a54250f26f67acc9",
+     "checksum": "75d78cdf605a339809ceaace462c5f33",
      "grade": true,
      "grade_id": "bar",
      "points": 1
@@ -59,7 +59,7 @@
    "metadata": {
     "deletable": false,
     "nbgrader": {
-     "checksum": "81dd7bc31e1c965b55508d5ad09f1545",
+     "checksum": "9e51fd0022c24c4105e38369d2f9d751",
      "grade": true,
      "grade_id": "baz",
      "points": 2,
@@ -76,7 +76,7 @@
    "metadata": {
     "collapsed": true,
     "nbgrader": {
-     "checksum": "1fb404d0e07daf29d82af5e26ef051f4",
+     "checksum": "5a193c164d7b444efe9a3612bee09f4c",
      "grade": true,
      "grade_id": "quux",
      "points": 3,
@@ -87,6 +87,39 @@
    "source": [
     "# YOUR CODE HERE\n",
     "raise NotImplementedError()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "nbgrader": {
+     "checksum": "86f5f877fe95faac003fcd4b8d43d093",
+     "grade": false,
+     "grade_id": "ro1",
+     "locked": true,
+     "solution": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print(\"Don't change this cell!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nbgrader": {
+     "checksum": "0122b50e5eaf367b9874d07ebaf80521",
+     "grade": false,
+     "grade_id": "ro2",
+     "locked": true,
+     "solution": false
+    }
+   },
+   "source": [
+    "This cell shouldn't be changed."
    ]
   }
  ],

--- a/nbgrader/tests/apps/files/submitted-locked-cell-changed.ipynb
+++ b/nbgrader/tests/apps/files/submitted-locked-cell-changed.ipynb
@@ -104,7 +104,7 @@
    },
    "outputs": [],
    "source": [
-    "print(\"Don't change this cell!\")"
+    "#print(\"Don't change this cell!\")"
    ]
   },
   {
@@ -119,7 +119,8 @@
     }
    },
    "source": [
-    "This cell shouldn't be changed."
+    "This cell shouldn't \n",
+    "be changed."
    ]
   }
  ],

--- a/nbgrader/tests/apps/files/test.ipynb
+++ b/nbgrader/tests/apps/files/test.ipynb
@@ -5,7 +5,9 @@
    "metadata": {
     "nbgrader": {
      "grade": false,
-     "solution": false
+     "solution": false,
+     "locked": true,
+     "grade_id": "jupyter"
     }
    },
    "source": [

--- a/nbgrader/tests/apps/test_nbgrader_validate.py
+++ b/nbgrader/tests/apps/test_nbgrader_validate.py
@@ -68,3 +68,32 @@ class TestNbGraderValidate(BaseTestApp):
             'nbgrader validate submitted-unchanged.ipynb '
             '--DisplayAutoGrades.ignore_checksums=True')
         assert output.split("\n")[0] == "VALIDATION FAILED ON 1 CELL(S)! If you submit your assignment as it is, you WILL NOT"
+
+    def test_locked_cell_changed(self):
+        """Does the validate fail if a locked cell has changed?"""
+        self._copy_file("files/submitted-locked-cell-changed.ipynb", "submitted-locked-cell-changed.ipynb")
+        output = run_command('nbgrader validate submitted-locked-cell-changed.ipynb')
+        assert output.split("\n")[0] == "THE CONTENTS OF 2 TEST CELL(S) HAVE CHANGED! This might mean that even though the tests"
+
+    def test_locked_cell_changed_ignore_checksums(self):
+        """Does the validate pass if a locked cell has changed but we're ignoring checksums?"""
+        self._copy_file("files/submitted-locked-cell-changed.ipynb", "submitted-locked-cell-changed.ipynb")
+        output = run_command(
+            'nbgrader validate submitted-locked-cell-changed.ipynb '
+            '--DisplayAutoGrades.ignore_checksums=True')
+        assert output.split("\n")[0] == "VALIDATION FAILED ON 1 CELL(S)! If you submit your assignment as it is, you WILL NOT"
+
+    def test_invert_locked_cell_changed(self):
+        """Does the validate fail if a locked cell has changed, even with --invert?"""
+        self._copy_file("files/submitted-locked-cell-changed.ipynb", "submitted-locked-cell-changed.ipynb")
+        output = run_command('nbgrader validate submitted-locked-cell-changed.ipynb --invert')
+        assert output.split("\n")[0] == "THE CONTENTS OF 2 TEST CELL(S) HAVE CHANGED! This might mean that even though the tests"
+
+    def test_invert_locked_cell_changed_ignore_checksums(self):
+        """Does the validate fail if a locked cell has changed with --invert and ignoring checksums?"""
+        self._copy_file("files/submitted-locked-cell-changed.ipynb", "submitted-locked-cell-changed.ipynb")
+        output = run_command(
+            'nbgrader validate submitted-locked-cell-changed.ipynb '
+            '--invert '
+            '--DisplayAutoGrades.ignore_checksums=True')
+        assert output.split("\n")[0] == "NOTEBOOK PASSED ON 1 CELL(S)!"

--- a/nbgrader/tests/nbextensions/test_nbextension.py
+++ b/nbgrader/tests/nbextensions/test_nbextension.py
@@ -232,6 +232,7 @@ def test_tests_cell(browser):
     assert not _get_metadata(browser)['locked']
 
 
+@pytest.mark.js
 def test_locked_cell(browser):
     _load_notebook(browser)
     _activate_toolbar(browser)
@@ -241,7 +242,7 @@ def test_locked_cell(browser):
         EC.presence_of_all_elements_located((By.CSS_SELECTOR, ".celltoolbar select")))
 
     # does the nbgrader metadata exist?
-    assert {} == _get_metadata(browser)
+    assert _get_metadata(browser) is None
 
     # make it locked
     _select_locked(browser)

--- a/nbgrader/tests/preprocessors/files/test.ipynb
+++ b/nbgrader/tests/preprocessors/files/test.ipynb
@@ -5,7 +5,9 @@
    "metadata": {
     "nbgrader": {
      "grade": false,
-     "solution": false
+     "solution": false,
+     "locked": true,
+     "grade_id": "jupyter"
     }
    },
    "source": [

--- a/nbgrader/tests/preprocessors/test_computechecksums.py
+++ b/nbgrader/tests/preprocessors/test_computechecksums.py
@@ -5,7 +5,7 @@ from nbgrader.utils import compute_checksum
 from nbgrader.tests.preprocessors.base import BaseTestPreprocessor
 from nbgrader.tests import (
     create_code_cell, create_text_cell,
-    create_grade_cell, create_solution_cell)
+    create_grade_cell, create_solution_cell, create_locked_cell)
 
 
 @pytest.fixture
@@ -45,6 +45,17 @@ class TestComputeChecksums(BaseTestPreprocessor):
         cell1 = create_solution_cell("", "code", "foo")
         cell1 = preprocessor.preprocess_cell(cell1, {}, 0)[0]
         cell2 = create_solution_cell("", "markdown", "foo")
+        cell2 = preprocessor.preprocess_cell(cell2, {}, 0)[0]
+
+        assert cell1.metadata.nbgrader["checksum"] == compute_checksum(cell1)
+        assert cell2.metadata.nbgrader["checksum"] == compute_checksum(cell2)
+        assert cell1.metadata.nbgrader["checksum"] != cell2.metadata.nbgrader["checksum"]
+
+    def test_checksum_locked_cell_type(self, preprocessor):
+        """Test that the checksum is computed for locked cells"""
+        cell1 = create_locked_cell("", "code", "foo")
+        cell1 = preprocessor.preprocess_cell(cell1, {}, 0)[0]
+        cell2 = create_locked_cell("", "markdown", "foo")
         cell2 = preprocessor.preprocess_cell(cell2, {}, 0)[0]
 
         assert cell1.metadata.nbgrader["checksum"] == compute_checksum(cell1)

--- a/nbgrader/tests/preprocessors/test_getgrades.py
+++ b/nbgrader/tests/preprocessors/test_getgrades.py
@@ -4,6 +4,7 @@ from IPython.nbformat.v4 import new_notebook, new_output
 
 from nbgrader.preprocessors import SaveCells, SaveAutoGrades, GetGrades
 from nbgrader.api import Gradebook
+from nbgrader.utils import compute_checksum
 from nbgrader.tests.preprocessors.base import BaseTestPreprocessor
 from nbgrader.tests import (
     create_grade_cell, create_solution_cell, create_grade_and_solution_cell)
@@ -39,6 +40,7 @@ class TestGetGrades(BaseTestPreprocessor):
     def test_save_correct_code(self, preprocessors, gradebook, resources):
         """Is a passing code cell correctly graded?"""
         cell = create_grade_cell("hello", "code", "foo", 1)
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
         nb = new_notebook()
         nb.cells.append(cell)
         preprocessors[0].preprocess(nb, resources)
@@ -53,6 +55,7 @@ class TestGetGrades(BaseTestPreprocessor):
     def test_save_incorrect_code(self, preprocessors, gradebook, resources):
         """Is a failing code cell correctly graded?"""
         cell = create_grade_cell("hello", "code", "foo", 1)
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
         cell.outputs = [new_output('error', ename="NotImplementedError", evalue="", traceback=["error"])]
         nb = new_notebook()
         nb.cells.append(cell)
@@ -68,6 +71,7 @@ class TestGetGrades(BaseTestPreprocessor):
     def test_save_unchanged_code(self, preprocessors, gradebook, resources):
         """Is an unchanged code cell given the correct comment?"""
         cell = create_solution_cell("hello", "code", "foo")
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
         nb = new_notebook()
         nb.cells.append(cell)
         preprocessors[0].preprocess(nb, resources)
@@ -82,6 +86,7 @@ class TestGetGrades(BaseTestPreprocessor):
     def test_save_changed_code(self, preprocessors, gradebook, resources):
         """Is an unchanged code cell given the correct comment?"""
         cell = create_solution_cell("hello", "code", "foo")
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
         nb = new_notebook()
         nb.cells.append(cell)
         preprocessors[0].preprocess(nb, resources)
@@ -97,6 +102,7 @@ class TestGetGrades(BaseTestPreprocessor):
     def test_save_unchanged_markdown(self, preprocessors, gradebook, resources):
         """Is an unchanged markdown cell correctly graded?"""
         cell = create_grade_and_solution_cell("hello", "markdown", "foo", 1)
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
         nb = new_notebook()
         nb.cells.append(cell)
         preprocessors[0].preprocess(nb, resources)
@@ -114,6 +120,7 @@ class TestGetGrades(BaseTestPreprocessor):
     def test_save_changed_markdown(self, preprocessors, gradebook, resources):
         """Is a changed markdown cell correctly graded?"""
         cell = create_grade_and_solution_cell("hello", "markdown", "foo", 1)
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
         nb = new_notebook()
         nb.cells.append(cell)
         preprocessors[0].preprocess(nb, resources)

--- a/nbgrader/tests/preprocessors/test_lockcells.py
+++ b/nbgrader/tests/preprocessors/test_lockcells.py
@@ -1,4 +1,5 @@
 import pytest
+import itertools
 
 from nbgrader.preprocessors import LockCells
 from nbgrader.tests.preprocessors.base import BaseTestPreprocessor
@@ -21,6 +22,7 @@ class TestLockCells(BaseTestPreprocessor):
         preprocessor.lock_solution_cells = True
         preprocessor.lock_grade_cells = False
         preprocessor.lock_all_cells = False
+        preprocessor.lock_readonly_cells = False
         cell = create_code_cell()
         cell.metadata['nbgrader'] = {}
         cell.metadata['nbgrader']['solution'] = True
@@ -33,6 +35,7 @@ class TestLockCells(BaseTestPreprocessor):
         preprocessor.lock_solution_cells = False
         preprocessor.lock_grade_cells = False
         preprocessor.lock_all_cells = False
+        preprocessor.lock_readonly_cells = False
         cell = create_code_cell()
         cell.metadata['nbgrader'] = {}
         cell.metadata['nbgrader']['solution'] = True
@@ -40,11 +43,25 @@ class TestLockCells(BaseTestPreprocessor):
         new_cell = preprocessor.preprocess_cell(cell, {}, 0)[0]
         assert self.deletable(new_cell)
 
+    def test_locked_cell_undeletable(self, preprocessor):
+        """Do locked cells become undeletable?"""
+        preprocessor.lock_solution_cells = False
+        preprocessor.lock_grade_cells = False
+        preprocessor.lock_all_cells = False
+        preprocessor.lock_readonly_cells = True
+        cell = create_code_cell()
+        cell.metadata['nbgrader'] = {}
+        cell.metadata['nbgrader']['locked'] = True
+        assert self.deletable(cell)
+        new_cell = preprocessor.preprocess_cell(cell, {}, 0)[0]
+        assert not self.deletable(new_cell)
+
     def test_grade_cell_undeletable(self, preprocessor):
         """Do grade cells become undeletable?"""
         preprocessor.lock_solution_cells = False
         preprocessor.lock_grade_cells = True
         preprocessor.lock_all_cells = False
+        preprocessor.lock_readonly_cells = False
         cell = create_code_cell()
         cell.metadata['nbgrader'] = {}
         cell.metadata['nbgrader']['grade'] = True
@@ -57,6 +74,7 @@ class TestLockCells(BaseTestPreprocessor):
         preprocessor.lock_solution_cells = False
         preprocessor.lock_grade_cells = False
         preprocessor.lock_all_cells = False
+        preprocessor.lock_readonly_cells = False
         cell = create_code_cell()
         cell.metadata['nbgrader'] = {}
         cell.metadata['nbgrader']['grade'] = True
@@ -69,6 +87,7 @@ class TestLockCells(BaseTestPreprocessor):
         preprocessor.lock_solution_cells = False
         preprocessor.lock_grade_cells = False
         preprocessor.lock_all_cells = True
+        preprocessor.lock_readonly_cells = False
         cell = create_code_cell()
         cell.metadata['nbgrader'] = {}
         assert self.deletable(cell)
@@ -80,25 +99,21 @@ class TestLockCells(BaseTestPreprocessor):
         preprocessor.lock_solution_cells = False
         preprocessor.lock_grade_cells = False
         preprocessor.lock_all_cells = False
+        preprocessor.lock_readonly_cells = False
         cell = create_code_cell()
         cell.metadata['nbgrader'] = {}
         assert self.deletable(cell)
         new_cell = preprocessor.preprocess_cell(cell, {}, 0)[0]
         assert self.deletable(new_cell)
 
-    @pytest.mark.parametrize("lock_solution_cells, lock_grade_cells, lock_all_cells", [
-        (True, True, True),
-        (True, True, False),
-        (True, False, True),
-        (True, False, False),
-        (False, True, True),
-        (False, True, False),
-        (False, False, True),
-        (False, False, False)
-    ])
-    def test_preprocess_nb(self, preprocessor, lock_solution_cells, lock_grade_cells, lock_all_cells):
+    @pytest.mark.parametrize(
+        "lock_solution_cells, lock_grade_cells, lock_all_cells, lock_readonly_cells",
+        list(itertools.product([True, False], [True, False], [True, False], [True, False]))
+    )
+    def test_preprocess_nb(self, preprocessor, lock_solution_cells, lock_grade_cells, lock_all_cells, lock_readonly_cells):
         """Is the test notebook processed without error?"""
         preprocessor.lock_solution_cells = lock_solution_cells
         preprocessor.lock_grade_cells = lock_grade_cells
         preprocessor.lock_all_cells = lock_all_cells
+        preprocessor.lock_readonly_cells = lock_readonly_cells
         preprocessor.preprocess(self._read_nb("files/test.ipynb"), {})

--- a/nbgrader/tests/preprocessors/test_overwritecells.py
+++ b/nbgrader/tests/preprocessors/test_overwritecells.py
@@ -7,7 +7,8 @@ from nbgrader.api import Gradebook
 from nbgrader.utils import compute_checksum
 from nbgrader.tests.preprocessors.base import BaseTestPreprocessor
 from nbgrader.tests import (
-    create_grade_cell, create_solution_cell, create_grade_and_solution_cell)
+    create_grade_cell, create_solution_cell, create_grade_and_solution_cell,
+    create_locked_cell)
 
 
 @pytest.fixture
@@ -38,6 +39,7 @@ class TestOverwriteCells(BaseTestPreprocessor):
     def test_overwrite_points(self, preprocessors, resources):
         """Are points overwritten for grade cells?"""
         cell = create_grade_cell("hello", "code", "foo", 1)
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
         nb = new_notebook()
         nb.cells.append(cell)
         nb, resources = preprocessors[0].preprocess(nb, resources)
@@ -50,6 +52,33 @@ class TestOverwriteCells(BaseTestPreprocessor):
     def test_overwrite_grade_source(self, preprocessors, resources):
         """Is the source overwritten for grade cells?"""
         cell = create_grade_cell("hello", "code", "foo", 1)
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
+        nb = new_notebook()
+        nb.cells.append(cell)
+        nb, resources = preprocessors[0].preprocess(nb, resources)
+
+        cell.source = "hello!"
+        nb, resources = preprocessors[1].preprocess(nb, resources)
+
+        assert cell.source == "hello"
+
+    def test_overwrite_locked_source_code(self, preprocessors, resources):
+        """Is the source overwritten for locked code cells?"""
+        cell = create_locked_cell("hello", "code", "foo")
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
+        nb = new_notebook()
+        nb.cells.append(cell)
+        nb, resources = preprocessors[0].preprocess(nb, resources)
+
+        cell.source = "hello!"
+        nb, resources = preprocessors[1].preprocess(nb, resources)
+
+        assert cell.source == "hello"
+
+    def test_overwrite_locked_source_markdown(self, preprocessors, resources):
+        """Is the source overwritten for locked markdown cells?"""
+        cell = create_locked_cell("hello", "markdown", "foo")
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
         nb = new_notebook()
         nb.cells.append(cell)
         nb, resources = preprocessors[0].preprocess(nb, resources)
@@ -62,6 +91,7 @@ class TestOverwriteCells(BaseTestPreprocessor):
     def test_dont_overwrite_grade_and_solution_source(self, preprocessors, resources):
         """Is the source not overwritten for grade+solution cells?"""
         cell = create_grade_and_solution_cell("hello", "code", "foo", 1)
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
         nb = new_notebook()
         nb.cells.append(cell)
         nb, resources = preprocessors[0].preprocess(nb, resources)
@@ -74,6 +104,7 @@ class TestOverwriteCells(BaseTestPreprocessor):
     def test_dont_overwrite_solution_source(self, preprocessors, resources):
         """Is the source not overwritten for solution cells?"""
         cell = create_solution_cell("hello", "code", "foo")
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
         nb = new_notebook()
         nb.cells.append(cell)
         nb, resources = preprocessors[0].preprocess(nb, resources)
@@ -86,6 +117,7 @@ class TestOverwriteCells(BaseTestPreprocessor):
     def test_overwrite_grade_cell_type(self, preprocessors, resources):
         """Is the cell type overwritten for grade cells?"""
         cell = create_grade_cell("hello", "code", "foo", 1)
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
         nb = new_notebook()
         nb.cells.append(cell)
         nb, resources = preprocessors[0].preprocess(nb, resources)
@@ -98,6 +130,20 @@ class TestOverwriteCells(BaseTestPreprocessor):
     def test_overwrite_solution_cell_type(self, preprocessors, resources):
         """Is the cell type overwritten for solution cells?"""
         cell = create_solution_cell("hello", "code", "foo")
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
+        nb = new_notebook()
+        nb.cells.append(cell)
+        nb, resources = preprocessors[0].preprocess(nb, resources)
+
+        cell.cell_type = "markdown"
+        nb, resources = preprocessors[1].preprocess(nb, resources)
+
+        assert cell.cell_type == "code"
+
+    def test_overwrite_locked_cell_type(self, preprocessors, resources):
+        """Is the cell type overwritten for locked cells?"""
+        cell = create_locked_cell("hello", "code", "foo")
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
         nb = new_notebook()
         nb.cells.append(cell)
         nb, resources = preprocessors[0].preprocess(nb, resources)
@@ -110,6 +156,7 @@ class TestOverwriteCells(BaseTestPreprocessor):
     def test_overwrite_grade_checksum(self, preprocessors, resources):
         """Is the checksum overwritten for grade cells?"""
         cell = create_grade_cell("hello", "code", "foo", 1)
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
         nb = new_notebook()
         nb.cells.append(cell)
         nb, resources = preprocessors[0].preprocess(nb, resources)
@@ -122,6 +169,20 @@ class TestOverwriteCells(BaseTestPreprocessor):
     def test_overwrite_solution_checksum(self, preprocessors, resources):
         """Is the checksum overwritten for solution cells?"""
         cell = create_solution_cell("hello", "code", "foo")
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
+        nb = new_notebook()
+        nb.cells.append(cell)
+        nb, resources = preprocessors[0].preprocess(nb, resources)
+
+        cell.metadata.nbgrader["checksum"] = "1234"
+        nb, resources = preprocessors[1].preprocess(nb, resources)
+
+        assert cell.metadata.nbgrader["checksum"] == compute_checksum(cell)
+
+    def test_overwrite_locked_checksum(self, preprocessors, resources):
+        """Is the checksum overwritten for locked cells?"""
+        cell = create_locked_cell("hello", "code", "foo")
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
         nb = new_notebook()
         nb.cells.append(cell)
         nb, resources = preprocessors[0].preprocess(nb, resources)

--- a/nbgrader/tests/preprocessors/test_saveautogrades.py
+++ b/nbgrader/tests/preprocessors/test_saveautogrades.py
@@ -4,6 +4,7 @@ from IPython.nbformat.v4 import new_notebook, new_output
 
 from nbgrader.preprocessors import SaveCells, SaveAutoGrades
 from nbgrader.api import Gradebook
+from nbgrader.utils import compute_checksum
 from nbgrader.tests.preprocessors.base import BaseTestPreprocessor
 from nbgrader.tests import (
     create_grade_cell, create_grade_and_solution_cell, create_solution_cell)
@@ -39,6 +40,7 @@ class TestSaveAutoGrades(BaseTestPreprocessor):
     def test_grade_correct_code(self, preprocessors, gradebook, resources):
         """Is a passing code cell correctly graded?"""
         cell = create_grade_cell("hello", "code", "foo", 1)
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
         nb = new_notebook()
         nb.cells.append(cell)
         preprocessors[0].preprocess(nb, resources)
@@ -55,6 +57,7 @@ class TestSaveAutoGrades(BaseTestPreprocessor):
     def test_grade_incorrect_code(self, preprocessors, gradebook, resources):
         """Is a failing code cell correctly graded?"""
         cell = create_grade_cell("hello", "code", "foo", 1)
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
         cell.outputs = [new_output('error', ename="NotImplementedError", evalue="", traceback=["error"])]
         nb = new_notebook()
         nb.cells.append(cell)
@@ -72,6 +75,7 @@ class TestSaveAutoGrades(BaseTestPreprocessor):
     def test_grade_unchanged_markdown(self, preprocessors, gradebook, resources):
         """Is an unchanged markdown cell correctly graded?"""
         cell = create_grade_and_solution_cell("hello", "markdown", "foo", 1)
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
         nb = new_notebook()
         nb.cells.append(cell)
         preprocessors[0].preprocess(nb, resources)
@@ -88,6 +92,7 @@ class TestSaveAutoGrades(BaseTestPreprocessor):
     def test_grade_changed_markdown(self, preprocessors, gradebook, resources):
         """Is a changed markdown cell correctly graded?"""
         cell = create_grade_and_solution_cell("hello", "markdown", "foo", 1)
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
         nb = new_notebook()
         nb.cells.append(cell)
         preprocessors[0].preprocess(nb, resources)
@@ -105,6 +110,7 @@ class TestSaveAutoGrades(BaseTestPreprocessor):
     def test_comment_unchanged_code(self, preprocessors, gradebook, resources):
         """Is an unchanged code cell given the correct comment?"""
         cell = create_solution_cell("hello", "code", "foo")
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
         nb = new_notebook()
         nb.cells.append(cell)
         preprocessors[0].preprocess(nb, resources)
@@ -117,6 +123,7 @@ class TestSaveAutoGrades(BaseTestPreprocessor):
     def test_comment_changed_code(self, preprocessors, gradebook, resources):
         """Is a changed code cell given the correct comment?"""
         cell = create_solution_cell("hello", "code", "foo")
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
         nb = new_notebook()
         nb.cells.append(cell)
         preprocessors[0].preprocess(nb, resources)
@@ -130,6 +137,7 @@ class TestSaveAutoGrades(BaseTestPreprocessor):
     def test_comment_unchanged_markdown(self, preprocessors, gradebook, resources):
         """Is an unchanged markdown cell given the correct comment?"""
         cell = create_grade_and_solution_cell("hello", "markdown", "foo", 1)
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
         nb = new_notebook()
         nb.cells.append(cell)
         preprocessors[0].preprocess(nb, resources)
@@ -142,6 +150,7 @@ class TestSaveAutoGrades(BaseTestPreprocessor):
     def test_comment_changed_markdown(self, preprocessors, gradebook, resources):
         """Is a changed markdown cell given the correct comment?"""
         cell = create_grade_and_solution_cell("hello", "markdown", "foo", 1)
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
         nb = new_notebook()
         nb.cells.append(cell)
         preprocessors[0].preprocess(nb, resources)

--- a/nbgrader/tests/preprocessors/test_savecells.py
+++ b/nbgrader/tests/preprocessors/test_savecells.py
@@ -4,9 +4,11 @@ from IPython.nbformat.v4 import new_notebook
 
 from nbgrader.preprocessors import SaveCells
 from nbgrader.api import Gradebook
+from nbgrader.utils import compute_checksum
 from nbgrader.tests.preprocessors.base import BaseTestPreprocessor
 from nbgrader.tests import (
-    create_grade_cell, create_solution_cell, create_grade_and_solution_cell)
+    create_grade_cell, create_solution_cell, create_grade_and_solution_cell,
+    create_locked_cell)
 
 
 @pytest.fixture
@@ -36,6 +38,7 @@ class TestSaveCells(BaseTestPreprocessor):
 
     def test_save_code_grade_cell(self, preprocessor, resources):
         cell = create_grade_cell("hello", "code", "foo", 1)
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
         nb = new_notebook()
         nb.cells.append(cell)
 
@@ -44,52 +47,51 @@ class TestSaveCells(BaseTestPreprocessor):
         gb = preprocessor.gradebook
         grade_cell = gb.find_grade_cell("foo", "test", "ps0")
         assert grade_cell.max_score == 1
-        assert grade_cell.source == "hello"
-        assert grade_cell.checksum == cell.metadata.nbgrader["checksum"]
         assert grade_cell.cell_type == "code"
 
-    def test_save_markdown_grade_cell(self, preprocessor, resources):
-        cell = create_grade_cell("hello", "markdown", "foo", 1)
-        nb = new_notebook()
-        nb.cells.append(cell)
-
-        nb, resources = preprocessor.preprocess(nb, resources)
-
-        gb = preprocessor.gradebook
-        grade_cell = gb.find_grade_cell("foo", "test", "ps0")
-        assert grade_cell.max_score == 1
-        assert grade_cell.source == "hello"
-        assert grade_cell.checksum == cell.metadata.nbgrader["checksum"]
-        assert grade_cell.cell_type == "markdown"
+        source_cell = gb.find_source_cell("foo", "test", "ps0")
+        assert source_cell.source == "hello"
+        assert source_cell.checksum == cell.metadata.nbgrader["checksum"]
+        assert source_cell.cell_type == "code"
+        assert source_cell.locked
 
     def test_save_code_solution_cell(self, preprocessor, resources):
         cell = create_solution_cell("hello", "code", "foo")
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
         nb = new_notebook()
         nb.cells.append(cell)
 
         nb, resources = preprocessor.preprocess(nb, resources)
 
         gb = preprocessor.gradebook
-        solution_cell = gb.find_solution_cell("foo", "test", "ps0")
-        assert solution_cell.source == "hello"
-        assert solution_cell.checksum == cell.metadata.nbgrader["checksum"]
-        assert solution_cell.cell_type == "code"
+        gb.find_solution_cell("foo", "test", "ps0")
+
+        source_cell = gb.find_source_cell("foo", "test", "ps0")
+        assert source_cell.source == "hello"
+        assert source_cell.checksum == cell.metadata.nbgrader["checksum"]
+        assert source_cell.cell_type == "code"
+        assert not source_cell.locked
 
     def test_save_markdown_solution_cell(self, preprocessor, resources):
         cell = create_solution_cell("hello", "markdown", "foo")
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
         nb = new_notebook()
         nb.cells.append(cell)
 
         nb, resources = preprocessor.preprocess(nb, resources)
 
         gb = preprocessor.gradebook
-        solution_cell = gb.find_solution_cell("foo", "test", "ps0")
-        assert solution_cell.source == "hello"
-        assert solution_cell.checksum == cell.metadata.nbgrader["checksum"]
-        assert solution_cell.cell_type == "markdown"
+        gb.find_solution_cell("foo", "test", "ps0")
+
+        source_cell = gb.find_source_cell("foo", "test", "ps0")
+        assert source_cell.source == "hello"
+        assert source_cell.checksum == cell.metadata.nbgrader["checksum"]
+        assert source_cell.cell_type == "markdown"
+        assert not source_cell.locked
 
     def test_save_code_grade_and_solution_cell(self, preprocessor, resources):
         cell = create_grade_and_solution_cell("hello", "code", "foo", 1)
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
         nb = new_notebook()
         nb.cells.append(cell)
 
@@ -98,17 +100,19 @@ class TestSaveCells(BaseTestPreprocessor):
         gb = preprocessor.gradebook
         grade_cell = gb.find_grade_cell("foo", "test", "ps0")
         assert grade_cell.max_score == 1
-        assert grade_cell.source == "hello"
-        assert grade_cell.checksum == cell.metadata.nbgrader["checksum"]
         assert grade_cell.cell_type == "code"
 
-        solution_cell = gb.find_solution_cell("foo", "test", "ps0")
-        assert solution_cell.source == "hello"
-        assert solution_cell.checksum == cell.metadata.nbgrader["checksum"]
-        assert solution_cell.cell_type == "code"
+        gb.find_solution_cell("foo", "test", "ps0")
+
+        source_cell = gb.find_source_cell("foo", "test", "ps0")
+        assert source_cell.source == "hello"
+        assert source_cell.checksum == cell.metadata.nbgrader["checksum"]
+        assert source_cell.cell_type == "code"
+        assert not source_cell.locked
 
     def test_save_markdown_grade_and_solution_cell(self, preprocessor, resources):
         cell = create_grade_and_solution_cell("hello", "markdown", "foo", 1)
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
         nb = new_notebook()
         nb.cells.append(cell)
 
@@ -117,11 +121,42 @@ class TestSaveCells(BaseTestPreprocessor):
         gb = preprocessor.gradebook
         grade_cell = gb.find_grade_cell("foo", "test", "ps0")
         assert grade_cell.max_score == 1
-        assert grade_cell.source == "hello"
-        assert grade_cell.checksum == cell.metadata.nbgrader["checksum"]
         assert grade_cell.cell_type == "markdown"
 
-        solution_cell = gb.find_solution_cell("foo", "test", "ps0")
-        assert solution_cell.source == "hello"
-        assert solution_cell.checksum == cell.metadata.nbgrader["checksum"]
-        assert solution_cell.cell_type == "markdown"
+        gb.find_solution_cell("foo", "test", "ps0")
+
+        source_cell = gb.find_source_cell("foo", "test", "ps0")
+        assert source_cell.source == "hello"
+        assert source_cell.checksum == cell.metadata.nbgrader["checksum"]
+        assert source_cell.cell_type == "markdown"
+        assert not source_cell.locked
+
+    def test_save_locked_code_cell(self, preprocessor, resources):
+        cell = create_locked_cell("hello", "code", "foo")
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
+        nb = new_notebook()
+        nb.cells.append(cell)
+
+        nb, resources = preprocessor.preprocess(nb, resources)
+
+        gb = preprocessor.gradebook
+        source_cell = gb.find_source_cell("foo", "test", "ps0")
+        assert source_cell.source == "hello"
+        assert source_cell.checksum == cell.metadata.nbgrader["checksum"]
+        assert source_cell.cell_type == "code"
+        assert source_cell.locked
+
+    def test_save_locked_markdown_cell(self, preprocessor, resources):
+        cell = create_locked_cell("hello", "markdown", "foo")
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
+        nb = new_notebook()
+        nb.cells.append(cell)
+
+        nb, resources = preprocessor.preprocess(nb, resources)
+
+        gb = preprocessor.gradebook
+        source_cell = gb.find_source_cell("foo", "test", "ps0")
+        assert source_cell.source == "hello"
+        assert source_cell.checksum == cell.metadata.nbgrader["checksum"]
+        assert source_cell.cell_type == "markdown"
+        assert source_cell.locked

--- a/nbgrader/tests/utils/test_utils.py
+++ b/nbgrader/tests/utils/test_utils.py
@@ -48,6 +48,51 @@ def test_is_solution():
     assert utils.is_solution(cell)
 
 
+def test_is_locked():
+
+    cell = create_code_cell()
+    assert not utils.is_locked(cell)
+    cell.metadata['nbgrader'] = dict(solution=True, grade=False, locked=False)
+    assert not utils.is_locked(cell)
+
+    cell = create_code_cell()
+    assert not utils.is_locked(cell)
+    cell.metadata['nbgrader'] = dict(solution=True, grade=True, locked=False)
+    assert not utils.is_locked(cell)
+
+    cell = create_code_cell()
+    assert not utils.is_locked(cell)
+    cell.metadata['nbgrader'] = dict(solution=True, grade=False, locked=True)
+    assert not utils.is_locked(cell)
+
+    cell = create_code_cell()
+    assert not utils.is_locked(cell)
+    cell.metadata['nbgrader'] = dict(solution=True, grade=True, locked=True)
+    assert not utils.is_locked(cell)
+
+    cell = create_code_cell()
+    assert not utils.is_locked(cell)
+    cell.metadata['nbgrader'] = dict(solution=False, grade=True, locked=False)
+    assert utils.is_locked(cell)
+
+    cell = create_code_cell()
+    assert not utils.is_locked(cell)
+    cell.metadata['nbgrader'] = dict(solution=False, grade=True, locked=True)
+    assert utils.is_locked(cell)
+
+    cell = create_code_cell()
+    assert not utils.is_locked(cell)
+    cell.metadata['nbgrader'] = dict(solution=False, grade=False, locked=True)
+    assert utils.is_locked(cell)
+
+    assert utils.is_locked(cell)
+    cell = create_code_cell()
+    assert not utils.is_locked(cell)
+    cell.metadata['nbgrader'] = dict(solution=False, grade=False, locked=False)
+    assert not utils.is_locked(cell)
+
+
+
 def test_determine_grade_code_grade():
     cell = create_grade_cell('print("test")', "code", "foo", 10)
     cell.outputs = []
@@ -74,6 +119,7 @@ def test_determine_grade_solution():
 
 def test_determine_grade_code_grade_and_solution():
     cell = create_grade_and_solution_cell('test', "code", "foo", 10)
+    cell.metadata.nbgrader['checksum'] = utils.compute_checksum(cell)
     cell.outputs = []
     assert utils.determine_grade(cell) == (0, 10)
 
@@ -84,6 +130,7 @@ def test_determine_grade_code_grade_and_solution():
 
 def test_determine_grade_markdown_grade_and_solution():
     cell = create_grade_and_solution_cell('test', "markdown", "foo", 10)
+    cell.metadata.nbgrader['checksum'] = utils.compute_checksum(cell)
     assert utils.determine_grade(cell) == (0, 10)
 
     cell = create_grade_and_solution_cell('test', "markdown", "foo", 10)

--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -19,6 +19,17 @@ def is_solution(cell):
         return False
     return cell.metadata['nbgrader'].get('solution', False)
 
+def is_locked(cell):
+    """Returns True if the cell source is locked (will be overwritten)."""
+    if 'nbgrader' not in cell.metadata:
+        return False
+    elif is_solution(cell):
+        return False
+    elif is_grade(cell):
+        return True
+    else:
+        return cell.metadata['nbgrader'].get('locked', False)
+
 def determine_grade(cell):
     if not is_grade(cell):
         raise ValueError("cell is not a grade cell")
@@ -51,6 +62,7 @@ def compute_checksum(cell):
     # add whether it's a grade cell and/or solution cell
     m.update(str_to_bytes(str(is_grade(cell))))
     m.update(str_to_bytes(str(is_solution(cell))))
+    m.update(str_to_bytes(str(is_locked(cell))))
 
     # include the cell id
     m.update(str_to_bytes(cell.metadata.nbgrader['grade_id']))


### PR DESCRIPTION
Fixes #131

This adds special "read only" cells whose contents are recorded in the database and replaced (just like grade cells) if they are modified by students. The create assignment extension adds the cell type to the drop down menu, as well as a little lock icon:

![image](https://cloud.githubusercontent.com/assets/83444/8323842/4fad0610-1a0f-11e5-8f4a-29731349c21f.png)

If you hover your cursor over the lock icon, it will also display a message saying "student changes will be overwritten".

The lock icon also shows up for autograder test cells, e.g.:

![image](https://cloud.githubusercontent.com/assets/83444/8323848/713b4846-1a0f-11e5-8aa6-fad8d15391a7.png)

Under the hood, this adds a new table to the database for "source" cells. Both the autograder tests and the read-only cell types utilize the source cell model in the database to store their source and checksum.