### PR TITLE
Handle grade ids for non-nbgrader cells

### DIFF
--- a/nbgrader/preprocessors/checkcellmetadata.py
+++ b/nbgrader/preprocessors/checkcellmetadata.py
@@ -46,4 +46,9 @@ class CheckCellMetadata(NbGraderPreprocessor):
                 "Markdown solution cell (index {}) is not marked as a grade cell".format(
                     cell_index))
 
+        if 'nbgrader' in cell.metadata and 'grade_id' in cell.metadata.nbgrader:
+            if (not utils.is_grade(cell) and not utils.is_solution(cell) and not utils.is_locked(cell)):
+                self.log.warn("Removing unused grade_id from cell {}".format(cell_index))
+                del cell.metadata.nbgrader['grade_id']
+
         return cell, resources

--- a/nbgrader/tests/preprocessors/test_checkcellmetadata.py
+++ b/nbgrader/tests/preprocessors/test_checkcellmetadata.py
@@ -87,3 +87,16 @@ class TestCheckCellMetadata(BaseTestPreprocessor):
         nb = self._read_nb("files/bad-markdown-cell-2.ipynb")
         with pytest.raises(RuntimeError):
             preprocessor.preprocess(nb, {})
+
+    def test_non_nbgrader_cell_blank_grade_id(self, preprocessor):
+        resources = dict(grade_ids=[])
+        cell = create_grade_cell("", "code", "", 1)
+        cell.metadata.nbgrader['grade'] = False
+        new_cell, _ = preprocessor.preprocess_cell(cell, resources, 0)
+        assert 'grade_id' not in new_cell.metadata.nbgrader
+
+        resources = dict(grade_ids=[])
+        cell = create_solution_cell("", "code", "")
+        cell.metadata.nbgrader['solution'] = False
+        new_cell, _ = preprocessor.preprocess_cell(cell, resources, 0)
+        assert 'grade_id' not in new_cell.metadata.nbgrader

--- a/nbgrader/tests/preprocessors/test_overwritecells.py
+++ b/nbgrader/tests/preprocessors/test_overwritecells.py
@@ -192,3 +192,21 @@ class TestOverwriteCells(BaseTestPreprocessor):
 
         assert cell.metadata.nbgrader["checksum"] == compute_checksum(cell)
 
+    def test_nonexistant_grade_id(self, preprocessors, resources):
+        """Are cells not in the database ignored?"""
+        cell = create_grade_cell("", "code", "", 1)
+        cell.metadata.nbgrader['grade'] = False
+        nb = new_notebook()
+        nb.cells.append(cell)
+        nb, resources = preprocessors[0].preprocess(nb, resources)
+        nb, resources = preprocessors[1].preprocess(nb, resources)
+        assert 'grade_id' not in cell.metadata.nbgrader
+
+        cell = create_grade_cell("", "code", "foo", 1)
+        cell.metadata.nbgrader['grade'] = False
+        nb = new_notebook()
+        nb.cells.append(cell)
+        nb, resources = preprocessors[0].preprocess(nb, resources)
+        nb, resources = preprocessors[1].preprocess(nb, resources)
+        assert 'grade_id' not in cell.metadata.nbgrader
+


### PR DESCRIPTION
Currently nbgrader may crash if there are cells that aren't nbgrader cells but which have `grade_id` defined in their metadata. This fixes this issue in two places (when the assignment is released, and when it is graded) and adds tests.