### PR TITLE
Clear db when running nbgrader assign

### DIFF
--- a/docs/source/api/gradebook.rst
+++ b/docs/source/api/gradebook.rst
@@ -33,6 +33,8 @@ Gradebook
 
     .. automethod:: update_or_create_notebook
 
+    .. automethod:: remove_notebook
+
     .. automethod:: add_grade_cell
 
     .. automethod:: find_grade_cell
@@ -58,6 +60,8 @@ Gradebook
     .. automethod:: update_or_create_submission
 
     .. automethod:: remove_submission
+
+    .. automethod:: remove_submission_notebook
 
     .. automethod:: assignment_submissions
 

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1780,11 +1780,7 @@ class Gradebook(object):
         submission = self.find_submission(assignment, student)
 
         for notebook in submission.notebooks:
-            for grade in notebook.grades:
-                self.db.delete(grade)
-            for comment in notebook.comments:
-                self.db.delete(comment)
-            self.db.delete(notebook)
+            self.remove_submission_notebook(notebook.name, assignment, student)
 
         self.db.delete(submission)
 

--- a/nbgrader/apps/assignapp.py
+++ b/nbgrader/apps/assignapp.py
@@ -161,13 +161,10 @@ class AssignApp(BaseNbConvertApp):
         if len(assignment.submissions) > 0:
             self.fail("Cannot modify existing assignment '%s' because there are submissions associated with it", assignment)
 
-        # remove the assignment and re-add it
-        else:
-            self.log.debug("Removing existing assignment '%s' from the gradebook", assignment)
-            assignment_info = assignment.to_dict()
-            del assignment_info['name']
-            gb.remove_assignment(assignment_id)
-            gb.add_assignment(assignment_id, **assignment_info)
+        # remove the old notebooks
+        for notebook_id in (old_notebook_ids - new_notebook_ids):
+            self.log.warning("Removing notebook '%s' from the gradebook", notebook_id)
+            gb.remove_notebook(notebook_id, assignment_id)
 
     def init_assignment(self, assignment_id, student_id):
         super(AssignApp, self).init_assignment(assignment_id, student_id)
@@ -183,8 +180,8 @@ class AssignApp(BaseNbConvertApp):
                 gb.add_assignment(assignment_id)
             else:
                 self.fail("No assignment called '%s' exists in the database", assignment_id)
-
-        # check if there are any extra notebooks in the db that are no longer
-        # part of the assignment, and if so, remove them
-        if self.notebook_id == "*":
-            self._clean_old_notebooks(assignment_id, student_id)
+        else:
+            # check if there are any extra notebooks in the db that are no longer
+            # part of the assignment, and if so, remove them
+            if self.notebook_id == "*":
+                self._clean_old_notebooks(assignment_id, student_id)

--- a/nbgrader/preprocessors/savecells.py
+++ b/nbgrader/preprocessors/savecells.py
@@ -1,9 +1,56 @@
 from nbgrader import utils
-from nbgrader.api import Gradebook
+from nbgrader.api import Gradebook, MissingEntry
 from nbgrader.preprocessors import NbGraderPreprocessor
 
 class SaveCells(NbGraderPreprocessor):
     """A preprocessor to save information about grade and solution cells."""
+
+    def _create_notebook(self):
+        try:
+            notebook = self.gradebook.find_notebook(self.notebook_id, self.assignment_id)
+        except MissingEntry:
+            notebook_info = {}
+        else:
+            # pull out existing cell ids
+            self.old_grade_cells = set(x.name for x in notebook.grade_cells)
+            self.old_solution_cells = set(x.name for x in notebook.solution_cells)
+            self.old_source_cells = set(x.name for x in notebook.source_cells)
+
+            # throw an error if we're trying to modify a notebook that has
+            # submissions associated with it
+            if len(notebook.submissions) > 0:
+                changed = set(self.new_grade_cells.keys()) != self.old_grade_cells
+                changed = changed | (set(self.new_solution_cells.keys()) != self.old_solution_cells)
+                changed = changed | (set(self.new_source_cells.keys()) != self.old_source_cells)
+                if changed:
+                    raise RuntimeError(
+                        "Cannot add or remove cells for notebook '%s' because there "
+                        "are submissions associated with it" % self.notebook_id)
+
+            # clear data about the existing notebook
+            self.log.debug("Removing existing notebook '%s' from the database", self.notebook_id)
+            notebook_info = notebook.to_dict()
+            del notebook_info['name']
+            self.gradebook.remove_notebook(self.notebook_id, self.assignment_id)
+
+        # create the notebook
+        self.log.debug("Creating notebook '%s' in the database", self.notebook_id)
+        self.gradebook.add_notebook(self.notebook_id, self.assignment_id, **notebook_info)
+
+        # save grade cells
+        for name, info in self.new_grade_cells.items():
+            grade_cell = self.gradebook.add_grade_cell(name, self.notebook_id, self.assignment_id, **info)
+            self.log.debug("Recorded grade cell %s into the gradebook", grade_cell)
+
+        # save solution cells
+        for name, info in self.new_solution_cells.items():
+            solution_cell = self.gradebook.add_solution_cell(name, self.notebook_id, self.assignment_id, **info)
+            self.log.debug("Recorded solution cell %s into the gradebook", solution_cell)
+
+        # save source cells
+        for name, info in self.new_source_cells.items():
+            source_cell = self.gradebook.add_source_cell(name, self.notebook_id, self.assignment_id, **info)
+            self.log.debug("Recorded source cell %s into the gradebook", source_cell)
 
     def preprocess(self, nb, resources):
         # pull information from the resources
@@ -16,54 +63,80 @@ class SaveCells(NbGraderPreprocessor):
         if self.assignment_id == '':
             raise ValueError("Invalid assignment id: '{}'".format(self.assignment_id))
 
+        # create a place to put new cell information
+        self.new_grade_cells = {}
+        self.new_solution_cells = {}
+        self.new_source_cells = {}
+
         # connect to the database
         self.gradebook = Gradebook(self.db_url)
 
-        # create the notebook
-        self.gradebook.update_or_create_notebook(
-            self.notebook_id, self.assignment_id)
-
         nb, resources = super(SaveCells, self).preprocess(nb, resources)
+
+        # create the notebook and save it to the database
+        self._create_notebook()
 
         return nb, resources
 
+    def _create_grade_cell(self, cell):
+        grade_id = cell.metadata.nbgrader['grade_id']
+
+        try:
+            grade_cell = self.gradebook.find_grade_cell(grade_id, self.notebook_id, self.assignment_id).to_dict()
+            del grade_cell['name']
+            del grade_cell['notebook']
+            del grade_cell['assignment']
+        except MissingEntry:
+            grade_cell = {}
+
+        grade_cell.update({
+            'max_score': float(cell.metadata.nbgrader['points']),
+            'cell_type': cell.cell_type
+        })
+
+        self.new_grade_cells[grade_id] = grade_cell
+
+    def _create_solution_cell(self, cell):
+        grade_id = cell.metadata.nbgrader['grade_id']
+
+        try:
+            solution_cell = self.gradebook.find_solution_cell(grade_id, self.notebook_id, self.assignment_id).to_dict()
+            del solution_cell['name']
+            del solution_cell['notebook']
+            del solution_cell['assignment']
+        except MissingEntry:
+            solution_cell = {}
+
+        self.new_solution_cells[grade_id] = solution_cell
+
+    def _create_source_cell(self, cell):
+        grade_id = cell.metadata.nbgrader['grade_id']
+
+        try:
+            source_cell = self.gradebook.find_source_cell(grade_id, self.notebook_id, self.assignment_id).to_dict()
+            del source_cell['name']
+            del source_cell['notebook']
+            del source_cell['assignment']
+        except MissingEntry:
+            source_cell = {}
+
+        source_cell.update({
+            'cell_type': cell.cell_type,
+            'locked': utils.is_locked(cell),
+            'source': cell.source,
+            'checksum': cell.metadata.nbgrader.get('checksum', None)
+        })
+
+        self.new_source_cells[grade_id] = source_cell
+
     def preprocess_cell(self, cell, resources, cell_index):
         if utils.is_grade(cell):
-            max_score = float(cell.metadata.nbgrader['points'])
-            cell_type = cell.cell_type
-
-            grade_cell = self.gradebook.update_or_create_grade_cell(
-                cell.metadata.nbgrader['grade_id'],
-                self.notebook_id,
-                self.assignment_id,
-                max_score=max_score,
-                cell_type=cell_type)
-
-            self.log.debug("Recorded grade cell %s into database", grade_cell)
+            self._create_grade_cell(cell)
 
         if utils.is_solution(cell):
-            solution_cell = self.gradebook.update_or_create_solution_cell(
-                cell.metadata.nbgrader['grade_id'],
-                self.notebook_id,
-                self.assignment_id)
-
-            self.log.debug("Recorded solution cell %s into database", solution_cell)
+            self._create_solution_cell(cell)
 
         if utils.is_grade(cell) or utils.is_solution(cell) or utils.is_locked(cell):
-            cell_type = cell.cell_type
-            locked = utils.is_locked(cell)
-            source = cell.source
-            checksum = cell.metadata.nbgrader.get('checksum', None)
-
-            source_cell = self.gradebook.update_or_create_source_cell(
-                cell.metadata.nbgrader['grade_id'],
-                self.notebook_id,
-                self.assignment_id,
-                cell_type=cell_type,
-                locked=locked,
-                source=source,
-                checksum=checksum)
-
-            self.log.debug("Recorded source cell %s into database", source_cell)
+            self._create_source_cell(cell)
 
         return cell, resources

--- a/nbgrader/tests/apps/test_nbgrader_assign.py
+++ b/nbgrader/tests/apps/test_nbgrader_assign.py
@@ -123,3 +123,80 @@ class TestNbGraderAssign(BaseTestApp):
         assert os.path.isfile("release/ps1/foo.txt")
         assert self._get_permissions("release/ps1/foo.ipynb") == "666"
         assert self._get_permissions("release/ps1/foo.txt") == "666"
+
+    def test_remove_extra_notebooks(self, db):
+        """Are extra notebooks removed?"""
+        gb = Gradebook(db)
+        assignment = gb.add_assignment("ps1")
+
+        self._copy_file("files/test.ipynb", "source/ps1/test.ipynb")
+        run_command('nbgrader assign ps1 --db="{}"'.format(db))
+
+        gb.db.refresh(assignment)
+        assert len(assignment.notebooks) == 1
+
+        self._copy_file("files/test.ipynb", "source/ps1/test2.ipynb")
+        run_command('nbgrader assign ps1 --db="{}" --force'.format(db))
+
+        gb.db.refresh(assignment)
+        assert len(assignment.notebooks) == 2
+
+        os.remove("source/ps1/test2.ipynb")
+        run_command('nbgrader assign ps1 --db="{}" --force'.format(db))
+
+        gb.db.refresh(assignment)
+        assert len(assignment.notebooks) == 1
+
+    def test_add_extra_notebooks_with_submissions(self, db):
+        """Is an error thrown when new notebooks are added and there are existing submissions?"""
+        gb = Gradebook(db)
+        assignment = gb.add_assignment("ps1")
+
+        self._copy_file("files/test.ipynb", "source/ps1/test.ipynb")
+        run_command('nbgrader assign ps1 --db="{}"'.format(db))
+
+        gb.db.refresh(assignment)
+        assert len(assignment.notebooks) == 1
+
+        gb.add_student("hacker123")
+        gb.add_submission("ps1", "hacker123")
+
+        self._copy_file("files/test.ipynb", "source/ps1/test2.ipynb")
+        run_command('nbgrader assign ps1 --db="{}" --force'.format(db), retcode=1)
+
+    def test_remove_extra_notebooks_with_submissions(self, db):
+        """Is an error thrown when notebooks are removed and there are existing submissions?"""
+        gb = Gradebook(db)
+        assignment = gb.add_assignment("ps1")
+
+        self._copy_file("files/test.ipynb", "source/ps1/test.ipynb")
+        self._copy_file("files/test.ipynb", "source/ps1/test2.ipynb")
+        run_command('nbgrader assign ps1 --db="{}"'.format(db))
+
+        gb.db.refresh(assignment)
+        assert len(assignment.notebooks) == 2
+
+        gb.add_student("hacker123")
+        gb.add_submission("ps1", "hacker123")
+
+        os.remove("source/ps1/test2.ipynb")
+        run_command('nbgrader assign ps1 --db="{}" --force'.format(db), retcode=1)
+
+    def test_same_notebooks_with_submissions(self, db):
+        """Is an error thrown when new notebooks are added and there are existing submissions?"""
+        gb = Gradebook(db)
+        assignment = gb.add_assignment("ps1")
+
+        self._copy_file("files/test.ipynb", "source/ps1/test.ipynb")
+        run_command('nbgrader assign ps1 --db="{}"'.format(db))
+
+        gb.db.refresh(assignment)
+        assert len(assignment.notebooks) == 1
+
+        gb.add_student("hacker123")
+        gb.add_submission("ps1", "hacker123")
+
+        run_command('nbgrader assign ps1 --db="{}" --force'.format(db))
+
+        gb.db.refresh(assignment)
+        assert len(assignment.notebooks) == 1

--- a/nbgrader/tests/preprocessors/test_savecells.py
+++ b/nbgrader/tests/preprocessors/test_savecells.py
@@ -255,6 +255,7 @@ class TestSaveCells(BaseTestPreprocessor):
         nb, resources = preprocessor.preprocess(nb, resources)
 
         gb = preprocessor.gradebook
+        notebook = gb.find_notebook("test", "ps0")
         grade_cell = gb.find_grade_cell("foo", "test", "ps0")
         solution_cell = gb.find_solution_cell("foo", "test", "ps0")
         source_cell = gb.find_source_cell("foo", "test", "ps0")
@@ -264,6 +265,7 @@ class TestSaveCells(BaseTestPreprocessor):
         nb.cells[-1] = create_grade_and_solution_cell("goodbye", "markdown", "foo", 1)
         nb, resources = preprocessor.preprocess(nb, resources)
 
+        gb.db.refresh(notebook)
         gb.db.refresh(grade_cell)
         gb.db.refresh(solution_cell)
         gb.db.refresh(source_cell)
@@ -276,6 +278,7 @@ class TestSaveCells(BaseTestPreprocessor):
         nb, resources = preprocessor.preprocess(nb, resources)
 
         gb = preprocessor.gradebook
+        notebook = gb.find_notebook("test", "ps0")
         grade_cell = gb.find_grade_cell("foo", "test", "ps0")
         solution_cell = gb.find_solution_cell("foo", "test", "ps0")
         source_cell = gb.find_source_cell("foo", "test", "ps0")
@@ -283,12 +286,17 @@ class TestSaveCells(BaseTestPreprocessor):
         assert source_cell.source == "hello"
 
         gb.add_student("hacker123")
-        gb.add_submission("ps0", "hacker123")
+        submission = gb.add_submission("ps0", "hacker123").notebooks[0]
+        assert len(notebook.submissions) == 1
+
         nb.cells[-1] = create_grade_and_solution_cell("goodbye", "markdown", "foo", 1)
         nb, resources = preprocessor.preprocess(nb, resources)
 
+        gb.db.refresh(notebook)
+        gb.db.refresh(submission)
         gb.db.refresh(grade_cell)
         gb.db.refresh(solution_cell)
         gb.db.refresh(source_cell)
+        assert len(notebook.submissions) == 1
         assert grade_cell.max_score == 1
         assert source_cell.source == "goodbye"

--- a/nbgrader/tests/preprocessors/test_savecells.py
+++ b/nbgrader/tests/preprocessors/test_savecells.py
@@ -160,3 +160,135 @@ class TestSaveCells(BaseTestPreprocessor):
         assert source_cell.checksum == cell.metadata.nbgrader["checksum"]
         assert source_cell.cell_type == "markdown"
         assert source_cell.locked
+
+    def test_save_new_cell(self, preprocessor, resources):
+        cell1 = create_grade_and_solution_cell("hello", "markdown", "foo", 2)
+        cell2 = create_grade_and_solution_cell("hello", "markdown", "bar", 1)
+
+        nb = new_notebook()
+        nb.cells.append(cell1)
+        nb, resources = preprocessor.preprocess(nb, resources)
+
+        gb = preprocessor.gradebook
+        notebook = gb.find_notebook("test", "ps0")
+        assert len(notebook.grade_cells) == 1
+        assert len(notebook.solution_cells) == 1
+        assert len(notebook.source_cells) == 1
+
+        nb.cells.append(cell2)
+        nb, resources = preprocessor.preprocess(nb, resources)
+
+        gb.db.refresh(notebook)
+        assert len(notebook.grade_cells) == 2
+        assert len(notebook.solution_cells) == 2
+        assert len(notebook.source_cells) == 2
+
+    def test_save_new_cell_with_submissions(self, preprocessor, resources):
+        cell1 = create_grade_and_solution_cell("hello", "markdown", "foo", 2)
+        cell2 = create_grade_and_solution_cell("hello", "markdown", "bar", 1)
+
+        nb = new_notebook()
+        nb.cells.append(cell1)
+        nb, resources = preprocessor.preprocess(nb, resources)
+
+        gb = preprocessor.gradebook
+        notebook = gb.find_notebook("test", "ps0")
+        assert len(notebook.grade_cells) == 1
+        assert len(notebook.solution_cells) == 1
+        assert len(notebook.source_cells) == 1
+
+        gb.add_student("hacker123")
+        gb.add_submission("ps0", "hacker123")
+        nb.cells.append(cell2)
+
+        with pytest.raises(RuntimeError):
+            nb, resources = preprocessor.preprocess(nb, resources)
+
+    def test_remove_cell(self, preprocessor, resources):
+        cell1 = create_grade_and_solution_cell("hello", "markdown", "foo", 2)
+        cell2 = create_grade_and_solution_cell("hello", "markdown", "bar", 1)
+
+        nb = new_notebook()
+        nb.cells.append(cell1)
+        nb.cells.append(cell2)
+        nb, resources = preprocessor.preprocess(nb, resources)
+
+        gb = preprocessor.gradebook
+        notebook = gb.find_notebook("test", "ps0")
+        assert len(notebook.grade_cells) == 2
+        assert len(notebook.solution_cells) == 2
+        assert len(notebook.source_cells) == 2
+
+        nb.cells = nb.cells[:-1]
+        nb, resources = preprocessor.preprocess(nb, resources)
+
+        gb.db.refresh(notebook)
+        assert len(notebook.grade_cells) == 1
+        assert len(notebook.solution_cells) == 1
+        assert len(notebook.source_cells) == 1
+
+    def test_remove_cell_with_submissions(self, preprocessor, resources):
+        cell1 = create_grade_and_solution_cell("hello", "markdown", "foo", 2)
+        cell2 = create_grade_and_solution_cell("hello", "markdown", "bar", 1)
+
+        nb = new_notebook()
+        nb.cells.append(cell1)
+        nb.cells.append(cell2)
+        nb, resources = preprocessor.preprocess(nb, resources)
+
+        gb = preprocessor.gradebook
+        notebook = gb.find_notebook("test", "ps0")
+        assert len(notebook.grade_cells) == 2
+        assert len(notebook.solution_cells) == 2
+        assert len(notebook.source_cells) == 2
+
+        gb.add_student("hacker123")
+        gb.add_submission("ps0", "hacker123")
+        nb.cells = nb.cells[:-1]
+
+        with pytest.raises(RuntimeError):
+            nb, resources = preprocessor.preprocess(nb, resources)
+
+    def test_modify_cell(self, preprocessor, resources):
+        nb = new_notebook()
+        nb.cells.append(create_grade_and_solution_cell("hello", "markdown", "foo", 2))
+        nb, resources = preprocessor.preprocess(nb, resources)
+
+        gb = preprocessor.gradebook
+        grade_cell = gb.find_grade_cell("foo", "test", "ps0")
+        solution_cell = gb.find_solution_cell("foo", "test", "ps0")
+        source_cell = gb.find_source_cell("foo", "test", "ps0")
+        assert grade_cell.max_score == 2
+        assert source_cell.source == "hello"
+
+        nb.cells[-1] = create_grade_and_solution_cell("goodbye", "markdown", "foo", 1)
+        nb, resources = preprocessor.preprocess(nb, resources)
+
+        gb.db.refresh(grade_cell)
+        gb.db.refresh(solution_cell)
+        gb.db.refresh(source_cell)
+        assert grade_cell.max_score == 1
+        assert source_cell.source == "goodbye"
+
+    def test_modify_cell_with_submissions(self, preprocessor, resources):
+        nb = new_notebook()
+        nb.cells.append(create_grade_and_solution_cell("hello", "markdown", "foo", 2))
+        nb, resources = preprocessor.preprocess(nb, resources)
+
+        gb = preprocessor.gradebook
+        grade_cell = gb.find_grade_cell("foo", "test", "ps0")
+        solution_cell = gb.find_solution_cell("foo", "test", "ps0")
+        source_cell = gb.find_source_cell("foo", "test", "ps0")
+        assert grade_cell.max_score == 2
+        assert source_cell.source == "hello"
+
+        gb.add_student("hacker123")
+        gb.add_submission("ps0", "hacker123")
+        nb.cells[-1] = create_grade_and_solution_cell("goodbye", "markdown", "foo", 1)
+        nb, resources = preprocessor.preprocess(nb, resources)
+
+        gb.db.refresh(grade_cell)
+        gb.db.refresh(solution_cell)
+        gb.db.refresh(source_cell)
+        assert grade_cell.max_score == 1
+        assert source_cell.source == "goodbye"

--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -75,6 +75,8 @@ def compute_checksum(cell):
 
 def parse_utc(ts):
     """Parses a timestamp into datetime format, converting it to UTC if necessary."""
+    if ts is None:
+        return None
     if isinstance(ts, string_types):
         ts = dateutil.parser.parse(ts)
     if ts.tzinfo is not None:


### PR DESCRIPTION
Fixes #208

This will remove information in the database about old notebooks and cells when running `nbgrader assign`, so that if you rerun it you don't end up with some assignments having cells or notebooks associated with them that no longer exist.

The one exception is if there are submissions associated with the assignment already. If this is the case, an error will be thrown if anything is added or removed. Existing cell contents/metadata can be changed, however.