### PR TITLE
Fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If using conda, run
 
 Otherwise, run
 
-    pip install ipython[notebook]==3.2
+    pip install ipython[all]==3.2
 
 ### Installing nbgrader
 


### PR DESCRIPTION
People should install ipython[all], not ipython[notebook].