### PR TITLE
Fixing installation requirements and documentation.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,18 @@ This document gives an overview of how various parts of the project work and wha
 
 In general, the guidelines for opening issues, submitting PRs, code style, etc. are the same as the [IPython contribution guidelines](https://github.com/ipython/ipython/blob/master/CONTRIBUTING.md).
 
+## Preliminary IPython installation
+
+Before installing the other dependencies of nbgrader, please ensure that IPython Notebooks are properly installed.
+
+If using conda, run
+
+    conda install ipython-notebook
+
+Otherwise, run
+
+    pip install ipython[notebook]
+
 ## Development installation
 
 To develop and test nbgrader, you will want to install nbgrader using the development requirements:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ipython[all]==3.2
+ipython==3.2
 sqlalchemy
 Flask
 python-dateutil

--- a/tasks.py
+++ b/tasks.py
@@ -318,6 +318,9 @@ def before_install(group, python_version):
     run('git clone --quiet --depth 1 https://github.com/minrk/travis-wheels ~/travis-wheels')
     run('pip install -f ~/travis-wheels/wheelhouse -r dev-requirements.txt')
 
+    # install ipython
+    run('pip install ipython[all]')
+
     # install jupyterhub
     if python_version == '3.4' and group == 'js':
         os.chdir(os.environ['HOME'])


### PR DESCRIPTION
Because conda does not preserve package information using ipython[notebook],
developers will need to install ipython notebook separately from other
requirements