### PR TITLE
Depend on Jupyter v4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,7 @@ docs/_build/
 # PyBuilder
 target/
 
-# IPython checkpoints
+# Jupyter notebook checkpoints
 .ipynb_checkpoints/
 
 # Coverage files

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,6 @@ In general, the guidelines for opening issues, submitting PRs, code style, etc. 
 
 ## Development installation
 
-In addition to the dependencies listed below, you must have the IPython notebook installed.
-Please refer to the [README](README.md#dependencies) for instructions on how to install the notebook.
-
 ### Dependencies
 
 Phantomjs must be installed in order to run tests.

--- a/README.md
+++ b/README.md
@@ -11,23 +11,7 @@ A system for assigning and grading notebooks.
 ## Installation
 
 If you want to develop on nbgrader, please follow the [development installation instructions](CONTRIBUTING.md#development-installation).
-
-### Dependencies
-
-Before installing nbgrader, please ensure that the IPython notebook is properly installed.
-Note that it is not sufficient to just install IPython; you must specifically install the notebook components as well.
-
-If using conda, run
-
-    conda install ipython-notebook=3.2
-
-Otherwise, run
-
-    pip install ipython[all]==3.2
-
-### Installing nbgrader
-
-After installing the above dependencies, you can install the current version of nbgrader with:
+Otherwise, you can install the current version of nbgrader with:
 
     pip install nbgrader
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,2 @@
-ipython[all]==3.2
 invoke
 flit

--- a/docs/source/build_docs.py
+++ b/docs/source/build_docs.py
@@ -3,20 +3,15 @@ import glob
 import re
 import shutil
 import sys
+import six
 import nbgrader.apps
 
 from textwrap import dedent
 from clear_docs import run, clear_notebooks
 
-try:
-    from StringIO import StringIO # Python 2
-except ImportError:
-    from io import StringIO # Python 3
-
-
-# get absolute path to IPython to make sure it's the same one as what is installed
+# get absolute path to Jupyter to make sure it's the same one as what is installed
 # in the virtualenv
-IPYTHON = os.path.join(os.path.dirname(sys.executable), 'ipython')
+JUPYTER = os.path.join(os.path.dirname(sys.executable), 'jupyter')
 
 
 def autogen_command_line(root):
@@ -52,7 +47,7 @@ def autogen_command_line(root):
 
     for app in apps:
         cls = getattr(nbgrader.apps, app)
-        buf = sys.stdout = StringIO()
+        buf = sys.stdout = six.StringIO()
         cls().print_help(True)
         buf.flush()
         helpstr = buf.getvalue()
@@ -101,11 +96,10 @@ def build_notebooks(root):
     # hack to convert links to ipynb files to html
     for filename in sorted(glob.glob('user_guide/*.ipynb')):
         run([
-            IPYTHON, 'nbconvert',
+            JUPYTER, 'nbconvert',
             '--to', 'rst',
             '--execute',
             '--FilesWriter.build_directory=user_guide',
-            '--profile-dir', '/tmp',
             filename
         ])
 
@@ -130,10 +124,9 @@ def build_notebooks(root):
         for filename in sorted(filenames):
             if filename.endswith('.ipynb'):
                 run([
-                    IPYTHON, 'nbconvert',
+                    JUPYTER, 'nbconvert',
                     '--to', 'html',
                     "--FilesWriter.build_directory='{}'".format(build_directory),
-                    '--profile-dir', '/tmp',
                     os.path.join(dirname, filename)
                 ])
 

--- a/docs/source/clear_docs.py
+++ b/docs/source/clear_docs.py
@@ -4,10 +4,10 @@ import subprocess as sp
 from copy import deepcopy
 
 try:
-    from IPython.nbformat import read, write
-    from IPython.nbconvert.preprocessors import ClearOutputPreprocessor
+    from nbformat import read, write
+    from nbconvert.preprocessors import ClearOutputPreprocessor
 except ImportError:
-    print("Warning: IPython could not be imported, some tasks may not work")
+    print("Warning: nbformat and/or nbconvert could not be imported, some tasks may not work")
 
 
 def run(cmd):

--- a/flit.ini
+++ b/flit.ini
@@ -5,7 +5,13 @@ author-email = jupyter@googlegroups.com
 requires = sqlalchemy
     Flask
     python-dateutil
-    ipython (==3.2)
+    notebook
+    nbconvert
+    nbformat
+    traitlets
+    jupyter_core
+    tornado
+    six
 dev-requires = nose
     pytest
     pytest-cov
@@ -14,6 +20,7 @@ dev-requires = nose
     invoke
     sphinx
     codecov
+    cov-core
 description-file = README.md
 home-page = https://github.com/jupyter/nbgrader
 classifiers=Intended Audience :: Developers

--- a/nbgrader/apps/assignapp.py
+++ b/nbgrader/apps/assignapp.py
@@ -2,7 +2,7 @@ import os
 import re
 from textwrap import dedent
 
-from IPython.utils.traitlets import List, Bool
+from traitlets import List, Bool
 
 from nbgrader.api import Gradebook, MissingEntry
 from nbgrader.apps.baseapp import (

--- a/nbgrader/apps/autogradeapp.py
+++ b/nbgrader/apps/autogradeapp.py
@@ -1,9 +1,8 @@
 import os
+import shutil
 
 from textwrap import dedent
-
-from IPython.utils.traitlets import List, Bool
-from IPython.utils.path import link_or_copy, ensure_dir_exists
+from traitlets import List, Bool
 
 from nbgrader.apps.baseapp import BaseNbConvertApp, nbconvert_aliases, nbconvert_flags
 from nbgrader.preprocessors import (
@@ -147,10 +146,12 @@ class AutogradeApp(BaseNbConvertApp):
         # copy them to the build directory
         for filename in source_files:
             dest = os.path.join(dest_path, os.path.relpath(filename, source_path))
-            ensure_dir_exists(os.path.dirname(dest))
-            if not os.path.normpath(dest) == os.path.normpath(filename):
-                self.log.info("Linking %s -> %s", filename, dest)
-                link_or_copy(filename, dest)
+            if not os.path.exists(os.path.dirname(dest)):
+                os.makedirs(os.path.dirname(dest))
+            if os.path.exists(dest):
+                os.remove(dest)
+            self.log.info("Copying %s -> %s", filename, dest)
+            shutil.copy(filename, dest)
 
         # ignore notebooks that aren't in the database
         notebooks = []

--- a/nbgrader/apps/collectapp.py
+++ b/nbgrader/apps/collectapp.py
@@ -3,7 +3,7 @@ import glob
 import shutil
 from collections import defaultdict
 
-from IPython.utils.traitlets import Bool
+from traitlets import Bool
 
 from nbgrader.apps.baseapp import TransferApp, transfer_aliases, transfer_flags
 from nbgrader.utils import check_mode, parse_utc

--- a/nbgrader/apps/feedbackapp.py
+++ b/nbgrader/apps/feedbackapp.py
@@ -1,8 +1,8 @@
 import os
 
-from IPython.utils.traitlets import List
-from IPython.nbconvert.exporters import HTMLExporter
-from IPython.nbconvert.preprocessors import CSSHTMLHeaderPreprocessor
+from traitlets import List
+from nbconvert.exporters import HTMLExporter
+from nbconvert.preprocessors import CSSHTMLHeaderPreprocessor
 
 from nbgrader.apps.baseapp import BaseNbConvertApp, nbconvert_aliases, nbconvert_flags
 from nbgrader.preprocessors import GetGrades

--- a/nbgrader/apps/formgradeapp.py
+++ b/nbgrader/apps/formgradeapp.py
@@ -1,13 +1,12 @@
 import os
 import signal
 import sys
+import notebook
 
+from nbconvert.exporters import HTMLExporter
 from textwrap import dedent
-
-from IPython.utils.traitlets import Unicode, Integer, Type, Instance
-
-from IPython.nbconvert.exporters import HTMLExporter
-from IPython.config.application import catch_config_error
+from traitlets import Unicode, Integer, Type, Instance
+from traitlets.config.application import catch_config_error
 
 from nbgrader.apps.baseapp import BaseNbGraderApp, nbgrader_aliases, nbgrader_flags
 from nbgrader.html.formgrade import app
@@ -42,7 +41,7 @@ class FormgradeApp(BaseNbGraderApp):
         graded, as long as it has already been run through the autograder.
 
         By default, the formgrader runs at http://localhost:5000. It also starts
-        an IPython notebook server, to allow students' notebooks to be open up
+        a Jupyter notebook server, to allow students' notebooks to be open up
         and run manually if so desired. The notebook server also runs on
         localhost on a random port, though this port can be specified by setting
         `FormgradeApp.nbserver_port`. The notebook server can be disabled entirely
@@ -76,15 +75,14 @@ class FormgradeApp(BaseNbGraderApp):
         config=True,
         help=dedent(
             """
-            URL or local path to mathjax installation. To install it locally,
-            install mathjax with IPython and then configure this variable to
-            use the local version.
+            URL or local path to mathjax installation. Defaults to the version
+            of MathJax included with the Jupyter Notebook.
             """
         )
     )
 
     def _mathjax_url_default(self):
-        url = os.path.join(self.ipython_dir, 'nbextensions', 'mathjax', 'MathJax.js')
+        url = os.path.join(notebook.DEFAULT_STATIC_FILES_PATH, 'components', 'MathJax', 'MathJax.js')
         if not os.path.exists(url):
             url = 'https://cdn.mathjax.org/mathjax/latest/MathJax.js'
         self.log.info("Serving MathJax from %s", url)

--- a/nbgrader/apps/listapp.py
+++ b/nbgrader/apps/listapp.py
@@ -4,7 +4,7 @@ import shutil
 import re
 import json
 
-from IPython.utils.traitlets import Bool
+from traitlets import Bool
 
 from nbgrader.apps.baseapp import TransferApp, transfer_aliases, transfer_flags
 

--- a/nbgrader/apps/nbgraderapp.py
+++ b/nbgrader/apps/nbgraderapp.py
@@ -6,8 +6,8 @@ import os
 
 from textwrap import dedent
 
-from IPython.config.application import catch_config_error
-from IPython.utils.traitlets import Bool
+from traitlets.config.application import catch_config_error
+from traitlets import Bool
 
 from nbgrader import preprocessors
 from nbgrader.apps.baseapp import nbgrader_aliases, nbgrader_flags
@@ -37,11 +37,7 @@ flags.update({
     'generate-config': (
         {'NbGraderApp' : {'generate_config': True}},
         "Generate a config file."
-    ),
-    'overwrite': (
-        {'BasicConfig' : {'overwrite': True}},
-        "Overwrite existing config files."
-    ),
+    )
 })
 
 
@@ -214,8 +210,8 @@ class NbGraderApp(BaseNbGraderApp):
             s = self.generate_config_file()
             filename = "nbgrader_config.py"
 
-            if os.path.exists(filename) and not self.overwrite:
-                self.fail("Config file '{}' already exists (run with --overwrite to overwrite it)".format(filename))
+            if os.path.exists(filename):
+                self.fail("Config file '{}' already exists".format(filename))
 
             with open(filename, 'w') as fh:
                 fh.write(s)

--- a/nbgrader/apps/notebookapp.py
+++ b/nbgrader/apps/notebookapp.py
@@ -1,5 +1,5 @@
 from tornado import ioloop
-from IPython.html.notebookapp import NotebookApp
+from notebook.notebookapp import NotebookApp
 
 class FormgradeNotebookApp(NotebookApp):
     """A Subclass of the regular NotebookApp that can be spawned by the form grader."""

--- a/nbgrader/apps/releaseapp.py
+++ b/nbgrader/apps/releaseapp.py
@@ -7,7 +7,7 @@ from stat import (
     S_ISVTX, S_ISGID
 )
 
-from IPython.utils.traitlets import Bool
+from traitlets import Bool
 
 from nbgrader.apps.baseapp import TransferApp, transfer_aliases, transfer_flags
 from nbgrader.utils import self_owned

--- a/nbgrader/apps/validateapp.py
+++ b/nbgrader/apps/validateapp.py
@@ -1,5 +1,5 @@
-from IPython.utils.traitlets import Unicode, List, Bool
-from IPython.nbconvert.nbconvertapp import NbConvertApp, DottedOrNone
+from traitlets import Unicode, List, Bool
+from nbconvert.nbconvertapp import NbConvertApp, DottedOrNone
 from nbgrader.preprocessors import DisplayAutoGrades, Execute, ClearOutput
 from nbgrader.apps.baseapp import BaseApp, base_flags, base_aliases
 

--- a/nbgrader/auth/base.py
+++ b/nbgrader/auth/base.py
@@ -1,5 +1,5 @@
 """Base formgrade authenticator."""
-from IPython.config.configurable import LoggingConfigurable
+from traitlets.config.configurable import LoggingConfigurable
 
 
 class BaseAuth(LoggingConfigurable):

--- a/nbgrader/auth/hubauth.py
+++ b/nbgrader/auth/hubauth.py
@@ -4,7 +4,7 @@ import os
 import json
 from subprocess import check_output
 from flask import request, redirect, abort
-from IPython.utils.traitlets import Unicode, Int, List, Bool 
+from traitlets import Unicode, Int, List, Bool 
 
 from nbgrader.html.formgrade import blueprint
 from .base import BaseAuth

--- a/nbgrader/auth/noauth.py
+++ b/nbgrader/auth/noauth.py
@@ -5,7 +5,7 @@ import subprocess as sp
 import time
 import sys
 from textwrap import dedent
-from IPython.utils.traitlets import Bool, Integer, Unicode
+from traitlets import Bool, Integer, Unicode
 
 from .base import BaseAuth
 

--- a/nbgrader/config.py
+++ b/nbgrader/config.py
@@ -1,6 +1,5 @@
-from IPython.config import Configurable
-from IPython.utils.traitlets import Unicode, Bool, link
-from IPython.utils.path import get_ipython_dir
+from traitlets.config import Configurable
+from traitlets import Unicode, Bool, link
 
 from textwrap import dedent
 
@@ -20,58 +19,7 @@ class LinkedConfig(Configurable):
 
 
 class BasicConfig(LinkedConfig):
-    """Config options that inherited from IPython."""
-
-    profile = Unicode(
-        'nbgrader',
-        config=True,
-        help="Default IPython profile to use")
-
-    overwrite = Bool(
-        False,
-        config=True,
-        help="Whether to overwrite existing config files when copying")
-
-    auto_create = Bool(
-        True,
-        config=True,
-        help="Whether to automatically generate the profile")
-
-    extra_config_file = Unicode(
-        config=True,
-        help=dedent(
-            """
-            Path to an extra config file to load. If specified, load this config
-            file in addition to any other IPython config.
-            """
-        )
-    )
-
-    copy_config_files = Bool(
-        False,
-        config=True,
-        help=dedent(
-            """
-            Whether to install the default config files into the profile dir.
-            If a new profile is being created, and IPython contains config files
-            for that profile, then they will be staged into the new directory.
-            Otherwise, default config files will be automatically generated.
-            """
-        )
-    )
-
-    ipython_dir = Unicode(
-        get_ipython_dir(),
-        config=True,
-        help=dedent(
-            """
-            The name of the IPython directory. This directory is used for logging
-            configuration (through profiles), history storage, etc. The default
-            is usually $HOME/.ipython. This option can also be specified through
-            the environment variable IPYTHONDIR.
-            """
-        )
-    )
+    """Config options that inherited from Jupyter."""
 
     log_datefmt = Unicode(
         "%Y-%m-%d %H:%M:%S",

--- a/nbgrader/nbextensions/assignment_list/handlers.py
+++ b/nbgrader/nbextensions/assignment_list/handlers.py
@@ -6,10 +6,10 @@ import subprocess as sp
 
 from tornado import web
 
-from IPython.html.utils import url_path_join as ujoin
-from IPython.html.base.handlers import IPythonHandler
-from IPython.utils.traitlets import Unicode
-from IPython.config import LoggingConfigurable
+from notebook.utils import url_path_join as ujoin
+from notebook.base.handlers import IPythonHandler
+from traitlets import Unicode
+from traitlets.config import LoggingConfigurable
 
 static = os.path.join(os.path.dirname(__file__), 'static')
 

--- a/nbgrader/nbextensions/assignment_list/static/assignment_list.js
+++ b/nbgrader/nbextensions/assignment_list/static/assignment_list.js
@@ -6,7 +6,7 @@ define([
     'jquery',
     'base/js/utils',
     'base/js/dialog',
-], function(IPython, $, utils, dialog) {
+], function(Jupyter, $, utils, dialog) {
     "use strict";
 
     var AssignmentList = function (released_selector, fetched_selector, submitted_selector, options) {

--- a/nbgrader/nbextensions/assignment_list/static/main.js
+++ b/nbgrader/nbextensions/assignment_list/static/main.js
@@ -1,6 +1,6 @@
 define(function(require) {
     var $ = require('jquery');
-    var IPython = require('base/js/namespace');
+    var Jupyter = require('base/js/namespace');
     var AssignmentList = require('./assignment_list');
 
     var assignment_html = $([
@@ -57,8 +57,8 @@ define(function(require) {
     ].join('\n'));
 
    function load() {
-        if (!IPython.notebook_list) return;
-        var base_url = IPython.notebook_list.base_url;
+        if (!Jupyter.notebook_list) return;
+        var base_url = Jupyter.notebook_list.base_url;
         $('head').append(
             $('<link>')
             .attr('rel', 'stylesheet')
@@ -83,8 +83,8 @@ define(function(require) {
             '#fetched_assignments_list',
             '#submitted_assignments_list',
             {
-                base_url: IPython.notebook_list.base_url,
-                notebook_path: IPython.notebook_list.notebook_path,
+                base_url: Jupyter.notebook_list.base_url,
+                notebook_path: Jupyter.notebook_list.notebook_path,
             }
         );
         assignment_list.load_list();

--- a/nbgrader/nbextensions/create_assignment/main.js
+++ b/nbgrader/nbextensions/create_assignment/main.js
@@ -1,15 +1,3 @@
-/*global define*/
-/**
- * To load this extension, add the following to your custom.js:
- *
- * require(['base/js/events'], function (events) {
- *     events.on('app_initialized.NotebookApp', function() {
- *         IPython.load_extensions('nbgrader');
- *     });
- * });
- *
-**/
-
 define([
     'require',
     'jquery',
@@ -18,7 +6,7 @@ define([
     'notebook/js/celltoolbar',
     'base/js/events'
 
-], function (require, $, IPython, dialog, celltoolbar, events) {
+], function (require, $, Jupyter, dialog, celltoolbar, events) {
     "use strict";
 
     var nbgrader_preset_name = "Create Assignment";
@@ -96,7 +84,7 @@ define([
 
     var update_total = function() {
         var total_points = 0;
-        var cells = IPython.notebook.get_cells();
+        var cells = Jupyter.notebook.get_cells();
         for (var i=0; i < cells.length; i++) {
             if (is_grade(cells[i])) {
                 total_points += to_float(cells[i].metadata.nbgrader.points);
@@ -114,8 +102,8 @@ define([
 
         var valid = /^[a-zA-Z0-9_\-]+$/;
         var modal_opts = {
-            notebook: IPython.notebook,
-            keyboard_manager: IPython.keyboard_manager,
+            notebook: Jupyter.notebook,
+            keyboard_manager: Jupyter.keyboard_manager,
             buttons: {
                 OK: {
                     class: "btn-primary",
@@ -373,7 +361,7 @@ define([
         local_div.addClass('nbgrader-id');
         $(div).append(local_div.append($('<span/>').append(lbl)));
 
-        IPython.keyboard_manager.register_events(text);
+        Jupyter.keyboard_manager.register_events(text);
     };
 
     /**
@@ -403,7 +391,7 @@ define([
         local_div.addClass('nbgrader-points');
         $(div).append(local_div.append($('<span/>').append(lbl)));
 
-        IPython.keyboard_manager.register_events(text);
+        Jupyter.keyboard_manager.register_events(text);
     };
 
     var create_lock_cell_button = function (div, cell, celltoolbar) {
@@ -446,7 +434,7 @@ define([
             'create_assignment.id_input',
             'create_assignment.grading_options',
         ];
-        CellToolbar.register_preset(nbgrader_preset_name, preset, IPython.notebook);
+        CellToolbar.register_preset(nbgrader_preset_name, preset, Jupyter.notebook);
         console.log('nbgrader extension for metadata editing loaded.');
     };
 

--- a/nbgrader/preprocessors/base.py
+++ b/nbgrader/preprocessors/base.py
@@ -1,5 +1,5 @@
-from IPython.nbconvert.preprocessors import Preprocessor
-from IPython.utils.traitlets import List, Unicode, Bool
+from nbconvert.preprocessors import Preprocessor
+from traitlets import List, Unicode, Bool
 
 class NbGraderPreprocessor(Preprocessor):
 

--- a/nbgrader/preprocessors/clearoutput.py
+++ b/nbgrader/preprocessors/clearoutput.py
@@ -1,4 +1,4 @@
-from IPython.nbconvert.preprocessors import ClearOutputPreprocessor
+from nbconvert.preprocessors import ClearOutputPreprocessor
 from nbgrader.preprocessors import NbGraderPreprocessor
 
 class ClearOutput(NbGraderPreprocessor, ClearOutputPreprocessor):

--- a/nbgrader/preprocessors/clearsolutions.py
+++ b/nbgrader/preprocessors/clearsolutions.py
@@ -1,4 +1,4 @@
-from IPython.utils.traitlets import Unicode
+from traitlets import Unicode
 
 from nbgrader import utils
 from nbgrader.preprocessors import NbGraderPreprocessor

--- a/nbgrader/preprocessors/displayautogrades.py
+++ b/nbgrader/preprocessors/displayautogrades.py
@@ -1,8 +1,8 @@
 import sys
 import json
 
-from IPython.utils.traitlets import Unicode, Integer, Bool
-from IPython.nbconvert.filters import ansi2html, strip_ansi
+from traitlets import Unicode, Integer, Bool
+from nbconvert.filters import ansi2html, strip_ansi
 
 from nbgrader import utils
 from nbgrader.preprocessors import NbGraderPreprocessor

--- a/nbgrader/preprocessors/execute.py
+++ b/nbgrader/preprocessors/execute.py
@@ -1,9 +1,10 @@
-from IPython.nbconvert.preprocessors import ExecutePreprocessor
-from IPython.utils.traitlets import Bool, List
+from nbconvert.preprocessors import ExecutePreprocessor
+from traitlets import Bool, List
 
 from nbgrader.preprocessors import NbGraderPreprocessor
 
 class Execute(NbGraderPreprocessor, ExecutePreprocessor):
 
     interrupt_on_timeout = Bool(True)
+    allow_errors = Bool(True)
     extra_arguments = List(["--HistoryManager.hist_file=:memory:"])

--- a/nbgrader/preprocessors/headerfooter.py
+++ b/nbgrader/preprocessors/headerfooter.py
@@ -1,6 +1,6 @@
-from IPython.nbformat import read as read_nb
-from IPython.nbformat import current_nbformat
-from IPython.utils.traitlets import Unicode
+from nbformat import read as read_nb
+from nbformat import current_nbformat
+from traitlets import Unicode
 
 from nbgrader.preprocessors import NbGraderPreprocessor
 

--- a/nbgrader/preprocessors/limitoutput.py
+++ b/nbgrader/preprocessors/limitoutput.py
@@ -1,6 +1,6 @@
 from nbgrader.preprocessors import NbGraderPreprocessor
 
-from IPython.utils.traitlets import Integer
+from traitlets import Integer
 
 class LimitOutput(NbGraderPreprocessor):
     """Preprocessor for limiting cell output"""

--- a/nbgrader/preprocessors/lockcells.py
+++ b/nbgrader/preprocessors/lockcells.py
@@ -1,4 +1,4 @@
-from IPython.utils.traitlets import Bool
+from traitlets import Bool
 
 from nbgrader import utils
 from nbgrader.preprocessors import NbGraderPreprocessor

--- a/nbgrader/preprocessors/overwritecells.py
+++ b/nbgrader/preprocessors/overwritecells.py
@@ -1,4 +1,4 @@
-from IPython.nbformat.v4.nbbase import validate
+from nbformat.v4.nbbase import validate
 
 from nbgrader import utils
 from nbgrader.api import Gradebook

--- a/nbgrader/tests/__init__.py
+++ b/nbgrader/tests/__init__.py
@@ -3,7 +3,7 @@ import glob
 import shutil
 import subprocess as sp
 
-from IPython.nbformat.v4 import new_code_cell, new_markdown_cell
+from nbformat.v4 import new_code_cell, new_markdown_cell
 
 from nbgrader.utils import compute_checksum
 
@@ -102,8 +102,8 @@ def copy_coverage_files():
             shutil.copyfile(filename, os.path.join(root, filename))
 
 
-def run_command(command, retcode=0, coverage=True):
-    proc = start_subprocess(command, stdout=sp.PIPE, stderr=sp.STDOUT)
+def run_command(command, retcode=0, coverage=True, **kwargs):
+    proc = start_subprocess(command, stdout=sp.PIPE, stderr=sp.STDOUT, **kwargs)
     output = proc.communicate()[0].decode()
     output = output.replace("Coverage.py warning: No data was collected.\n", "")
     print(output)

--- a/nbgrader/tests/apps/base.py
+++ b/nbgrader/tests/apps/base.py
@@ -2,8 +2,8 @@ import os
 import shutil
 import pytest
 
-from IPython.nbformat import write as write_nb
-from IPython.nbformat.v4 import new_notebook
+from nbformat import write as write_nb
+from nbformat.v4 import new_notebook
 
 
 @pytest.mark.usefixtures("temp_cwd")

--- a/nbgrader/tests/apps/conftest.py
+++ b/nbgrader/tests/apps/conftest.py
@@ -53,6 +53,36 @@ def temp_dir(request):
 
 
 @pytest.fixture
+def jupyter_config_dir(request):
+    path = tempfile.mkdtemp()
+
+    def fin():
+        shutil.rmtree(path)
+    request.addfinalizer(fin)
+
+    return path
+
+
+@pytest.fixture
+def jupyter_data_dir(request):
+    path = tempfile.mkdtemp()
+
+    def fin():
+        shutil.rmtree(path)
+    request.addfinalizer(fin)
+
+    return path
+
+
+@pytest.fixture
+def env(request, jupyter_config_dir, jupyter_data_dir):
+    env = os.environ.copy()
+    env['JUPYTER_DATA_DIR'] = jupyter_data_dir
+    env['JUPYTER_CONFIG_DIR'] = jupyter_config_dir
+    return env
+
+
+@pytest.fixture
 def exchange(request):
     path = tempfile.mkdtemp()
 

--- a/nbgrader/tests/apps/test_nbgrader.py
+++ b/nbgrader/tests/apps/test_nbgrader.py
@@ -16,16 +16,9 @@ class TestNbGrader(BaseTestApp):
 
     def test_generate_config(self):
         """Is the config file properly generated?"""
+
         run_command(["nbgrader", "--generate-config"])
         assert os.path.isfile("nbgrader_config.py")
 
-        with open("nbgrader_config.py", "w") as fh:
-            fh.write("foo")
-
+        # does it fail if it already exists?
         run_command(["nbgrader", "--generate-config"], retcode=1)
-        run_command(["nbgrader", "--generate-config", "--overwrite"])
-
-        with open("nbgrader_config.py", "r") as fh:
-            contents = fh.read()
-
-        assert contents != "foo"

--- a/nbgrader/tests/nbextensions/test_create_assignment.py
+++ b/nbgrader/tests/nbextensions/test_create_assignment.py
@@ -18,7 +18,7 @@ def _load_notebook(browser, retries=5):
 
     def page_loaded(browser):
         return browser.execute_script(
-            'return typeof IPython !== "undefined" && IPython.page !== undefined;')
+            'return typeof Jupyter !== "undefined" && Jupyter.page !== undefined;')
 
     # wait for the page to load
     try:
@@ -86,7 +86,7 @@ def _set_id(browser, cell_id="foo", index=0):
 def _get_metadata(browser):
     return browser.execute_script(
         """
-        var cell = IPython.notebook.get_cell(0);
+        var cell = Jupyter.notebook.get_cell(0);
         return cell.metadata.nbgrader;
         """
     )
@@ -98,7 +98,7 @@ def _get_total_points(browser):
 
 
 def _save(browser):
-    browser.execute_script("IPython.notebook.save_notebook();")
+    browser.execute_script("Jupyter.notebook.save_notebook();")
 
 
 def _wait_for_modal(browser):

--- a/nbgrader/tests/preprocessors/base.py
+++ b/nbgrader/tests/preprocessors/base.py
@@ -1,7 +1,7 @@
 import os
 
-from IPython.nbformat import current_nbformat
-from IPython.nbformat import read as read_nb
+from nbformat import current_nbformat
+from nbformat import read as read_nb
 
 
 class BaseTestPreprocessor(object):

--- a/nbgrader/tests/preprocessors/test_deduplicateids.py
+++ b/nbgrader/tests/preprocessors/test_deduplicateids.py
@@ -1,6 +1,6 @@
 import pytest
 
-from IPython.nbformat.v4 import new_notebook
+from nbformat.v4 import new_notebook
 
 from nbgrader.preprocessors import DeduplicateIds
 from nbgrader.tests.preprocessors.base import BaseTestPreprocessor

--- a/nbgrader/tests/preprocessors/test_displayautogrades.py
+++ b/nbgrader/tests/preprocessors/test_displayautogrades.py
@@ -1,13 +1,9 @@
 import pytest
 import json
-
-try:
-    from StringIO import StringIO # python 2
-except ImportError:
-    from io import StringIO # python 3
+import six
 
 from textwrap import dedent
-from IPython.nbformat.v4 import new_output
+from nbformat.v4 import new_output
 
 from nbgrader.preprocessors import DisplayAutoGrades
 from nbgrader.tests.preprocessors.base import BaseTestPreprocessor
@@ -20,7 +16,7 @@ def preprocessor():
 
 @pytest.fixture
 def stream():
-    return StringIO()
+    return six.StringIO()
 
 
 class TestDisplayAutoGrades(BaseTestPreprocessor):

--- a/nbgrader/tests/preprocessors/test_getgrades.py
+++ b/nbgrader/tests/preprocessors/test_getgrades.py
@@ -1,6 +1,6 @@
 import pytest
 
-from IPython.nbformat.v4 import new_notebook, new_output
+from nbformat.v4 import new_notebook, new_output
 
 from nbgrader.preprocessors import SaveCells, SaveAutoGrades, GetGrades
 from nbgrader.api import Gradebook

--- a/nbgrader/tests/preprocessors/test_overwritecells.py
+++ b/nbgrader/tests/preprocessors/test_overwritecells.py
@@ -1,6 +1,6 @@
 import pytest
 
-from IPython.nbformat.v4 import new_notebook
+from nbformat.v4 import new_notebook
 
 from nbgrader.preprocessors import SaveCells, OverwriteCells
 from nbgrader.api import Gradebook

--- a/nbgrader/tests/preprocessors/test_saveautogrades.py
+++ b/nbgrader/tests/preprocessors/test_saveautogrades.py
@@ -1,6 +1,6 @@
 import pytest
 
-from IPython.nbformat.v4 import new_notebook, new_output
+from nbformat.v4 import new_notebook, new_output
 
 from nbgrader.preprocessors import SaveCells, SaveAutoGrades
 from nbgrader.api import Gradebook

--- a/nbgrader/tests/preprocessors/test_savecells.py
+++ b/nbgrader/tests/preprocessors/test_savecells.py
@@ -1,6 +1,6 @@
 import pytest
 
-from IPython.nbformat.v4 import new_notebook
+from nbformat.v4 import new_notebook
 
 from nbgrader.preprocessors import SaveCells
 from nbgrader.api import Gradebook

--- a/nbgrader/tests/utils/test_utils.py
+++ b/nbgrader/tests/utils/test_utils.py
@@ -3,7 +3,7 @@ import pytest
 import tempfile
 import shutil
 
-from IPython.nbformat.v4 import new_output
+from nbformat.v4 import new_output
 
 from nbgrader import utils
 from nbgrader.tests import (

--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -3,8 +3,7 @@ import hashlib
 import dateutil.parser
 import pwd
 import glob
-
-from IPython.utils.py3compat import str_to_bytes, string_types
+import six
 
 
 def is_grade(cell):
@@ -56,20 +55,20 @@ def determine_grade(cell):
 def compute_checksum(cell):
     m = hashlib.md5()
     # add the cell source and type
-    m.update(str_to_bytes(cell.source))
-    m.update(str_to_bytes(cell.cell_type))
+    m.update(six.b(cell.source))
+    m.update(six.b(cell.cell_type))
 
     # add whether it's a grade cell and/or solution cell
-    m.update(str_to_bytes(str(is_grade(cell))))
-    m.update(str_to_bytes(str(is_solution(cell))))
-    m.update(str_to_bytes(str(is_locked(cell))))
+    m.update(six.b(str(is_grade(cell))))
+    m.update(six.b(str(is_solution(cell))))
+    m.update(six.b(str(is_locked(cell))))
 
     # include the cell id
-    m.update(str_to_bytes(cell.metadata.nbgrader['grade_id']))
+    m.update(six.b(cell.metadata.nbgrader['grade_id']))
 
     # include the number of points that the cell is worth, if it is a grade cell
     if is_grade(cell):
-        m.update(str_to_bytes(str(float(cell.metadata.nbgrader['points']))))
+        m.update(six.b(str(float(cell.metadata.nbgrader['points']))))
 
     return m.hexdigest()
 
@@ -77,7 +76,7 @@ def parse_utc(ts):
     """Parses a timestamp into datetime format, converting it to UTC if necessary."""
     if ts is None:
         return None
-    if isinstance(ts, string_types):
+    if isinstance(ts, six.string_types):
         ts = dateutil.parser.parse(ts)
     if ts.tzinfo is not None:
         ts = (ts - ts.utcoffset()).replace(tzinfo=None)

--- a/tasks.py
+++ b/tasks.py
@@ -25,9 +25,9 @@ def _check_if_directory_in_path(pth, target):
 
 
 try:
-    from IPython.nbformat import read
+    from nbformat import read
 except ImportError:
-    echo("Warning: IPython could not be imported, some tasks may not work")
+    echo("Warning: nbformat could not be imported, some tasks may not work")
 
 
 @task
@@ -167,9 +167,6 @@ def js(clean=True):
 
 @task
 def before_install(group, python_version):
-    # install ipython
-    run('pip install ipython[all]==3.2')
-
     # clone travis wheels repo to make installing requirements easier
     run('git clone --quiet --depth 1 https://github.com/minrk/travis-wheels ~/travis-wheels')
 
@@ -182,11 +179,7 @@ def before_install(group, python_version):
     # install jupyterhub
     if python_version == '3.4' and group == 'js':
         run('npm install -g configurable-http-proxy')
-        run('pip install jupyterhub==0.2.0')
-
-    # install js dependencies
-    if group == 'js':
-        run('python -m IPython.external.mathjax')
+        run('pip install jupyterhub')
 
 
 @task


### PR DESCRIPTION
This deprecates support for IPython <4 and adds dependencies for Jupyter >=4. Besides changing imports, the code is mostly unchanged, with the exception that a few options are now deprecated (e.g. `profile` and `ipython_dir`) since they are also deprecated in Jupyter.

Fixes #344