### PR TITLE
Add cache to nbgrader submit and nbgrader list

### DIFF
--- a/nbgrader/apps/baseapp.py
+++ b/nbgrader/apps/baseapp.py
@@ -229,7 +229,21 @@ class TransferApp(BaseNbGraderApp):
         help="Format string for timestamps"
     )
 
-    course = Unicode(None, config=True, allow_none=True, help="Optional course name.")
+    course = Unicode('', config=True, allow_none=True, help="Required course name.")
+
+    exchange_directory = Unicode(
+        "/srv/nbgrader/exchange",
+        config=True,
+        help="The nbgrader exchange directory writable to everyone. MUST be preexisting."
+    )
+
+    cache_directory = Unicode(
+        "",
+        config=True,
+        help="Local cache directory for nbgrader submit and nbgrader list. Defaults to ~/.nbgrader/cache")
+
+    def _cache_directory_default(self):
+        return os.path.join(os.environ['HOME'], '.nbgrader', 'cache')
 
     def set_timestamp(self):
         """Set the timestap using the configured timezone."""
@@ -238,14 +252,7 @@ class TransferApp(BaseNbGraderApp):
             self.fail("Invalid timezone: {}".format(self.timezone))
         self.timestamp = datetime.datetime.now(tz).strftime(self.timestamp_format)
 
-    exchange_directory = Unicode(
-        "/srv/nbgrader/exchange",
-        config=True,
-        help="The nbgrader exchange directory writable to everyone. MUST be preexisting."
-    )
-
     def ensure_exchange_directory(self):
-        return
         """See if the exchange directory exists and is writable, fail if not."""
         if not check_directory(self.exchange_directory, write=True, execute=True):
             self.fail("Unwritable directory, please contact your instructor: {}".format(self.exchange_directory))

--- a/nbgrader/tests/apps/conftest.py
+++ b/nbgrader/tests/apps/conftest.py
@@ -61,3 +61,13 @@ def exchange(request):
     request.addfinalizer(fin)
 
     return path
+
+@pytest.fixture
+def cache(request):
+    path = tempfile.mkdtemp()
+
+    def fin():
+        shutil.rmtree(path)
+    request.addfinalizer(fin)
+
+    return path

--- a/nbgrader/tests/apps/test_nbgrader_submit.py
+++ b/nbgrader/tests/apps/test_nbgrader_submit.py
@@ -9,23 +9,26 @@ from nbgrader.tests.apps.base import BaseTestApp
 
 class TestNbGraderSubmit(BaseTestApp):
 
-    def _release_and_fetch(self, assignment, exchange):
+    def _release_and_fetch(self, assignment, exchange, cache):
         self._copy_file("files/test.ipynb", "release/ps1/p1.ipynb")
         run_command([
             "nbgrader", "release", assignment,
             "--course", "abc101",
+            "--TransferApp.cache_directory={}".format(cache),
             "--TransferApp.exchange_directory={}".format(exchange)
         ])
         run_command([
             "nbgrader", "fetch", assignment,
             "--course", "abc101",
+            "--TransferApp.cache_directory={}".format(cache),
             "--TransferApp.exchange_directory={}".format(exchange)
         ])
 
-    def _submit(self, assignment, exchange, flags=None, retcode=0):
+    def _submit(self, assignment, exchange, cache, flags=None, retcode=0):
         cmd = [
             "nbgrader", "submit", assignment,
             "--course", "abc101",
+            "--TransferApp.cache_directory={}".format(cache),
             "--TransferApp.exchange_directory={}".format(exchange)
         ]
 
@@ -38,44 +41,64 @@ class TestNbGraderSubmit(BaseTestApp):
         """Does the help display without error?"""
         run_command(["nbgrader", "submit", "--help-all"])
 
-    def test_no_course_id(self, exchange):
+    def test_no_course_id(self, exchange, cache):
         """Does releasing without a course id thrown an error?"""
-        self._release_and_fetch("ps1", exchange)
+        self._release_and_fetch("ps1", exchange, cache)
         cmd = [
             "nbgrader", "submit", "ps1",
+            "--TransferApp.cache_directory={}".format(cache),
             "--TransferApp.exchange_directory={}".format(exchange)
         ]
         run_command(cmd, retcode=1)
 
-    def test_submit(self, exchange):
-        self._release_and_fetch("ps1", exchange)
+    def test_submit(self, exchange, cache):
+        self._release_and_fetch("ps1", exchange, cache)
         now = datetime.datetime.now()
 
         time.sleep(1)
-        self._submit("ps1", exchange)
+        self._submit("ps1", exchange, cache)
 
-        filename, = os.listdir(os.path.join(exchange, "abc101/inbound"))
+        filename, = os.listdir(os.path.join(exchange, "abc101", "inbound"))
         username, assignment, timestamp1 = filename.split("+")
         assert username == os.environ['USER']
         assert assignment == "ps1"
         assert parse_utc(timestamp1) > now
-        assert os.path.isfile(os.path.join(exchange, "abc101/inbound", filename, "p1.ipynb"))
-        assert os.path.isfile(os.path.join(exchange, "abc101/inbound", filename, "timestamp.txt"))
+        assert os.path.isfile(os.path.join(exchange, "abc101", "inbound", filename, "p1.ipynb"))
+        assert os.path.isfile(os.path.join(exchange, "abc101", "inbound", filename, "timestamp.txt"))
+        with open(os.path.join(exchange, "abc101", "inbound", filename, "timestamp.txt"), "r") as fh:
+            assert fh.read() == timestamp1
 
-        with open(os.path.join(exchange, "abc101/inbound", filename, "timestamp.txt"), "r") as fh:
+        filename, = os.listdir(os.path.join(cache, "abc101"))
+        username, assignment, timestamp1 = filename.split("+")
+        assert username == os.environ['USER']
+        assert assignment == "ps1"
+        assert parse_utc(timestamp1) > now
+        assert os.path.isfile(os.path.join(cache, "abc101", filename, "p1.ipynb"))
+        assert os.path.isfile(os.path.join(cache, "abc101", filename, "timestamp.txt"))
+        with open(os.path.join(cache, "abc101", filename, "timestamp.txt"), "r") as fh:
             assert fh.read() == timestamp1
 
         time.sleep(1)
-        self._submit("ps1", exchange)
+        self._submit("ps1", exchange, cache)
 
-        assert len(os.listdir(os.path.join(exchange, "abc101/inbound"))) == 2
-        filename = sorted(os.listdir(os.path.join(exchange, "abc101/inbound")))[1]
+        assert len(os.listdir(os.path.join(exchange, "abc101", "inbound"))) == 2
+        filename = sorted(os.listdir(os.path.join(exchange, "abc101", "inbound")))[1]
         username, assignment, timestamp2 = filename.split("+")
         assert username == os.environ['USER']
         assert assignment == "ps1"
         assert parse_utc(timestamp2) > parse_utc(timestamp1)
-        assert os.path.isfile(os.path.join(exchange, "abc101/inbound", filename, "p1.ipynb"))
-        assert os.path.isfile(os.path.join(exchange, "abc101/inbound", filename, "timestamp.txt"))
+        assert os.path.isfile(os.path.join(exchange, "abc101", "inbound", filename, "p1.ipynb"))
+        assert os.path.isfile(os.path.join(exchange, "abc101", "inbound", filename, "timestamp.txt"))
+        with open(os.path.join(exchange, "abc101", "inbound", filename, "timestamp.txt"), "r") as fh:
+            assert fh.read() == timestamp2
 
-        with open(os.path.join(exchange, "abc101/inbound", filename, "timestamp.txt"), "r") as fh:
+        assert len(os.listdir(os.path.join(cache, "abc101"))) == 2
+        filename = sorted(os.listdir(os.path.join(cache, "abc101")))[1]
+        username, assignment, timestamp2 = filename.split("+")
+        assert username == os.environ['USER']
+        assert assignment == "ps1"
+        assert parse_utc(timestamp2) > parse_utc(timestamp1)
+        assert os.path.isfile(os.path.join(cache, "abc101", filename, "p1.ipynb"))
+        assert os.path.isfile(os.path.join(cache, "abc101", filename, "timestamp.txt"))
+        with open(os.path.join(cache, "abc101", filename, "timestamp.txt"), "r") as fh:
             assert fh.read() == timestamp2


### PR DESCRIPTION
This modifies the behavior of `nbgrader submit` so that it additionally copies a version of the assignment to a cache directory (by default, `~/.nbgrader/cache`). Then, the `--cached` flag is added to `nbgrader list` so that you can see the list of cached assignments.

This is kind of a workaround to #295. It's not a perfect or ideal solution, but it'll work for the time being until we can implement something more robust like an authenticated REST api for releasing and submitting assignments.

FYI @ellisonbg 