### PR TITLE
Require course id in transfer apps

### DIFF
--- a/nbgrader/apps/collectapp.py
+++ b/nbgrader/apps/collectapp.py
@@ -88,6 +88,9 @@ class CollectApp(TransferApp):
         return sorted(records, key=lambda item: item['timestamp'], reverse=True)
 
     def init_src(self):
+        if self.course_id == '':
+            self.fail("No course id specified. Re-run with --course flag.")
+
         self.course_path = os.path.join(self.exchange_directory, self.course_id)
         self.inbound_path = os.path.join(self.course_path, 'inbound')
         if not os.path.isdir(self.inbound_path):

--- a/nbgrader/apps/fetchapp.py
+++ b/nbgrader/apps/fetchapp.py
@@ -30,7 +30,7 @@ class FetchApp(TransferApp):
 
         To fetch an assignment by name into the current directory:
 
-            nbgrader list assignment1
+            nbgrader fetch assignment1
 
         To fetch an assignment for a specific course, you must first know the
         `course_id` for your course.  If you don't know it, ask your instructor.
@@ -44,6 +44,9 @@ class FetchApp(TransferApp):
         """
 
     def init_src(self):
+        if self.course_id == '':
+            self.fail("No course id specified. Re-run with --course flag.")
+
         self.course_path = os.path.join(self.exchange_directory, self.course_id)
         self.outbound_path = os.path.join(self.course_path, 'outbound')
         self.src_path = os.path.join(self.outbound_path, self.assignment_id)

--- a/nbgrader/apps/listapp.py
+++ b/nbgrader/apps/listapp.py
@@ -1,6 +1,7 @@
 import os
 import glob
 import shutil
+import re
 
 from IPython.utils.traitlets import Bool
 
@@ -63,12 +64,12 @@ class ListApp(TransferApp):
 
         To see the inbound (submitted) assignments:
 
-            nbgrader list --inbound phys101
+            nbgrader list --inbound
 
         You can use the `--student` and `--assignment` options to filter the list
         by student or assignment:
 
-            nbgrader list --inbound --student=student1 --assignment=assignment1 phys101
+            nbgrader list --inbound --student=student1 --assignment=assignment1
 
         If a student has submitted an assignment multiple times, the `list` command
         will show all submissions with their timestamps.
@@ -76,29 +77,48 @@ class ListApp(TransferApp):
         The `list` command can optionally remove listed assignments by providing the
         `--remove` flag:
 
-            nbgrader list --inbound --remove --student=student1 phys101
+            nbgrader list --inbound --remove --student=student1
         """
 
     inbound = Bool(False, config=True, help="List inbound files rather than outbound.")
-
     remove = Bool(False, config=True, help="Remove, rather than list files.")
 
     def init_src(self):
         pass
 
     def init_dest(self):
-        self.course_path = os.path.join(self.exchange_directory, self.course_id)
-        self.outbound_path = os.path.join(self.course_path, 'outbound')
-        self.inbound_path = os.path.join(self.course_path, 'inbound')
-
+        course_id = self.course_id if self.course_id else '*'
         assignment_id = self.assignment_id if self.assignment_id else '*'
+        student_id = self.student_id if self.student_id else '*'
+
         if self.inbound:
-            student_id = self.student_id if self.student_id else '*'
-            pattern = os.path.join(self.inbound_path, '{}+{}+*'.format(student_id, assignment_id))
+            pattern = os.path.join(self.exchange_directory, course_id, 'inbound', '{}+{}+*'.format(student_id, assignment_id))
         else:
-            pattern = os.path.join(self.outbound_path, assignment_id)
+            pattern = os.path.join(self.exchange_directory, course_id, 'outbound', '{}'.format(assignment_id))
 
         self.assignments = sorted(glob.glob(pattern))
+
+    def parse_inbound_assignment(self, assignment):
+        regexp = r".*/(?P<course_id>.*)/inbound/(?P<student_id>.*)\+(?P<assignment_id>.*)\+(?P<timestamp>.*)"
+        m = re.match(regexp, assignment)
+        if m is None:
+            raise RuntimeError("Could not match '%s' with regexp '%s'", assignment, regexp)
+        return m.groupdict()
+
+    def parse_outbound_assignment(self, assignment):
+        regexp = r".*/(?P<course_id>.*)/outbound/(?P<assignment_id>.*)"
+        m = re.match(regexp, assignment)
+        if m is None:
+            raise RuntimeError("Could not match '%s' with regexp '%s'", assignment, regexp)
+        return m.groupdict()
+
+    def format_inbound_assignment(self, assignment):
+        info = self.parse_inbound_assignment(assignment)
+        return "{course_id} {student_id} {assignment_id} {timestamp}".format(**info)
+
+    def format_outbound_assignment(self, assignment):
+        info = self.parse_outbound_assignment(assignment)
+        return "{course_id} {assignment_id}".format(**info)
 
     def copy_files(self):
         pass
@@ -108,29 +128,24 @@ class ListApp(TransferApp):
         if self.inbound:
             self.log.info("Submitted assignments:")
             for path in self.assignments:
-                username, assignment, timestamp = os.path.split(path)[1].rsplit('+',2)
-                self.log.info("{} {} {} {}".format(
-                    self.course_id, username, assignment, timestamp
-                ))
+                self.log.info(self.format_inbound_assignment(path))
+
         else:
             self.log.info("Released assignments:")
             for path in self.assignments:
-                self.log.info("{} {}".format(self.course_id, os.path.split(path)[1]))
+                self.log.info(self.format_outbound_assignment(path))
 
     def remove_files(self):
         """List and remove files."""
         if self.inbound:
             self.log.info("Removing submitted assignments:")
             for path in self.assignments:
-                username, assignment, timestamp = os.path.split(path)[1].rsplit('+',2)
-                self.log.info("{} {} {} {}".format(
-                    self.course_id, username, assignment, timestamp
-                ))
+                self.log.info(self.format_inbound_assignment(path))
                 shutil.rmtree(path)
         else:
             self.log.info("Removing released assignments:")
             for path in self.assignments:
-                self.log.info("{} {}".format(self.course_id, os.path.split(path)[1]))
+                self.log.info(self.format_outbound_assignment(path))
                 shutil.rmtree(path)
 
     def start(self):

--- a/nbgrader/apps/releaseapp.py
+++ b/nbgrader/apps/releaseapp.py
@@ -88,6 +88,9 @@ class ReleaseApp(TransferApp):
                 ))
 
     def init_dest(self):
+        if self.course_id == '':
+            self.fail("No course id specified. Re-run with --course flag.")
+
         self.course_path = os.path.join(self.exchange_directory, self.course_id)
         self.outbound_path = os.path.join(self.course_path, 'outbound')
         self.inbound_path = os.path.join(self.course_path, 'inbound')

--- a/nbgrader/apps/submitapp.py
+++ b/nbgrader/apps/submitapp.py
@@ -56,6 +56,9 @@ class SubmitApp(TransferApp):
             self.fail("Assignment not found: {}".format(self.src_path))
 
     def init_dest(self):
+        if self.course_id == '':
+            self.fail("No course id specified. Re-run with --course flag.")
+
         self.course_path = os.path.join(self.exchange_directory, self.course_id)
         self.inbound_path = os.path.join(self.course_path, 'inbound')
         self.assignment_filename = get_username() + '+' + self.assignment_id + '+' + self.timestamp

--- a/nbgrader/tests/apps/test_nbgrader_collect.py
+++ b/nbgrader/tests/apps/test_nbgrader_collect.py
@@ -11,7 +11,7 @@ class TestNbGraderCollect(BaseTestApp):
         self._copy_file("files/test.ipynb", "release/ps1/p1.ipynb")
         run_command([
             'nbgrader', 'release', assignment,
-            '--NbGraderConfig.course_id=abc101',
+            '--course', 'abc101',
             '--TransferApp.exchange_directory={}'.format(exchange)
         ])
         run_command([
@@ -30,7 +30,7 @@ class TestNbGraderCollect(BaseTestApp):
     def _collect(self, assignment, exchange, flags=None, retcode=0):
         cmd = [
             'nbgrader', 'collect', assignment,
-            '--NbGraderConfig.course_id=abc101',
+            '--course', 'abc101',
             '--TransferApp.exchange_directory={}'.format(exchange)
         ]
 
@@ -47,6 +47,16 @@ class TestNbGraderCollect(BaseTestApp):
     def test_help(self):
         """Does the help display without error?"""
         run_command(["nbgrader", "collect", "--help-all"])
+
+    def test_no_course_id(self, exchange):
+        """Does releasing without a course id thrown an error?"""
+        self._release_and_fetch("ps1", exchange)
+        self._submit("ps1", exchange)
+        cmd = [
+            "nbgrader", "collect", "ps1",
+            "--TransferApp.exchange_directory={}".format(exchange)
+        ]
+        run_command(cmd, retcode=1)
 
     def test_collect(self, exchange):
         self._release_and_fetch("ps1", exchange)

--- a/nbgrader/tests/apps/test_nbgrader_fetch.py
+++ b/nbgrader/tests/apps/test_nbgrader_fetch.py
@@ -10,7 +10,7 @@ class TestNbGraderFetch(BaseTestApp):
         self._copy_file("files/test.ipynb", "release/ps1/p1.ipynb")
         run_command([
             "nbgrader", "release", assignment,
-            "--NbGraderConfig.course_id=abc101",
+            "--course", "abc101",
             "--TransferApp.exchange_directory={}".format(exchange)
         ])
 
@@ -29,6 +29,15 @@ class TestNbGraderFetch(BaseTestApp):
     def test_help(self):
         """Does the help display without error?"""
         run_command(["nbgrader", "fetch", "--help-all"])
+
+    def test_no_course_id(self, exchange):
+        """Does releasing without a course id thrown an error?"""
+        self._release("ps1", exchange)
+        cmd = [
+            "nbgrader", "fetch", "ps1",
+            "--TransferApp.exchange_directory={}".format(exchange)
+        ]
+        run_command(cmd, retcode=1)
 
     def test_fetch(self, exchange):
         self._release("ps1", exchange)

--- a/nbgrader/tests/apps/test_nbgrader_list.py
+++ b/nbgrader/tests/apps/test_nbgrader_list.py
@@ -8,37 +8,38 @@ from nbgrader.tests.apps.base import BaseTestApp
 
 class TestNbGraderList(BaseTestApp):
 
-    def _release(self, assignment, exchange):
+    def _release(self, assignment, exchange, course="abc101"):
         self._copy_file("files/test.ipynb", "release/{}/p1.ipynb".format(assignment))
         run_command([
             "nbgrader", "release", assignment,
-            "--NbGraderConfig.course_id=abc101",
+            "--course", course,
             "--TransferApp.exchange_directory={}".format(exchange)
         ])
 
-    def _fetch(self, assignment, exchange):
+    def _fetch(self, assignment, exchange, course="abc101"):
         run_command([
             "nbgrader", "fetch", assignment,
-            "--course", "abc101",
+            "--course", course,
             "--TransferApp.exchange_directory={}".format(exchange)
         ])
 
-    def _submit(self, assignment, exchange):
+    def _submit(self, assignment, exchange, course="abc101"):
         run_command([
             "nbgrader", "submit", assignment,
-            "--course", "abc101",
+            "--course", course,
             "--TransferApp.exchange_directory={}".format(exchange)
         ])
 
-    def _list(self, assignment, exchange, flags=None, retcode=0):
+    def _list(self, exchange, assignment=None, flags=None, retcode=0):
         cmd = [
-            "nbgrader", "list", assignment,
-            "--course", "abc101",
+            "nbgrader", "list",
             "--TransferApp.exchange_directory={}".format(exchange)
         ]
 
         if flags is not None:
             cmd.extend(flags)
+        if assignment is not None:
+            cmd.append(assignment)
 
         return run_command(cmd, retcode=retcode)
 
@@ -48,33 +49,60 @@ class TestNbGraderList(BaseTestApp):
 
     def test_list_released(self, exchange):
         self._release("ps1", exchange)
-        assert self._list("ps1", exchange) == dedent(
+        self._release("ps1", exchange, course="xyz200")
+        assert self._list(exchange, "ps1", flags=["--course", "abc101"]) == dedent(
             """
             [ListApp | INFO] Released assignments:
             [ListApp | INFO] abc101 ps1
             """
         ).lstrip()
+        assert self._list(exchange, "ps1", flags=["--course", "xyz200"]) == dedent(
+            """
+            [ListApp | INFO] Released assignments:
+            [ListApp | INFO] xyz200 ps1
+            """
+        ).lstrip()
+        assert self._list(exchange, "ps1") == dedent(
+            """
+            [ListApp | INFO] Released assignments:
+            [ListApp | INFO] abc101 ps1
+            [ListApp | INFO] xyz200 ps1
+            """
+        ).lstrip()
 
         self._release("ps2", exchange)
-        assert self._list("ps2", exchange) == dedent(
+        self._release("ps2", exchange, course="xyz200")
+        assert self._list(exchange, "ps2") == dedent(
+            """
+            [ListApp | INFO] Released assignments:
+            [ListApp | INFO] abc101 ps2
+            [ListApp | INFO] xyz200 ps2
+            """
+        ).lstrip()
+
+        assert self._list(exchange) == dedent(
+            """
+            [ListApp | INFO] Released assignments:
+            [ListApp | INFO] abc101 ps1
+            [ListApp | INFO] abc101 ps2
+            [ListApp | INFO] xyz200 ps1
+            [ListApp | INFO] xyz200 ps2
+            """
+        ).lstrip()
+
+    def test_list_remove_outbound(self, exchange):
+        self._release("ps1", exchange)
+        self._release("ps2", exchange)
+        self._list(exchange, "ps1", flags=["--remove"])
+        assert self._list(exchange) == dedent(
             """
             [ListApp | INFO] Released assignments:
             [ListApp | INFO] abc101 ps2
             """
         ).lstrip()
 
-    def test_list_remove_outbound(self, exchange):
-        self._release("ps1", exchange)
-        self._list("ps1", exchange, flags=["--remove"])
-        assert self._list("ps1", exchange) == dedent(
-            """
-            [ListApp | INFO] Released assignments:
-            """
-        ).lstrip()
-
-        self._release("ps2", exchange)
-        self._list("ps2", exchange, flags=["--remove"])
-        assert self._list("ps2", exchange) == dedent(
+        self._list(exchange, "ps2", flags=["--remove"])
+        assert self._list(exchange, "ps2") == dedent(
             """
             [ListApp | INFO] Released assignments:
             """
@@ -83,7 +111,7 @@ class TestNbGraderList(BaseTestApp):
     def test_list_submitted(self, exchange):
         self._release("ps1", exchange)
 
-        assert self._list("ps1", exchange, flags=['--inbound']) == dedent(
+        assert self._list(exchange, "ps1", flags=['--inbound']) == dedent(
             """
             [ListApp | INFO] Submitted assignments:
             """
@@ -93,7 +121,7 @@ class TestNbGraderList(BaseTestApp):
         self._submit("ps1", exchange)
         filename, = os.listdir(os.path.join(exchange, "abc101/inbound"))
         timestamp = filename.split("+")[2]
-        assert self._list("ps1", exchange, flags=['--inbound']) == dedent(
+        assert self._list(exchange, "ps1", flags=['--inbound']) == dedent(
             """
             [ListApp | INFO] Submitted assignments:
             [ListApp | INFO] abc101 {} ps1 {}
@@ -103,7 +131,7 @@ class TestNbGraderList(BaseTestApp):
         self._submit("ps1", exchange)
         filenames = sorted(os.listdir(os.path.join(exchange, "abc101/inbound")))
         timestamps = [x.split("+")[2] for x in filenames]
-        assert self._list("ps1", exchange, flags=['--inbound']) == dedent(
+        assert self._list(exchange, "ps1", flags=['--inbound']) == dedent(
             """
             [ListApp | INFO] Submitted assignments:
             [ListApp | INFO] abc101 {} ps1 {}
@@ -119,22 +147,23 @@ class TestNbGraderList(BaseTestApp):
 
         self._submit("ps1", exchange)
         self._submit("ps2", exchange)
+        filenames = sorted(os.listdir(os.path.join(exchange, "abc101/inbound")))
+        timestamps = [x.split("+")[2] for x in filenames]
 
-        self._list("ps1", exchange, flags=["--inbound", "--remove"])
-        assert self._list("ps1", exchange, flags=['--inbound']) == dedent(
+        self._list(exchange, "ps1", flags=["--inbound", "--remove"])
+        assert self._list(exchange, flags=['--inbound']) == dedent(
             """
             [ListApp | INFO] Submitted assignments:
-            """
+            [ListApp | INFO] abc101 {} ps2 {}
+            """.format(os.environ['USER'], timestamps[1])
         ).lstrip()
 
         self._submit("ps1", exchange)
         self._submit("ps2", exchange)
 
-        self._list("ps2", exchange, flags=["--inbound", "--remove"])
-        filename = sorted(os.listdir(os.path.join(exchange, "abc101/inbound")))[0]
-        timestamp = filename.split("+")[2]
-        assert self._list("ps2", exchange, flags=['--inbound']) == dedent(
+        self._list(exchange, "ps2", flags=["--inbound", "--remove"])
+        assert self._list(exchange, "ps2", flags=['--inbound']) == dedent(
             """
             [ListApp | INFO] Submitted assignments:
-            """.format(os.environ['USER'], timestamp)
+            """
         ).lstrip()

--- a/nbgrader/tests/apps/test_nbgrader_release.py
+++ b/nbgrader/tests/apps/test_nbgrader_release.py
@@ -9,7 +9,7 @@ class TestNbGraderRelease(BaseTestApp):
     def _release(self, assignment, exchange, flags=None, retcode=0):
         cmd = [
             "nbgrader", "release", assignment,
-            "--NbGraderConfig.course_id=abc101",
+            "--course", "abc101",
             "--TransferApp.exchange_directory={}".format(exchange)
         ]
 
@@ -21,6 +21,14 @@ class TestNbGraderRelease(BaseTestApp):
     def test_help(self):
         """Does the help display without error?"""
         run_command(["nbgrader", "release", "--help-all"])
+
+    def test_no_course_id(self, exchange):
+        """Does releasing without a course id thrown an error?"""
+        cmd = [
+            "nbgrader", "release", "ps1",
+            "--TransferApp.exchange_directory={}".format(exchange)
+        ]
+        run_command(cmd, retcode=1)
 
     def test_release(self, exchange):
         self._copy_file("files/test.ipynb", "release/ps1/p1.ipynb")

--- a/nbgrader/tests/apps/test_nbgrader_submit.py
+++ b/nbgrader/tests/apps/test_nbgrader_submit.py
@@ -13,7 +13,7 @@ class TestNbGraderSubmit(BaseTestApp):
         self._copy_file("files/test.ipynb", "release/ps1/p1.ipynb")
         run_command([
             "nbgrader", "release", assignment,
-            "--NbGraderConfig.course_id=abc101",
+            "--course", "abc101",
             "--TransferApp.exchange_directory={}".format(exchange)
         ])
         run_command([
@@ -37,6 +37,15 @@ class TestNbGraderSubmit(BaseTestApp):
     def test_help(self):
         """Does the help display without error?"""
         run_command(["nbgrader", "submit", "--help-all"])
+
+    def test_no_course_id(self, exchange):
+        """Does releasing without a course id thrown an error?"""
+        self._release_and_fetch("ps1", exchange)
+        cmd = [
+            "nbgrader", "submit", "ps1",
+            "--TransferApp.exchange_directory={}".format(exchange)
+        ]
+        run_command(cmd, retcode=1)
 
     def test_submit(self, exchange):
         self._release_and_fetch("ps1", exchange)


### PR DESCRIPTION
This fixes the transfer apps so that they will fail if a course id is not specified.