### PR TITLE
Separate the notions of automatically assigned comments and manually assigned comments

### DIFF
--- a/docs/source/api/models.rst
+++ b/docs/source/api/models.rst
@@ -285,6 +285,10 @@ Submitted assignments
 
     .. autoattribute:: student
 
+    .. autoattribute:: auto_comment
+
+    .. autoattribute:: manual_comment
+
     .. autoattribute:: comment
 
     .. automethod:: to_dict

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -728,8 +728,25 @@ class Comment(Base):
     #: :class:`~nbgrader.api.Student` object
     student = association_proxy('notebook', 'student')
 
-    #: The actual text of the comment
-    comment = Column(Text())
+    #: A comment which is automatically assigned by the autograder
+    auto_comment = Column(Text())
+
+    #: A commment which is assigned manually
+    manual_comment = Column(Text())
+
+    #: The overall comment, computed automatically from the
+    #: :attr:`~nbgrader.api.Comment.auto_comment` and
+    #: :attr:`~nbgrader.api.Comment.manual_comment` values. If neither are set,
+    #: the comment is None. If both are set, then the manual comment
+    #: takes precedence. If only one is set, then that value is used for the
+    #: comment.
+    comment = column_property(case(
+        [
+            (manual_comment != None, manual_comment),
+            (auto_comment != None, auto_comment)
+        ],
+        else_=None
+    ))
 
     def to_dict(self):
         """Convert the comment object to a JSON-friendly dictionary representation.
@@ -745,7 +762,8 @@ class Comment(Base):
             "notebook": self.notebook.name,
             "assignment": self.assignment.name,
             "student": self.student.id,
-            "comment": self.comment,
+            "auto_comment": self.auto_comment,
+            "manual_comment": self.manual_comment
         }
 
     def __repr__(self):

--- a/nbgrader/html/formgrade.py
+++ b/nbgrader/html/formgrade.py
@@ -422,7 +422,7 @@ def get_comment(_id):
         abort(404)
 
     if request.method == "PUT":
-        comment.comment = request.json.get("comment", None)
+        comment.manual_comment = request.json.get("manual_comment", None)
         app.gradebook.db.commit()
 
     return json.dumps(comment.to_dict())

--- a/nbgrader/html/static/js/models.js
+++ b/nbgrader/html/static/js/models.js
@@ -120,15 +120,16 @@ var CommentUI = Backbone.View.extend({
         this.listenTo(this.model, "request", this.animateSaving);
         this.listenTo(this.model, "sync", this.animateSaved);
 
+        this.$comment.attr("placeholder", this.model.get("auto_comment") || "Comments");
         this.render();
     },
 
     render: function () {
-        this.$comment.val(this.model.get("comment"));
+        this.$comment.val(this.model.get("manual_comment"));
     },
 
     save: function () {
-        this.model.save({"comment": this.$comment.val()});
+        this.model.save({"manual_comment": this.$comment.val()});
     },
 
     animateSaving: function () {

--- a/nbgrader/html/templates/feedback.tpl
+++ b/nbgrader/html/templates/feedback.tpl
@@ -122,8 +122,8 @@ span.nbgrader-label {
             {% elif cell.cell_type == "markdown" and cell.metadata.nbgrader and cell.metadata.nbgrader.grade %}
             <li><a href="#{{ cell.metadata.nbgrader.grade_id }}">Written response</a> (Score: {{ cell.metadata.nbgrader.score | float | round(2) }} / {{ cell.metadata.nbgrader.points | float | round(2) }})</li>
             {% endif %}
-            {% if cell.metadata.nbgrader and cell.metadata.nbgrader.comment and cell.metadata.nbgrader.comment.comment %}
-            <li><a href="#comment-{{ cell.metadata.nbgrader.comment.name }}">Comment</a></li>
+            {% if cell.metadata.nbgrader and cell.metadata.nbgrader.comment and cell.metadata.nbgrader.comment %}
+            <li><a href="#comment-{{ cell.metadata.nbgrader.grade_id }}">Comment</a></li>
             {% endif %}
           {% endfor %}
           </ol>
@@ -154,7 +154,7 @@ span.nbgrader-label {
 
 {% macro nbgrader_heading(cell) -%}
 {%- if cell.metadata.nbgrader.solution -%}
-<a name="comment-{{ cell.metadata.nbgrader.comment.name }}"></a>
+<a name="comment-{{ cell.metadata.nbgrader.grade_id }}"></a>
 {%- endif -%}
 {%- if cell.metadata.nbgrader.grade -%}
 <a name="{{ cell.metadata.nbgrader.grade_id }}"></a>
@@ -175,10 +175,10 @@ span.nbgrader-label {
 {%- endmacro %}
 
 {% macro nbgrader_footer(cell) -%}
-{%- if cell.metadata.nbgrader.solution and cell.metadata.nbgrader.comment.comment -%}
+{%- if cell.metadata.nbgrader.solution and cell.metadata.nbgrader.comment -%}
 <div class="panel-footer">
   <div>
-    <b>Comments:</b> {{ cell.metadata.nbgrader.comment.comment }}
+    <b>Comments:</b> {{ cell.metadata.nbgrader.comment }}
   </div>
 </div>
 {%- endif -%}

--- a/nbgrader/html/templates/formgrade.tpl
+++ b/nbgrader/html/templates/formgrade.tpl
@@ -100,7 +100,7 @@ window.MathJax = {
 {% macro nbgrader_footer(cell) -%}
 {%- if cell.metadata.nbgrader.solution -%}
 <div class="panel-footer">
-  <div><textarea id="{{ cell.metadata.nbgrader.grade_id }}-comment" class="comment tabbable" placeholder="Comments"></textarea></div>
+  <div><textarea id="{{ cell.metadata.nbgrader.grade_id }}-comment" class="comment tabbable"></textarea></div>
 </div>
 {%- endif -%}
 {%- endmacro %}

--- a/nbgrader/preprocessors/getgrades.py
+++ b/nbgrader/preprocessors/getgrades.py
@@ -42,7 +42,7 @@ class GetGrades(NbGraderPreprocessor):
             self.student_id)
 
         # save it in the notebook
-        cell.metadata.nbgrader['comment'] = comment.to_dict()
+        cell.metadata.nbgrader['comment'] = comment.comment
 
     def _get_score(self, cell, resources):
         grade = self.gradebook.find_grade(

--- a/nbgrader/preprocessors/saveautogrades.py
+++ b/nbgrader/preprocessors/saveautogrades.py
@@ -58,12 +58,13 @@ class SaveAutoGrades(NbGraderPreprocessor):
             self.assignment_id,
             self.student_id)
 
-        if comment.comment:
-            return
-        elif cell.metadata.nbgrader.get("checksum", None) == utils.compute_checksum(cell):
-            comment.comment = "No response."
-            self.gradebook.db.commit()
-            self.log.debug(comment)
+        if cell.metadata.nbgrader.get("checksum", None) == utils.compute_checksum(cell):
+            comment.auto_comment = "No response."
+        else:
+            comment.auto_comment = None
+
+        self.gradebook.db.commit()
+        self.log.debug(comment)
 
     def preprocess_cell(self, cell, resources, cell_index):
         # if it's a grade cell, the add a grade

--- a/nbgrader/tests/preprocessors/test_getgrades.py
+++ b/nbgrader/tests/preprocessors/test_getgrades.py
@@ -79,9 +79,7 @@ class TestGetGrades(BaseTestPreprocessor):
         preprocessors[1].preprocess(nb, resources)
         preprocessors[2].preprocess(nb, resources)
 
-        comment = gradebook.find_comment("foo", "test", "ps0", "bar")
-        assert cell.metadata.nbgrader['comment'] == comment.to_dict()
-        assert cell.metadata.nbgrader['comment']['comment'] == "No response."
+        assert cell.metadata.nbgrader['comment'] == "No response."
 
     def test_save_changed_code(self, preprocessors, gradebook, resources):
         """Is an unchanged code cell given the correct comment?"""
@@ -95,9 +93,7 @@ class TestGetGrades(BaseTestPreprocessor):
         preprocessors[1].preprocess(nb, resources)
         preprocessors[2].preprocess(nb, resources)
 
-        comment = gradebook.find_comment("foo", "test", "ps0", "bar")
-        assert cell.metadata.nbgrader['comment'] == comment.to_dict()
-        assert cell.metadata.nbgrader['comment']['comment'] == None
+        assert cell.metadata.nbgrader['comment'] is None
 
     def test_save_unchanged_markdown(self, preprocessors, gradebook, resources):
         """Is an unchanged markdown cell correctly graded?"""
@@ -110,12 +106,9 @@ class TestGetGrades(BaseTestPreprocessor):
         preprocessors[1].preprocess(nb, resources)
         preprocessors[2].preprocess(nb, resources)
 
-        comment = gradebook.find_comment("foo", "test", "ps0", "bar")
-
         assert cell.metadata.nbgrader['score'] == 0
         assert cell.metadata.nbgrader['points'] == 1
-        assert cell.metadata.nbgrader['comment'] == comment.to_dict()
-        assert cell.metadata.nbgrader['comment']['comment'] == "No response."
+        assert cell.metadata.nbgrader['comment'] == "No response."
 
     def test_save_changed_markdown(self, preprocessors, gradebook, resources):
         """Is a changed markdown cell correctly graded?"""
@@ -132,6 +125,4 @@ class TestGetGrades(BaseTestPreprocessor):
         assert cell.metadata.nbgrader['score'] == 0
         assert cell.metadata.nbgrader['points'] == 1
 
-        comment = gradebook.find_comment("foo", "test", "ps0", "bar")
-        assert cell.metadata.nbgrader['comment'] == comment.to_dict()
-        assert cell.metadata.nbgrader['comment']['comment'] == None
+        assert cell.metadata.nbgrader['comment'] is None

--- a/nbgrader/tests/preprocessors/test_saveautogrades.py
+++ b/nbgrader/tests/preprocessors/test_saveautogrades.py
@@ -118,7 +118,7 @@ class TestSaveAutoGrades(BaseTestPreprocessor):
         preprocessors[1].preprocess(nb, resources)
 
         comment = gradebook.find_comment("foo", "test", "ps0", "bar")
-        assert comment.comment == "No response."
+        assert comment.auto_comment == "No response."
 
     def test_comment_changed_code(self, preprocessors, gradebook, resources):
         """Is a changed code cell given the correct comment?"""
@@ -132,7 +132,7 @@ class TestSaveAutoGrades(BaseTestPreprocessor):
         preprocessors[1].preprocess(nb, resources)
 
         comment = gradebook.find_comment("foo", "test", "ps0", "bar")
-        assert comment.comment == None
+        assert comment.auto_comment is None
 
     def test_comment_unchanged_markdown(self, preprocessors, gradebook, resources):
         """Is an unchanged markdown cell given the correct comment?"""
@@ -145,7 +145,7 @@ class TestSaveAutoGrades(BaseTestPreprocessor):
         preprocessors[1].preprocess(nb, resources)
 
         comment = gradebook.find_comment("foo", "test", "ps0", "bar")
-        assert comment.comment == "No response."
+        assert comment.auto_comment == "No response."
 
     def test_comment_changed_markdown(self, preprocessors, gradebook, resources):
         """Is a changed markdown cell given the correct comment?"""
@@ -159,7 +159,7 @@ class TestSaveAutoGrades(BaseTestPreprocessor):
         preprocessors[1].preprocess(nb, resources)
 
         comment = gradebook.find_comment("foo", "test", "ps0", "bar")
-        assert comment.comment == None
+        assert comment.auto_comment is None
 
     def test_grade_existing_manual_grade(self, preprocessors, gradebook, resources):
         """Is a failing code cell correctly graded?"""
@@ -190,3 +190,22 @@ class TestSaveAutoGrades(BaseTestPreprocessor):
         assert grade_cell.auto_score == None
         assert grade_cell.manual_score == 1
         assert grade_cell.needs_manual_grade
+
+    def test_grade_existing_auto_comment(self, preprocessors, gradebook, resources):
+        """Is a failing code cell correctly graded?"""
+        cell = create_grade_and_solution_cell("hello", "markdown", "foo", 1)
+        cell.metadata.nbgrader['checksum'] = compute_checksum(cell)
+        nb = new_notebook()
+        nb.cells.append(cell)
+        preprocessors[0].preprocess(nb, resources)
+        gradebook.add_submission("ps0", "bar")
+        preprocessors[1].preprocess(nb, resources)
+
+        comment = gradebook.find_comment("foo", "test", "ps0", "bar")
+        assert comment.auto_comment == "No response."
+
+        nb.cells[-1].source = 'goodbye'
+        preprocessors[1].preprocess(nb, resources)
+
+        gradebook.db.refresh(comment)
+        assert comment.auto_comment is None


### PR DESCRIPTION
Fixes #255

This removes the `comment` column from the `Comment` model and replaces it with `auto_comment` and `manual_comment`. This basically makes comments behave just like the score in `Grade` -- there are comments that can be assigned by the autograded, and there are comments that can be assigned by human graders. Manual comments always take precedence.