### PR TITLE
Fix subprocess handling in tests

### DIFF
--- a/nbgrader/tests/__init__.py
+++ b/nbgrader/tests/__init__.py
@@ -103,10 +103,10 @@ def copy_coverage_files():
 
 
 def run_command(command, retcode=0):
-    proc = start_subprocess(command, shell=True, stdout=sp.PIPE, stderr=sp.STDOUT)
-    true_retcode = proc.wait()
+    proc = start_subprocess(command, stdout=sp.PIPE, stderr=sp.STDOUT)
     output = proc.communicate()[0].decode()
     output = output.replace("Coverage.py warning: No data was collected.\n", "")
+    true_retcode = proc.poll()
     if true_retcode != retcode:
         print(output)
         raise AssertionError(

--- a/nbgrader/tests/__init__.py
+++ b/nbgrader/tests/__init__.py
@@ -102,14 +102,18 @@ def copy_coverage_files():
             shutil.copyfile(filename, os.path.join(root, filename))
 
 
-def run_command(command, retcode=0):
+def run_command(command, retcode=0, coverage=True):
     proc = start_subprocess(command, stdout=sp.PIPE, stderr=sp.STDOUT)
     output = proc.communicate()[0].decode()
     output = output.replace("Coverage.py warning: No data was collected.\n", "")
+    print(output)
+
     true_retcode = proc.poll()
     if true_retcode != retcode:
-        print(output)
         raise AssertionError(
             "process returned an unexpected return code: {}".format(true_retcode))
-    copy_coverage_files()
+
+    if coverage:
+        copy_coverage_files()
+
     return output

--- a/nbgrader/tests/apps/test_nbgrader.py
+++ b/nbgrader/tests/apps/test_nbgrader.py
@@ -8,22 +8,22 @@ class TestNbGrader(BaseTestApp):
 
     def test_help(self):
         """Does the help display without error?"""
-        run_command("nbgrader --help-all")
+        run_command(["nbgrader", "--help-all"])
 
     def test_no_subapp(self):
         """Is the help displayed when no subapp is given?"""
-        run_command("nbgrader", retcode=1)
+        run_command(["nbgrader"], retcode=1)
 
     def test_generate_config(self):
         """Is the config file properly generated?"""
-        run_command("nbgrader --generate-config")
+        run_command(["nbgrader", "--generate-config"])
         assert os.path.isfile("nbgrader_config.py")
 
         with open("nbgrader_config.py", "w") as fh:
             fh.write("foo")
 
-        run_command("nbgrader --generate-config", retcode=1)
-        run_command("nbgrader --generate-config --overwrite")
+        run_command(["nbgrader", "--generate-config"], retcode=1)
+        run_command(["nbgrader", "--generate-config", "--overwrite"])
 
         with open("nbgrader_config.py", "r") as fh:
             contents = fh.read()

--- a/nbgrader/tests/apps/test_nbgrader_assign.py
+++ b/nbgrader/tests/apps/test_nbgrader_assign.py
@@ -12,36 +12,36 @@ class TestNbGraderAssign(BaseTestApp):
 
     def test_help(self):
         """Does the help display without error?"""
-        run_command("nbgrader assign --help-all")
+        run_command(["nbgrader", "assign", "--help-all"])
 
     def test_no_args(self):
         """Is there an error if no arguments are given?"""
-        run_command("nbgrader assign", 1)
+        run_command(["nbgrader", "assign"], 1)
 
     def test_conflicting_args(self):
         """Is there an error if assignment is specified both in config and as an argument?"""
-        run_command("nbgrader assign --assignment=foo foo", 1)
+        run_command(["nbgrader", "assign", "--assignment", "foo", "foo"], 1)
 
     def test_multiple_args(self):
         """Is there an error if multiple arguments are given?"""
-        run_command("nbgrader assign foo bar", 1)
+        run_command(["nbgrader", "assign", "foo", "bar"], 1)
 
     def test_no_assignment(self):
         """Is an error thrown if the assignment doesn't exist?"""
         self._empty_notebook('source/ps1/foo.ipynb')
-        run_command("nbgrader assign ps1", 1)
+        run_command(["nbgrader", "assign", "ps1"], 1)
 
     def test_single_file(self):
         """Can a single file be assigned?"""
         self._empty_notebook('source/ps1/foo.ipynb')
-        run_command("nbgrader assign ps1 --create")
+        run_command(["nbgrader", "assign", "ps1", "--create"])
         assert os.path.isfile("release/ps1/foo.ipynb")
 
     def test_multiple_files(self):
         """Can multiple files be assigned?"""
         self._empty_notebook('source/ps1/foo.ipynb')
         self._empty_notebook('source/ps1/bar.ipynb')
-        run_command("nbgrader assign ps1 --create")
+        run_command(["nbgrader", "assign", "ps1", "--create"])
         assert os.path.isfile("release/ps1/foo.ipynb")
         assert os.path.isfile("release/ps1/bar.ipynb")
 
@@ -51,7 +51,7 @@ class TestNbGraderAssign(BaseTestApp):
         self._make_file('source/ps1/data/bar.csv', 'bar')
         self._empty_notebook('source/ps1/foo.ipynb')
         self._empty_notebook('source/ps1/bar.ipynb')
-        run_command("nbgrader assign ps1 --create")
+        run_command(["nbgrader", "assign", "ps1", "--create"])
 
         assert os.path.isfile("release/ps1/foo.ipynb")
         assert os.path.isfile("release/ps1/bar.ipynb")
@@ -70,7 +70,7 @@ class TestNbGraderAssign(BaseTestApp):
         gb = Gradebook(db)
         gb.add_assignment("ps1")
 
-        run_command('nbgrader assign ps1 --db="{}"'.format(db))
+        run_command(["nbgrader", "assign", "ps1", "--db", db])
 
         notebook = gb.find_notebook("test", "ps1")
         assert len(notebook.grade_cells) == 6
@@ -82,7 +82,7 @@ class TestNbGraderAssign(BaseTestApp):
         self._make_file("source/ps1/data/bar.txt", "bar")
         self._make_file("source/ps1/blah.pyc", "asdf")
 
-        run_command('nbgrader assign ps1 --create')
+        run_command(["nbgrader", "assign", "ps1", "--create"])
         assert os.path.isfile("release/ps1/test.ipynb")
         assert os.path.isfile("release/ps1/foo.txt")
         assert os.path.isfile("release/ps1/data/bar.txt")
@@ -90,16 +90,16 @@ class TestNbGraderAssign(BaseTestApp):
 
         # check that it skips the existing directory
         os.remove("release/ps1/foo.txt")
-        run_command('nbgrader assign ps1')
+        run_command(["nbgrader", "assign", "ps1"])
         assert not os.path.isfile("release/ps1/foo.txt")
 
         # force overwrite the supplemental files
-        run_command('nbgrader assign ps1 --force')
+        run_command(["nbgrader", "assign", "ps1", "--force"])
         assert os.path.isfile("release/ps1/foo.txt")
 
         # force overwrite
         os.remove("source/ps1/foo.txt")
-        run_command('nbgrader assign ps1 --force')
+        run_command(["nbgrader", "assign", "ps1", "--force"])
         assert os.path.isfile("release/ps1/test.ipynb")
         assert os.path.isfile("release/ps1/data/bar.txt")
         assert not os.path.isfile("release/ps1/foo.txt")
@@ -109,7 +109,7 @@ class TestNbGraderAssign(BaseTestApp):
         """Are permissions properly set?"""
         self._empty_notebook('source/ps1/foo.ipynb')
         self._make_file("source/ps1/foo.txt", "foo")
-        run_command("nbgrader assign ps1 --create")
+        run_command(["nbgrader", "assign", "ps1", "--create"])
 
         assert os.path.isfile("release/ps1/foo.ipynb")
         assert os.path.isfile("release/ps1/foo.txt")
@@ -120,7 +120,7 @@ class TestNbGraderAssign(BaseTestApp):
         """Are custom permissions properly set?"""
         self._empty_notebook('source/ps1/foo.ipynb')
         self._make_file("source/ps1/foo.txt", "foo")
-        run_command("nbgrader assign ps1 --create --AssignApp.permissions=666")
+        run_command(["nbgrader", "assign", "ps1", "--create", "--AssignApp.permissions=666"])
 
         assert os.path.isfile("release/ps1/foo.ipynb")
         assert os.path.isfile("release/ps1/foo.txt")
@@ -133,14 +133,14 @@ class TestNbGraderAssign(BaseTestApp):
         assignment = gb.add_assignment("ps1")
 
         self._copy_file("files/test.ipynb", "source/ps1/test.ipynb")
-        run_command('nbgrader assign ps1 --db="{}"'.format(db))
+        run_command(["nbgrader", "assign", "ps1", "--db", db])
 
         gb.db.refresh(assignment)
         assert len(assignment.notebooks) == 1
         notebook1 = gb.find_notebook("test", "ps1")
 
         self._copy_file("files/test.ipynb", "source/ps1/test2.ipynb")
-        run_command('nbgrader assign ps1 --db="{}" --force'.format(db))
+        run_command(["nbgrader", "assign", "ps1", "--db", db, "--force"])
 
         gb.db.refresh(assignment)
         assert len(assignment.notebooks) == 2
@@ -148,7 +148,7 @@ class TestNbGraderAssign(BaseTestApp):
         notebook2 = gb.find_notebook("test2", "ps1")
 
         os.remove("source/ps1/test2.ipynb")
-        run_command('nbgrader assign ps1 --db="{}" --force'.format(db))
+        run_command(["nbgrader", "assign", "ps1", "--db", db, "--force"])
 
         gb.db.refresh(assignment)
         assert len(assignment.notebooks) == 1
@@ -162,7 +162,7 @@ class TestNbGraderAssign(BaseTestApp):
         assignment = gb.add_assignment("ps1")
 
         self._copy_file("files/test.ipynb", "source/ps1/test.ipynb")
-        run_command('nbgrader assign ps1 --db="{}"'.format(db))
+        run_command(["nbgrader", "assign", "ps1", "--db", db])
 
         gb.db.refresh(assignment)
         assert len(assignment.notebooks) == 1
@@ -171,7 +171,7 @@ class TestNbGraderAssign(BaseTestApp):
         gb.add_submission("ps1", "hacker123")
 
         self._copy_file("files/test.ipynb", "source/ps1/test2.ipynb")
-        run_command('nbgrader assign ps1 --db="{}" --force'.format(db), retcode=1)
+        run_command(["nbgrader", "assign", "ps1", "--db", db, "--force"], retcode=1)
 
     def test_remove_extra_notebooks_with_submissions(self, db):
         """Is an error thrown when notebooks are removed and there are existing submissions?"""
@@ -180,7 +180,7 @@ class TestNbGraderAssign(BaseTestApp):
 
         self._copy_file("files/test.ipynb", "source/ps1/test.ipynb")
         self._copy_file("files/test.ipynb", "source/ps1/test2.ipynb")
-        run_command('nbgrader assign ps1 --db="{}"'.format(db))
+        run_command(["nbgrader", "assign", "ps1", "--db", db])
 
         gb.db.refresh(assignment)
         assert len(assignment.notebooks) == 2
@@ -189,7 +189,7 @@ class TestNbGraderAssign(BaseTestApp):
         gb.add_submission("ps1", "hacker123")
 
         os.remove("source/ps1/test2.ipynb")
-        run_command('nbgrader assign ps1 --db="{}" --force'.format(db), retcode=1)
+        run_command(["nbgrader", "assign", "ps1", "--db", db, "--force"], retcode=1)
 
     def test_same_notebooks_with_submissions(self, db):
         """Is it ok to run nbgrader assign with the same notebooks and existing submissions?"""
@@ -197,7 +197,7 @@ class TestNbGraderAssign(BaseTestApp):
         assignment = gb.add_assignment("ps1")
 
         self._copy_file("files/test.ipynb", "source/ps1/test.ipynb")
-        run_command('nbgrader assign ps1 --db="{}"'.format(db))
+        run_command(["nbgrader", "assign", "ps1", "--db", db])
 
         gb.db.refresh(assignment)
         assert len(assignment.notebooks) == 1
@@ -207,7 +207,7 @@ class TestNbGraderAssign(BaseTestApp):
         submission = gb.add_submission("ps1", "hacker123")
         submission_notebook = submission.notebooks[0]
 
-        run_command('nbgrader assign ps1 --db="{}" --force'.format(db))
+        run_command(["nbgrader", "assign", "ps1", "--db", db, "--force"])
 
         gb.db.refresh(assignment)
         assert len(assignment.notebooks) == 1

--- a/nbgrader/tests/apps/test_nbgrader_autograde.py
+++ b/nbgrader/tests/apps/test_nbgrader_autograde.py
@@ -9,42 +9,42 @@ class TestNbGraderAutograde(BaseTestApp):
 
     def test_help(self):
         """Does the help display without error?"""
-        run_command("nbgrader autograde --help-all")
+        run_command(["nbgrader", "autograde", "--help-all"])
 
     def test_missing_student(self, gradebook):
         """Is an error thrown when the student is missing?"""
         self._copy_file("files/submitted-changed.ipynb", "source/ps1/p1.ipynb")
-        run_command('nbgrader assign ps1 --db="{}" '.format(gradebook))
+        run_command(["nbgrader", "assign", "ps1", "--db", gradebook])
 
         self._copy_file("files/submitted-changed.ipynb", "submitted/baz/ps1/p1.ipynb")
-        run_command('nbgrader autograde ps1 --db="{}" '.format(gradebook), retcode=1)
+        run_command(["nbgrader", "autograde", "ps1", "--db", gradebook], retcode=1)
 
     def test_add_missing_student(self, gradebook):
         """Can a missing student be added?"""
         self._copy_file("files/submitted-changed.ipynb", "source/ps1/p1.ipynb")
-        run_command('nbgrader assign ps1 --db="{}" '.format(gradebook))
+        run_command(["nbgrader", "assign", "ps1", "--db", gradebook])
 
         self._copy_file("files/submitted-changed.ipynb", "submitted/baz/ps1/p1.ipynb")
-        run_command('nbgrader autograde ps1 --db="{}" --create'.format(gradebook))
+        run_command(["nbgrader", "autograde", "ps1", "--db", gradebook, "--create"])
 
         assert os.path.isfile("autograded/baz/ps1/p1.ipynb")
 
     def test_missing_assignment(self, gradebook):
         """Is an error thrown when the assignment is missing?"""
         self._copy_file("files/submitted-changed.ipynb", "source/ps1/p1.ipynb")
-        run_command('nbgrader assign ps1 --db="{}" '.format(gradebook))
+        run_command(["nbgrader", "assign", "ps1", "--db", gradebook])
 
         self._copy_file("files/submitted-changed.ipynb", "submitted/ps2/foo/p1.ipynb")
-        run_command('nbgrader autograde ps2 --db="{}" '.format(gradebook), retcode=1)
+        run_command(["nbgrader", "autograde", "ps2", "--db", gradebook], retcode=1)
 
     def test_grade(self, gradebook):
         """Can files be graded?"""
         self._copy_file("files/submitted-unchanged.ipynb", "source/ps1/p1.ipynb")
-        run_command('nbgrader assign ps1 --db="{}" '.format(gradebook))
+        run_command(["nbgrader", "assign", "ps1", "--db", gradebook])
 
         self._copy_file("files/submitted-unchanged.ipynb", "submitted/foo/ps1/p1.ipynb")
         self._copy_file("files/submitted-changed.ipynb", "submitted/bar/ps1/p1.ipynb")
-        run_command('nbgrader autograde ps1 --db="{}"'.format(gradebook))
+        run_command(["nbgrader", "autograde", "ps1", "--db", gradebook])
 
         assert os.path.isfile("autograded/foo/ps1/p1.ipynb")
         assert not os.path.isfile("autograded/foo/ps1/timestamp.txt")
@@ -78,7 +78,7 @@ class TestNbGraderAutograde(BaseTestApp):
     def test_grade_timestamp(self, gradebook):
         """Is a timestamp correctly read in?"""
         self._copy_file("files/submitted-unchanged.ipynb", "source/ps1/p1.ipynb")
-        run_command('nbgrader assign ps1 --db="{}" '.format(gradebook))
+        run_command(["nbgrader", "assign", "ps1", "--db", gradebook])
 
         self._copy_file("files/submitted-unchanged.ipynb", "submitted/foo/ps1/p1.ipynb")
         self._make_file('submitted/foo/ps1/timestamp.txt', "2015-02-02 15:58:23.948203 PST")
@@ -86,7 +86,7 @@ class TestNbGraderAutograde(BaseTestApp):
         self._copy_file("files/submitted-changed.ipynb", "submitted/bar/ps1/p1.ipynb")
         self._make_file('submitted/bar/ps1/timestamp.txt', "2015-02-01 14:58:23.948203 PST")
 
-        run_command('nbgrader autograde ps1 --db="{}"'.format(gradebook))
+        run_command(["nbgrader", "autograde", "ps1", "--db", gradebook])
 
         assert os.path.isfile("autograded/foo/ps1/p1.ipynb")
         assert os.path.isfile("autograded/foo/ps1/timestamp.txt")
@@ -100,20 +100,20 @@ class TestNbGraderAutograde(BaseTestApp):
         assert submission.total_seconds_late == 0
 
         # make sure it still works to run it a second time
-        run_command('nbgrader autograde ps1 --db="{}"'.format(gradebook))
+        run_command(["nbgrader", "autograde", "ps1", "--db", gradebook])
 
     def test_force(self, gradebook):
         """Ensure the force option works properly"""
         self._copy_file("files/submitted-unchanged.ipynb", "source/ps1/p1.ipynb")
         self._make_file("source/ps1/foo.txt", "foo")
         self._make_file("source/ps1/data/bar.txt", "bar")
-        run_command('nbgrader assign ps1 --db="{}" '.format(gradebook))
+        run_command(["nbgrader", "assign", "ps1", "--db", gradebook])
 
         self._copy_file("files/submitted-unchanged.ipynb", "submitted/foo/ps1/p1.ipynb")
         self._make_file("submitted/foo/ps1/foo.txt", "foo")
         self._make_file("submitted/foo/ps1/data/bar.txt", "bar")
         self._make_file("submitted/foo/ps1/blah.pyc", "asdf")
-        run_command('nbgrader autograde ps1 --db="{}"'.format(gradebook))
+        run_command(["nbgrader", "autograde", "ps1", "--db", gradebook])
 
         assert os.path.isfile("autograded/foo/ps1/p1.ipynb")
         assert os.path.isfile("autograded/foo/ps1/foo.txt")
@@ -122,17 +122,17 @@ class TestNbGraderAutograde(BaseTestApp):
 
         # check that it skips the existing directory
         os.remove("autograded/foo/ps1/foo.txt")
-        run_command('nbgrader autograde ps1 --db="{}"'.format(gradebook))
+        run_command(["nbgrader", "autograde", "ps1", "--db", gradebook])
         assert not os.path.isfile("autograded/foo/ps1/foo.txt")
 
         # force overwrite the supplemental files
-        run_command('nbgrader autograde ps1 --db="{}" --force'.format(gradebook))
+        run_command(["nbgrader", "autograde", "ps1", "--db", gradebook, "--force"])
         assert os.path.isfile("autograded/foo/ps1/foo.txt")
 
         # force overwrite
         os.remove("source/ps1/foo.txt")
         os.remove("submitted/foo/ps1/foo.txt")
-        run_command('nbgrader autograde ps1 --db="{}" --force'.format(gradebook))
+        run_command(["nbgrader", "autograde", "ps1", "--db", gradebook, "--force"])
         assert os.path.isfile("autograded/foo/ps1/p1.ipynb")
         assert not os.path.isfile("autograded/foo/ps1/foo.txt")
         assert os.path.isfile("autograded/foo/ps1/data/bar.txt")
@@ -143,13 +143,13 @@ class TestNbGraderAutograde(BaseTestApp):
         self._copy_file("files/submitted-unchanged.ipynb", "source/ps1/p1.ipynb")
         self._make_file("source/ps1/foo.txt", "foo")
         self._make_file("source/ps1/data/bar.txt", "bar")
-        run_command('nbgrader assign ps1 --db="{}" '.format(gradebook))
+        run_command(["nbgrader", "assign", "ps1", "--db", gradebook])
 
         self._copy_file("files/submitted-unchanged.ipynb", "submitted/foo/ps1/p1.ipynb")
         self._make_file("submitted/foo/ps1/foo.txt", "foo")
         self._make_file("submitted/foo/ps1/data/bar.txt", "bar")
         self._make_file("submitted/foo/ps1/blah.pyc", "asdf")
-        run_command('nbgrader autograde ps1 --db="{}" --notebook "p1"'.format(gradebook))
+        run_command(["nbgrader", "autograde", "ps1", "--db", gradebook, "--notebook", "p1"])
 
         assert os.path.isfile("autograded/foo/ps1/p1.ipynb")
         assert os.path.isfile("autograded/foo/ps1/foo.txt")
@@ -159,7 +159,7 @@ class TestNbGraderAutograde(BaseTestApp):
         # check that removing the notebook still causes the autograder to run
         os.remove("autograded/foo/ps1/p1.ipynb")
         os.remove("autograded/foo/ps1/foo.txt")
-        run_command('nbgrader autograde ps1 --db="{}" --notebook "p1"'.format(gradebook))
+        run_command(["nbgrader", "autograde", "ps1", "--db", gradebook, "--notebook", "p1"])
 
         assert os.path.isfile("autograded/foo/ps1/p1.ipynb")
         assert os.path.isfile("autograded/foo/ps1/foo.txt")
@@ -168,7 +168,7 @@ class TestNbGraderAutograde(BaseTestApp):
 
         # check that running it again doesn't do anything
         os.remove("autograded/foo/ps1/foo.txt")
-        run_command('nbgrader autograde ps1 --db="{}" --notebook "p1"'.format(gradebook))
+        run_command(["nbgrader", "autograde", "ps1", "--db", gradebook, "--notebook", "p1"])
 
         assert os.path.isfile("autograded/foo/ps1/p1.ipynb")
         assert not os.path.isfile("autograded/foo/ps1/foo.txt")
@@ -177,7 +177,7 @@ class TestNbGraderAutograde(BaseTestApp):
 
         # check that removing the notebook doesn't caus the autograder to run
         os.remove("autograded/foo/ps1/p1.ipynb")
-        run_command('nbgrader autograde ps1 --db="{}"'.format(gradebook))
+        run_command(["nbgrader", "autograde", "ps1", "--db", gradebook])
 
         assert not os.path.isfile("autograded/foo/ps1/p1.ipynb")
         assert not os.path.isfile("autograded/foo/ps1/foo.txt")
@@ -188,12 +188,12 @@ class TestNbGraderAutograde(BaseTestApp):
         """Are dependent files properly linked and overwritten?"""
         self._copy_file("files/submitted-unchanged.ipynb", "source/ps1/p1.ipynb")
         self._make_file("source/ps1/data.csv", "some,data\n")
-        run_command('nbgrader assign ps1 --db="{}" '.format(gradebook))
+        run_command(["nbgrader", "assign", "ps1", "--db", gradebook])
 
         self._copy_file("files/submitted-unchanged.ipynb", "submitted/foo/ps1/p1.ipynb")
         self._make_file('submitted/foo/ps1/timestamp.txt', "2015-02-02 15:58:23.948203 PST")
         self._make_file("submitted/foo/ps1/data.csv", "some,other,data\n")
-        run_command('nbgrader autograde ps1 --db="{}"'.format(gradebook))
+        run_command(["nbgrader", "autograde", "ps1", "--db", gradebook])
 
         assert os.path.isfile("autograded/foo/ps1/p1.ipynb")
         assert os.path.isfile("autograded/foo/ps1/timestamp.txt")
@@ -209,21 +209,21 @@ class TestNbGraderAutograde(BaseTestApp):
 
     def test_side_effects(self, gradebook):
         self._copy_file("files/side-effects.ipynb", "source/ps1/p1.ipynb")
-        run_command('nbgrader assign ps1 --db="{}" '.format(gradebook))
+        run_command(["nbgrader", "assign", "ps1", "--db", gradebook])
 
         self._copy_file("files/side-effects.ipynb", "submitted/foo/ps1/p1.ipynb")
-        run_command('nbgrader autograde ps1 --db="{}"'.format(gradebook))
+        run_command(["nbgrader", "autograde", "ps1", "--db", gradebook])
 
         assert os.path.isfile("autograded/foo/ps1/side-effect.txt")
         assert not os.path.isfile("submitted/foo/ps1/side-effect.txt")
 
     def test_skip_extra_notebooks(self, gradebook):
         self._copy_file("files/submitted-unchanged.ipynb", "source/ps1/p1.ipynb")
-        run_command('nbgrader assign ps1 --db="{}" '.format(gradebook))
+        run_command(["nbgrader", "assign", "ps1", "--db", gradebook])
 
         self._copy_file("files/submitted-unchanged.ipynb", "submitted/foo/ps1/p1 copy.ipynb")
         self._copy_file("files/submitted-changed.ipynb", "submitted/foo/ps1/p1.ipynb")
-        run_command('nbgrader autograde ps1 --db="{}"'.format(gradebook))
+        run_command(["nbgrader", "autograde", "ps1", "--db", gradebook])
 
         assert os.path.isfile("autograded/foo/ps1/p1.ipynb")
         assert not os.path.isfile("autograded/foo/ps1/p1 copy.ipynb")
@@ -232,11 +232,11 @@ class TestNbGraderAutograde(BaseTestApp):
         """Are permissions properly set?"""
         self._empty_notebook('source/ps1/foo.ipynb')
         self._make_file("source/ps1/foo.txt", "foo")
-        run_command("nbgrader assign ps1 --create")
+        run_command(["nbgrader", "assign", "ps1", "--create"])
 
         self._empty_notebook('submitted/foo/ps1/foo.ipynb')
         self._make_file("source/foo/ps1/foo.txt", "foo")
-        run_command("nbgrader autograde ps1 --create")
+        run_command(["nbgrader", "autograde", "ps1", "--create"])
 
         assert os.path.isfile("autograded/foo/ps1/foo.ipynb")
         assert os.path.isfile("autograded/foo/ps1/foo.txt")
@@ -247,11 +247,11 @@ class TestNbGraderAutograde(BaseTestApp):
         """Are custom permissions properly set?"""
         self._empty_notebook('source/ps1/foo.ipynb')
         self._make_file("source/ps1/foo.txt", "foo")
-        run_command("nbgrader assign ps1 --create")
+        run_command(["nbgrader", "assign", "ps1", "--create"])
 
         self._empty_notebook('submitted/foo/ps1/foo.ipynb')
         self._make_file("source/foo/ps1/foo.txt", "foo")
-        run_command("nbgrader autograde ps1 --create --AutogradeApp.permissions=644")
+        run_command(["nbgrader", "autograde", "ps1", "--create", "--AutogradeApp.permissions=644"])
 
         assert os.path.isfile("autograded/foo/ps1/foo.ipynb")
         assert os.path.isfile("autograded/foo/ps1/foo.txt")

--- a/nbgrader/tests/apps/test_nbgrader_collect.py
+++ b/nbgrader/tests/apps/test_nbgrader_collect.py
@@ -9,27 +9,35 @@ class TestNbGraderCollect(BaseTestApp):
 
     def _release_and_fetch(self, assignment, exchange):
         self._copy_file("files/test.ipynb", "release/ps1/p1.ipynb")
-        run_command(
-            'nbgrader release {} '
-            '--NbGraderConfig.course_id=abc101 '
-            '--TransferApp.exchange_directory={} '.format(assignment, exchange))
-        run_command(
-            'nbgrader fetch {} --course abc101 '
-            '--TransferApp.exchange_directory={} '.format(assignment, exchange))
+        run_command([
+            'nbgrader', 'release', assignment,
+            '--NbGraderConfig.course_id=abc101',
+            '--TransferApp.exchange_directory={}'.format(exchange)
+        ])
+        run_command([
+            'nbgrader', 'fetch', assignment,
+            '--course', 'abc101',
+            '--TransferApp.exchange_directory={}'.format(exchange)
+        ])
 
     def _submit(self, assignment, exchange):
-        run_command(
-            'nbgrader submit {} --course abc101 '
-            '--TransferApp.exchange_directory={} '.format(assignment, exchange))
+        run_command([
+            'nbgrader', 'submit', assignment,
+            '--course', 'abc101',
+            '--TransferApp.exchange_directory={}'.format(exchange)
+        ])
 
-    def _collect(self, assignment, exchange, flags="", retcode=0):
-        print("Calling collect with assignment: " + assignment)
-        run_command(
-            'nbgrader collect {} '
-            '--NbGraderConfig.course_id=abc101 '
-            '--TransferApp.exchange_directory={} '
-            '{}'.format(assignment, exchange, flags),
-            retcode=retcode)
+    def _collect(self, assignment, exchange, flags=None, retcode=0):
+        cmd = [
+            'nbgrader', 'collect', assignment,
+            '--NbGraderConfig.course_id=abc101',
+            '--TransferApp.exchange_directory={}'.format(exchange)
+        ]
+
+        if flags is not None:
+            cmd.extend(flags)
+
+        run_command(cmd, retcode=retcode)
 
     def _read_timestamp(self, root):
         with open(os.path.join(root, "timestamp.txt"), "r") as fh:
@@ -38,7 +46,7 @@ class TestNbGraderCollect(BaseTestApp):
 
     def test_help(self):
         """Does the help display without error?"""
-        run_command("nbgrader collect --help-all")
+        run_command(["nbgrader", "collect", "--help-all"])
 
     def test_collect(self, exchange):
         self._release_and_fetch("ps1", exchange)
@@ -70,6 +78,6 @@ class TestNbGraderCollect(BaseTestApp):
         assert self._read_timestamp(root) == timestamp
 
         # collect again with --update
-        self._collect("ps1", exchange, "--update")
+        self._collect("ps1", exchange, ["--update"])
         assert self._read_timestamp(root) != timestamp
 

--- a/nbgrader/tests/apps/test_nbgrader_extension.py
+++ b/nbgrader/tests/apps/test_nbgrader_extension.py
@@ -23,13 +23,13 @@ class TestNbGraderExtension(BaseTestApp):
 
     def test_help(self):
         """Does the help display without error?"""
-        run_command("nbgrader extension --help-all")
-        run_command("nbgrader extension install --help-all")
-        run_command("nbgrader extension activate --help-all")
-        run_command("nbgrader extension deactivate --help-all")
+        run_command(["nbgrader", "extension", "--help-all"])
+        run_command(["nbgrader", "extension", "install", "--help-all"])
+        run_command(["nbgrader", "extension", "activate", "--help-all"])
+        run_command(["nbgrader", "extension", "deactivate", "--help-all"])
 
     def test_install_system(self, temp_dir):
-        run_command("nbgrader extension install --prefix={}".format(temp_dir))
+        run_command(["nbgrader", "extension", "install", "--prefix", temp_dir])
 
         # check the extension file were copied
         nbextension_dir = os.path.join(temp_dir, "share", "jupyter", "nbextensions", "nbgrader")
@@ -38,7 +38,7 @@ class TestNbGraderExtension(BaseTestApp):
 
     def test_install_user(self, temp_dir):
         nbextension_dir = os.path.join(temp_dir, "nbextensions")
-        run_command("nbgrader extension install --nbextensions={}".format(nbextension_dir))
+        run_command(["nbgrader", "extension", "install", "--nbextensions", nbextension_dir])
 
         # check the extension file were copied
         assert os.path.isfile(os.path.join(nbextension_dir, "nbgrader", "create_assignment.js"))
@@ -46,8 +46,8 @@ class TestNbGraderExtension(BaseTestApp):
 
     def test_activate(self, temp_dir):
         nbextension_dir = os.path.join(temp_dir, "nbextensions")
-        run_command("nbgrader extension install --nbextensions={}".format(nbextension_dir))
-        run_command("nbgrader extension activate --ipython-dir={}".format(temp_dir))
+        run_command(["nbgrader", "extension", "install", "--nbextensions", nbextension_dir])
+        run_command(["nbgrader", "extension", "activate", "--ipython-dir", temp_dir])
 
         # check the extension file were copied
         assert os.path.isfile(os.path.join(nbextension_dir, "nbgrader", "create_assignment.js"))
@@ -59,8 +59,8 @@ class TestNbGraderExtension(BaseTestApp):
 
     def test_activate_custom_profile(self, temp_dir):
         nbextension_dir = os.path.join(temp_dir, "nbextensions")
-        run_command("nbgrader extension install --nbextensions={}".format(nbextension_dir))
-        run_command("nbgrader extension activate --ipython-dir={} --profile=foo".format(temp_dir))
+        run_command(["nbgrader", "extension", "install", "--nbextensions", nbextension_dir])
+        run_command(["nbgrader", "extension", "activate", "--ipython-dir", temp_dir, "--profile", "foo"])
 
         # check the extension file were copied
         assert os.path.isfile(os.path.join(nbextension_dir, "nbgrader", "create_assignment.js"))
@@ -72,8 +72,8 @@ class TestNbGraderExtension(BaseTestApp):
 
     def test_deactivate(self, temp_dir):
         nbextension_dir = os.path.join(temp_dir, "nbextensions")
-        run_command("nbgrader extension install --nbextensions={}".format(nbextension_dir))
-        run_command("nbgrader extension activate --ipython-dir={}".format(temp_dir))
+        run_command(["nbgrader", "extension", "install", "--nbextensions", nbextension_dir])
+        run_command(["nbgrader", "extension", "activate", "--ipython-dir", temp_dir])
 
         # check the extension file were copied
         assert os.path.isfile(os.path.join(nbextension_dir, "nbgrader", "create_assignment.js"))
@@ -95,7 +95,7 @@ class TestNbGraderExtension(BaseTestApp):
 
         self._assert_is_activated(config_file, key=okey)
 
-        run_command("nbgrader extension deactivate --ipython-dir={}".format(temp_dir))
+        run_command(["nbgrader", "extension", "deactivate", "--ipython-dir", temp_dir])
 
         # check that it is deactivated
         self._assert_is_deactivated(config_file)

--- a/nbgrader/tests/apps/test_nbgrader_feedback.py
+++ b/nbgrader/tests/apps/test_nbgrader_feedback.py
@@ -8,16 +8,16 @@ class TestNbGraderFeedback(BaseTestApp):
 
     def test_help(self):
         """Does the help display without error?"""
-        run_command("nbgrader feedback --help-all")
+        run_command(["nbgrader", "feedback", "--help-all"])
 
     def test_single_file(self, gradebook):
         """Can feedback be generated for an unchanged assignment?"""
         self._copy_file("files/submitted-unchanged.ipynb", "source/ps1/p1.ipynb")
-        run_command('nbgrader assign ps1 --db="{}" '.format(gradebook))
+        run_command(["nbgrader", "assign", "ps1", "--db", gradebook])
 
         self._copy_file("files/submitted-unchanged.ipynb", "submitted/foo/ps1/p1.ipynb")
-        run_command('nbgrader autograde ps1 --db="{}" '.format(gradebook))
-        run_command('nbgrader feedback ps1 --db="{}" '.format(gradebook))
+        run_command(["nbgrader", "autograde", "ps1", "--db", gradebook])
+        run_command(["nbgrader", "feedback", "ps1", "--db", gradebook])
 
         assert os.path.exists('feedback/foo/ps1/p1.html')
 
@@ -26,15 +26,15 @@ class TestNbGraderFeedback(BaseTestApp):
         self._copy_file("files/submitted-unchanged.ipynb", "source/ps1/p1.ipynb")
         self._make_file("source/ps1/foo.txt", "foo")
         self._make_file("source/ps1/data/bar.txt", "bar")
-        run_command('nbgrader assign ps1 --db="{}" '.format(gradebook))
+        run_command(["nbgrader", "assign", "ps1", "--db", gradebook])
 
         self._copy_file("files/submitted-unchanged.ipynb", "submitted/foo/ps1/p1.ipynb")
         self._make_file("submitted/foo/ps1/foo.txt", "foo")
         self._make_file("submitted/foo/ps1/data/bar.txt", "bar")
-        run_command('nbgrader autograde ps1 --db="{}"'.format(gradebook))
+        run_command(["nbgrader", "autograde", "ps1", "--db", gradebook])
 
         self._make_file("autograded/foo/ps1/blah.pyc", "asdf")
-        run_command('nbgrader feedback ps1 --db="{}"'.format(gradebook))
+        run_command(["nbgrader", "feedback", "ps1", "--db", gradebook])
 
         assert os.path.isfile("feedback/foo/ps1/p1.html")
         assert os.path.isfile("feedback/foo/ps1/foo.txt")
@@ -43,16 +43,16 @@ class TestNbGraderFeedback(BaseTestApp):
 
         # check that it skips the existing directory
         os.remove("feedback/foo/ps1/foo.txt")
-        run_command('nbgrader feedback ps1 --db="{}"'.format(gradebook))
+        run_command(["nbgrader", "feedback", "ps1", "--db", gradebook])
         assert not os.path.isfile("feedback/foo/ps1/foo.txt")
 
         # force overwrite the supplemental files
-        run_command('nbgrader feedback ps1 --db="{}" --force'.format(gradebook))
+        run_command(["nbgrader", "feedback", "ps1", "--db", gradebook, "--force"])
         assert os.path.isfile("feedback/foo/ps1/foo.txt")
 
         # force overwrite
         os.remove("autograded/foo/ps1/foo.txt")
-        run_command('nbgrader feedback ps1 --db="{}" --force'.format(gradebook))
+        run_command(["nbgrader", "feedback", "ps1", "--db", gradebook, "--force"])
         assert os.path.isfile("feedback/foo/ps1/p1.html")
         assert not os.path.isfile("feedback/foo/ps1/foo.txt")
         assert os.path.isfile("feedback/foo/ps1/data/bar.txt")
@@ -63,14 +63,14 @@ class TestNbGraderFeedback(BaseTestApp):
         self._copy_file("files/submitted-unchanged.ipynb", "source/ps1/p1.ipynb")
         self._make_file("source/ps1/foo.txt", "foo")
         self._make_file("source/ps1/data/bar.txt", "bar")
-        run_command('nbgrader assign ps1 --db="{}" '.format(gradebook))
+        run_command(["nbgrader", "assign", "ps1", "--db", gradebook])
 
         self._copy_file("files/submitted-unchanged.ipynb", "submitted/foo/ps1/p1.ipynb")
         self._make_file("submitted/foo/ps1/foo.txt", "foo")
         self._make_file("submitted/foo/ps1/data/bar.txt", "bar")
         self._make_file("submitted/foo/ps1/blah.pyc", "asdf")
-        run_command('nbgrader autograde ps1 --db="{}"'.format(gradebook))
-        run_command('nbgrader feedback ps1 --db="{}" --notebook "p1"'.format(gradebook))
+        run_command(["nbgrader", "autograde", "ps1", "--db", gradebook])
+        run_command(["nbgrader", "feedback", "ps1", "--db", gradebook, "--notebook", "p1"])
 
         assert os.path.isfile("feedback/foo/ps1/p1.html")
         assert os.path.isfile("feedback/foo/ps1/foo.txt")
@@ -80,7 +80,7 @@ class TestNbGraderFeedback(BaseTestApp):
         # check that removing the notebook still causes it to run
         os.remove("feedback/foo/ps1/p1.html")
         os.remove("feedback/foo/ps1/foo.txt")
-        run_command('nbgrader feedback ps1 --db="{}" --notebook "p1"'.format(gradebook))
+        run_command(["nbgrader", "feedback", "ps1", "--db", gradebook, "--notebook", "p1"])
 
         assert os.path.isfile("feedback/foo/ps1/p1.html")
         assert os.path.isfile("feedback/foo/ps1/foo.txt")
@@ -89,7 +89,7 @@ class TestNbGraderFeedback(BaseTestApp):
 
         # check that running it again doesn't do anything
         os.remove("feedback/foo/ps1/foo.txt")
-        run_command('nbgrader feedback ps1 --db="{}" --notebook "p1"'.format(gradebook))
+        run_command(["nbgrader", "feedback", "ps1", "--db", gradebook, "--notebook", "p1"])
 
         assert os.path.isfile("feedback/foo/ps1/p1.html")
         assert not os.path.isfile("feedback/foo/ps1/foo.txt")
@@ -98,7 +98,7 @@ class TestNbGraderFeedback(BaseTestApp):
 
         # check that removing the notebook doesn't cause it to run
         os.remove("feedback/foo/ps1/p1.html")
-        run_command('nbgrader feedback ps1 --db="{}"'.format(gradebook))
+        run_command(["nbgrader", "feedback", "ps1", "--db", gradebook])
 
         assert not os.path.isfile("feedback/foo/ps1/p1.html")
         assert not os.path.isfile("feedback/foo/ps1/foo.txt")
@@ -108,11 +108,11 @@ class TestNbGraderFeedback(BaseTestApp):
     def test_permissions(self):
         """Are permissions properly set?"""
         self._empty_notebook('source/ps1/foo.ipynb')
-        run_command("nbgrader assign ps1 --create")
+        run_command(["nbgrader", "assign", "ps1", "--create"])
 
         self._empty_notebook('submitted/foo/ps1/foo.ipynb')
-        run_command("nbgrader autograde ps1 --create")
-        run_command("nbgrader feedback ps1")
+        run_command(["nbgrader", "autograde", "ps1", "--create"])
+        run_command(["nbgrader", "feedback", "ps1"])
 
         assert os.path.isfile("feedback/foo/ps1/foo.html")
         assert self._get_permissions("feedback/foo/ps1/foo.html") == "444"
@@ -120,11 +120,11 @@ class TestNbGraderFeedback(BaseTestApp):
     def test_custom_permissions(self):
         """Are custom permissions properly set?"""
         self._empty_notebook('source/ps1/foo.ipynb')
-        run_command("nbgrader assign ps1 --create")
+        run_command(["nbgrader", "assign", "ps1", "--create"])
 
         self._empty_notebook('submitted/foo/ps1/foo.ipynb')
-        run_command("nbgrader autograde ps1 --create")
-        run_command("nbgrader feedback ps1 --FeedbackApp.permissions=644")
+        run_command(["nbgrader", "autograde", "ps1", "--create"])
+        run_command(["nbgrader", "feedback", "ps1", "--FeedbackApp.permissions=644"])
 
         assert os.path.isfile("feedback/foo/ps1/foo.html")
         assert self._get_permissions("feedback/foo/ps1/foo.html") == "644"

--- a/nbgrader/tests/apps/test_nbgrader_fetch.py
+++ b/nbgrader/tests/apps/test_nbgrader_fetch.py
@@ -8,21 +8,27 @@ class TestNbGraderFetch(BaseTestApp):
 
     def _release(self, assignment, exchange):
         self._copy_file("files/test.ipynb", "release/ps1/p1.ipynb")
-        run_command(
-            'nbgrader release {} '
-            '--NbGraderConfig.course_id=abc101 '
-            '--TransferApp.exchange_directory={} '.format(assignment, exchange))
+        run_command([
+            "nbgrader", "release", assignment,
+            "--NbGraderConfig.course_id=abc101",
+            "--TransferApp.exchange_directory={}".format(exchange)
+        ])
 
-    def _fetch(self, assignment, exchange, flags="", retcode=0):
-        run_command(
-            'nbgrader fetch {} --course abc101  '
-            '--TransferApp.exchange_directory={} '
-            '{}'.format(assignment, exchange, flags),
-            retcode=retcode)
+    def _fetch(self, assignment, exchange, flags=None, retcode=0):
+        cmd = [
+            "nbgrader", "fetch", assignment,
+            "--course", "abc101",
+            "--TransferApp.exchange_directory={}".format(exchange)
+        ]
+
+        if flags is not None:
+            cmd.extend(flags)
+
+        run_command(cmd, retcode=retcode)
 
     def test_help(self):
         """Does the help display without error?"""
-        run_command("nbgrader fetch --help-all")
+        run_command(["nbgrader", "fetch", "--help-all"])
 
     def test_fetch(self, exchange):
         self._release("ps1", exchange)

--- a/nbgrader/tests/apps/test_nbgrader_release.py
+++ b/nbgrader/tests/apps/test_nbgrader_release.py
@@ -6,17 +6,21 @@ from nbgrader.tests.apps.base import BaseTestApp
 
 class TestNbGraderRelease(BaseTestApp):
 
-    def _release(self, assignment, exchange, flags="", retcode=0):
-        run_command(
-            'nbgrader release {} '
-            '--NbGraderConfig.course_id=abc101 '
-            '--TransferApp.exchange_directory={} '
-            '{}'.format(assignment, exchange, flags),
-            retcode=retcode)
+    def _release(self, assignment, exchange, flags=None, retcode=0):
+        cmd = [
+            "nbgrader", "release", assignment,
+            "--NbGraderConfig.course_id=abc101",
+            "--TransferApp.exchange_directory={}".format(exchange)
+        ]
+
+        if flags is not None:
+            cmd.extend(flags)
+
+        run_command(cmd, retcode=retcode)
 
     def test_help(self):
         """Does the help display without error?"""
-        run_command("nbgrader release --help-all")
+        run_command(["nbgrader", "release", "--help-all"])
 
     def test_release(self, exchange):
         self._copy_file("files/test.ipynb", "release/ps1/p1.ipynb")
@@ -33,5 +37,5 @@ class TestNbGraderRelease(BaseTestApp):
         os.remove(os.path.join(exchange, "abc101/outbound/ps1/p1.ipynb"))
         self._release("ps1", exchange, retcode=1)
 
-        self._release("ps1", exchange, flags='--force')
+        self._release("ps1", exchange, flags=['--force'])
         assert os.path.isfile(os.path.join(exchange, "abc101/outbound/ps1/p1.ipynb"))

--- a/nbgrader/tests/apps/test_nbgrader_submit.py
+++ b/nbgrader/tests/apps/test_nbgrader_submit.py
@@ -11,24 +11,32 @@ class TestNbGraderSubmit(BaseTestApp):
 
     def _release_and_fetch(self, assignment, exchange):
         self._copy_file("files/test.ipynb", "release/ps1/p1.ipynb")
-        run_command(
-            'nbgrader release {} '
-            '--NbGraderConfig.course_id=abc101 '
-            '--TransferApp.exchange_directory={} '.format(assignment, exchange))
-        run_command(
-            'nbgrader fetch {} --course abc101 '
-            '--TransferApp.exchange_directory={} '.format(assignment, exchange))
+        run_command([
+            "nbgrader", "release", assignment,
+            "--NbGraderConfig.course_id=abc101",
+            "--TransferApp.exchange_directory={}".format(exchange)
+        ])
+        run_command([
+            "nbgrader", "fetch", assignment,
+            "--course", "abc101",
+            "--TransferApp.exchange_directory={}".format(exchange)
+        ])
 
-    def _submit(self, assignment, exchange, flags="", retcode=0):
-        run_command(
-            'nbgrader submit {} --course abc101 '
-            '--TransferApp.exchange_directory={} '
-            '{}'.format(assignment, exchange, flags),
-            retcode=retcode)
+    def _submit(self, assignment, exchange, flags=None, retcode=0):
+        cmd = [
+            "nbgrader", "submit", assignment,
+            "--course", "abc101",
+            "--TransferApp.exchange_directory={}".format(exchange)
+        ]
+
+        if flags is not None:
+            cmd.extend(flags)
+
+        run_command(cmd, retcode=retcode)
 
     def test_help(self):
         """Does the help display without error?"""
-        run_command("nbgrader submit --help-all")
+        run_command(["nbgrader", "submit", "--help-all"])
 
     def test_submit(self, exchange):
         self._release_and_fetch("ps1", exchange)

--- a/nbgrader/tests/apps/test_nbgrader_validate.py
+++ b/nbgrader/tests/apps/test_nbgrader_validate.py
@@ -6,94 +6,99 @@ class TestNbGraderValidate(BaseTestApp):
 
     def test_help(self):
         """Does the help display without error?"""
-        run_command("nbgrader validate --help-all")
+        run_command(["nbgrader", "validate", "--help-all"])
 
     def test_validate_unchanged(self):
         """Does the validation fail on an unchanged notebook?"""
         self._copy_file("files/submitted-unchanged.ipynb", "submitted-unchanged.ipynb")
-        output = run_command('nbgrader validate submitted-unchanged.ipynb')
+        output = run_command(["nbgrader", "validate", "submitted-unchanged.ipynb"])
         assert output.split("\n")[0] == "VALIDATION FAILED ON 3 CELL(S)! If you submit your assignment as it is, you WILL NOT"
 
     def test_validate_changed(self):
         """Does the validation pass on an changed notebook?"""
         self._copy_file("files/submitted-changed.ipynb", "submitted-changed.ipynb")
-        output = run_command('nbgrader validate submitted-changed.ipynb')
+        output = run_command(["nbgrader", "validate", "submitted-changed.ipynb"])
         assert output == "Success! Your notebook passes all the tests.\n"
 
     def test_invert_validate_unchanged(self):
         """Does the inverted validation pass on an unchanged notebook?"""
         self._copy_file("files/submitted-unchanged.ipynb", "submitted-unchanged.ipynb")
-        output = run_command('nbgrader validate submitted-unchanged.ipynb --invert')
+        output = run_command(["nbgrader", "validate", "submitted-unchanged.ipynb", "--invert"])
         assert output.split("\n")[0] == "NOTEBOOK PASSED ON 1 CELL(S)!"
 
     def test_invert_validate_changed(self):
         """Does the inverted validation fail on a changed notebook?"""
         self._copy_file("files/submitted-changed.ipynb", "submitted-changed.ipynb")
-        output = run_command('nbgrader validate submitted-changed.ipynb --invert')
+        output = run_command(["nbgrader", "validate", "submitted-changed.ipynb", "--invert"])
         assert output.split("\n")[0] == "NOTEBOOK PASSED ON 2 CELL(S)!"
 
     def test_grade_cell_changed(self):
         """Does the validate fail if a grade cell has changed?"""
         self._copy_file("files/submitted-grade-cell-changed.ipynb", "submitted-grade-cell-changed.ipynb")
-        output = run_command('nbgrader validate submitted-grade-cell-changed.ipynb')
+        output = run_command(["nbgrader", "validate", "submitted-grade-cell-changed.ipynb"])
         assert output.split("\n")[0] == "THE CONTENTS OF 1 TEST CELL(S) HAVE CHANGED! This might mean that even though the tests"
 
     def test_grade_cell_changed_ignore_checksums(self):
         """Does the validate pass if a grade cell has changed but we're ignoring checksums?"""
         self._copy_file("files/submitted-grade-cell-changed.ipynb", "submitted-grade-cell-changed.ipynb")
-        output = run_command(
-            'nbgrader validate submitted-grade-cell-changed.ipynb '
-            '--DisplayAutoGrades.ignore_checksums=True')
+        output = run_command([
+            "nbgrader", "validate", "submitted-grade-cell-changed.ipynb",
+            "--DisplayAutoGrades.ignore_checksums=True"
+        ])
         assert output.split("\n")[0] == "Success! Your notebook passes all the tests."
 
     def test_invert_grade_cell_changed(self):
         """Does the validate fail if a grade cell has changed, even with --invert?"""
         self._copy_file("files/submitted-grade-cell-changed.ipynb", "submitted-grade-cell-changed.ipynb")
-        output = run_command('nbgrader validate submitted-grade-cell-changed.ipynb --invert')
+        output = run_command(["nbgrader", "validate", "submitted-grade-cell-changed.ipynb", "--invert"])
         assert output.split("\n")[0] == "THE CONTENTS OF 1 TEST CELL(S) HAVE CHANGED! This might mean that even though the tests"
 
     def test_invert_grade_cell_changed_ignore_checksums(self):
         """Does the validate fail if a grade cell has changed with --invert and ignoring checksums?"""
         self._copy_file("files/submitted-grade-cell-changed.ipynb", "submitted-grade-cell-changed.ipynb")
-        output = run_command(
-            'nbgrader validate submitted-grade-cell-changed.ipynb '
-            '--invert '
-            '--DisplayAutoGrades.ignore_checksums=True')
+        output = run_command([
+            "nbgrader", "validate", "submitted-grade-cell-changed.ipynb",
+            "--invert",
+            "--DisplayAutoGrades.ignore_checksums=True"
+        ])
         assert output.split("\n")[0] == "NOTEBOOK PASSED ON 2 CELL(S)!"
 
     def test_validate_unchanged_ignore_checksums(self):
         """Does the validation fail on an unchanged notebook with ignoring checksums?"""
         self._copy_file("files/submitted-unchanged.ipynb", "submitted-unchanged.ipynb")
-        output = run_command(
-            'nbgrader validate submitted-unchanged.ipynb '
-            '--DisplayAutoGrades.ignore_checksums=True')
+        output = run_command([
+            "nbgrader", "validate", "submitted-unchanged.ipynb",
+            "--DisplayAutoGrades.ignore_checksums=True"
+        ])
         assert output.split("\n")[0] == "VALIDATION FAILED ON 1 CELL(S)! If you submit your assignment as it is, you WILL NOT"
 
     def test_locked_cell_changed(self):
         """Does the validate fail if a locked cell has changed?"""
         self._copy_file("files/submitted-locked-cell-changed.ipynb", "submitted-locked-cell-changed.ipynb")
-        output = run_command('nbgrader validate submitted-locked-cell-changed.ipynb')
+        output = run_command(["nbgrader", "validate", "submitted-locked-cell-changed.ipynb"])
         assert output.split("\n")[0] == "THE CONTENTS OF 2 TEST CELL(S) HAVE CHANGED! This might mean that even though the tests"
 
     def test_locked_cell_changed_ignore_checksums(self):
         """Does the validate pass if a locked cell has changed but we're ignoring checksums?"""
         self._copy_file("files/submitted-locked-cell-changed.ipynb", "submitted-locked-cell-changed.ipynb")
-        output = run_command(
-            'nbgrader validate submitted-locked-cell-changed.ipynb '
-            '--DisplayAutoGrades.ignore_checksums=True')
+        output = run_command([
+            "nbgrader", "validate", "submitted-locked-cell-changed.ipynb",
+            "--DisplayAutoGrades.ignore_checksums=True"
+        ])
         assert output.split("\n")[0] == "VALIDATION FAILED ON 1 CELL(S)! If you submit your assignment as it is, you WILL NOT"
 
     def test_invert_locked_cell_changed(self):
         """Does the validate fail if a locked cell has changed, even with --invert?"""
         self._copy_file("files/submitted-locked-cell-changed.ipynb", "submitted-locked-cell-changed.ipynb")
-        output = run_command('nbgrader validate submitted-locked-cell-changed.ipynb --invert')
+        output = run_command(["nbgrader", "validate", "submitted-locked-cell-changed.ipynb", "--invert"])
         assert output.split("\n")[0] == "THE CONTENTS OF 2 TEST CELL(S) HAVE CHANGED! This might mean that even though the tests"
 
     def test_invert_locked_cell_changed_ignore_checksums(self):
         """Does the validate fail if a locked cell has changed with --invert and ignoring checksums?"""
         self._copy_file("files/submitted-locked-cell-changed.ipynb", "submitted-locked-cell-changed.ipynb")
-        output = run_command(
-            'nbgrader validate submitted-locked-cell-changed.ipynb '
-            '--invert '
-            '--DisplayAutoGrades.ignore_checksums=True')
+        output = run_command([
+            "nbgrader", "validate", "submitted-locked-cell-changed.ipynb",
+            "--invert",
+            "--DisplayAutoGrades.ignore_checksums=True"
+        ])
         assert output.split("\n")[0] == "NOTEBOOK PASSED ON 1 CELL(S)!"

--- a/nbgrader/tests/formgrader/conftest.py
+++ b/nbgrader/tests/formgrader/conftest.py
@@ -49,12 +49,13 @@ def gradebook(request, tempdir):
     gb.add_student("Reasoner", first_name="Louis", last_name="R")
 
     # run nbgrader assign
-    run_command(
-        'nbgrader assign "Problem Set 1" '
-        '--IncludeHeaderFooter.header=source/header.ipynb')
+    run_command([
+        "nbgrader", "assign", "Problem Set 1",
+        "--IncludeHeaderFooter.header=source/header.ipynb"
+    ])
 
     # run the autograder
-    run_command('nbgrader autograde "Problem Set 1"')
+    run_command(["nbgrader", "autograde", "Problem Set 1"])
 
     def fin():
         os.chdir(origdir)

--- a/nbgrader/tests/formgrader/test_nbgrader_formgrade.py
+++ b/nbgrader/tests/formgrader/test_nbgrader_formgrade.py
@@ -2,4 +2,4 @@ from nbgrader.tests import run_command
 
 
 def test_help():
-    run_command("nbgrader formgrade --help-all")
+    run_command(["nbgrader", "formgrade", "--help-all"])

--- a/nbgrader/tests/nbextensions/conftest.py
+++ b/nbgrader/tests/nbextensions/conftest.py
@@ -31,7 +31,7 @@ def ipythondir(request):
     ipythondir = tempfile.mkdtemp()
 
     # ensure IPython dir exists.
-    sp.call(['ipython', 'profile', 'create', '--ipython-dir', ipythondir])
+    run_command(['ipython', 'profile', 'create', '--ipython-dir', ipythondir])
 
     def fin():
         shutil.rmtree(ipythondir)
@@ -42,8 +42,8 @@ def ipythondir(request):
 
 @pytest.fixture(scope="module")
 def nbserver(request, tempdir, ipythondir):
-    run_command("nbgrader extension install --nbextensions={}".format(os.path.join(ipythondir, "nbextensions")))
-    run_command("nbgrader extension activate --ipython-dir={}".format(ipythondir))
+    run_command(["nbgrader", "extension", "install", "--nbextensions", os.path.join(ipythondir, "nbextensions")])
+    run_command(["nbgrader", "extension", "activate", "--ipython-dir", ipythondir])
 
     # bug in IPython cannot use --profile-dir
     # that does not set it for everything.
@@ -54,7 +54,8 @@ def nbserver(request, tempdir, ipythondir):
     nbserver = sp.Popen([
         "ipython", "notebook",
         "--no-browser",
-        "--port", "9000"], env=env)
+        "--port", "9000"],
+        env=env)
 
     def fin():
         nbserver.send_signal(15) # SIGTERM

--- a/nbgrader/tests/nbextensions/conftest.py
+++ b/nbgrader/tests/nbextensions/conftest.py
@@ -54,8 +54,7 @@ def nbserver(request, tempdir, ipythondir):
     nbserver = sp.Popen([
         "ipython", "notebook",
         "--no-browser",
-        "--port", "9000"],
-        env=env)
+        "--port", "9000"], env=env)
 
     def fin():
         nbserver.send_signal(15) # SIGTERM

--- a/tasks.py
+++ b/tasks.py
@@ -114,8 +114,7 @@ def _run_tests(mark=None, skip=None):
         '--cov nbgrader',
         '--no-cov-on-fail',
         '-v',
-        '-x',
-        '--capture=no'
+        '-x'
     ]
 
     marks = []


### PR DESCRIPTION
This modifies the tests so that when they call a subprocess, they never use `shell=True`. Additionally, this now uses `proc.communicate()` instead of `proc.wait()`, which should hopefully fix some deadlock issues that I think we've been having with the travis tests.