### PR TITLE
Access notebook server of formgrader user

### DIFF
--- a/nbgrader/auth/base.py
+++ b/nbgrader/auth/base.py
@@ -26,6 +26,10 @@ class BaseAuth(LoggingConfigurable):
         """Checks for a notebook server."""
         return False
 
+    def get_notebook_server_cookie(self):
+        """Gets a cookie that is needed to access the notebook server."""
+        return None
+
     def get_notebook_url(self, relative_path):
         """Gets the notebook's url."""
         raise NotImplemented

--- a/nbgrader/auth/hubauth.py
+++ b/nbgrader/auth/hubauth.py
@@ -4,7 +4,8 @@ import os
 import json
 from subprocess import check_output
 from flask import request, redirect, abort
-from traitlets import Unicode, Int, List, Bool 
+from traitlets import Unicode, Int, List, Bool
+from urllib.parse import unquote
 
 from nbgrader.html.formgrade import blueprint
 from .base import BaseAuth
@@ -43,6 +44,8 @@ class HubAuth(BaseAuth):
     
     generate_hubapi_token = Bool(False, config=True, help="""Use `jupyterhub token` as a default
         for HubAuth.hubapi_token instead of $JPY_API_TOKEN.""")
+    hubapi_token_user = Unicode('', config=True, help="""The user for which to obtain
+        a jupyterhub token. Only used if `generate_hubapi_token` is True.""")
 
     hub_db = Unicode(config=True, help="""Path to JupyterHub's database.  Only
         manditory if `generate_hubapi_token` is True.""")
@@ -52,9 +55,10 @@ class HubAuth(BaseAuth):
         nbgrader will use $JPY_API_TOKEN as the API token.""")
     def _hubapi_token_default(self):
         if self.generate_hubapi_token:
-            return check_output([
-                'jupyterhub', 'token', '--db={}'.format(self.hub_db)
-                ]).decode('utf-8').strip()
+            cmd = ['jupyterhub', 'token', '--db={}'.format(self.hub_db)]
+            if self.hubapi_token_user:
+                cmd.append(self.hubapi_token_user)
+            return check_output(cmd).decode('utf-8').strip()
         else:
             return os.environ.get('JPY_API_TOKEN', '')
 
@@ -77,6 +81,15 @@ class HubAuth(BaseAuth):
     connect_ip = Unicode('', config=True, help="""The formgrader ip address that
         JupyterHub should actually connect to. Useful for when the formgrader is
         running behind a proxy or inside a container.""")
+
+    notebook_server_user = Unicode('', config=True, help="""The user that hosts
+        the autograded notebooks. By default, this is just the user that is logged
+        in, but if that user is an admin user and has the ability to access other
+        users' servers, then this variable can be set, allowing them to access
+        the notebook server with the autograded notebooks.""")
+
+    notebook_server_cookie = Unicode('', help="""The value of the cookie used to access the
+        notebook server user's notebook server.""")
 
     def __init__(self, *args, **kwargs):
         super(HubAuth, self).__init__(*args, **kwargs)
@@ -166,15 +179,66 @@ class HubAuth(BaseAuth):
 
     def notebook_server_exists(self):
         """Does the notebook server exist?"""
+        if self.notebook_server_user:
+            user = self.notebook_server_user
+        else:
+            user = self._user
+
+        # first check if the server is running
+        response = self._hubapi_request('/hub/api/users/{}'.format(user))
+        if response.status_code == 200:
+            user_data = response.json()
+        else:
+            self.log.warn("Could not access information about user {} (response: {} {})".format(
+                user, response.status_code, response.reason))
+            return False
+
+        # start it if it's not running
+        if user_data['server'] is None and user_data['pending'] != 'spawn':
+            # start the server
+            response = self._hubapi_request('/hub/api/users/{}/server'.format(user), method='POST')
+            if response.status_code not in (201, 202):
+                self.log.warn("Could not start server for user {} (response: {} {})".format(
+                    user, response.status_code, response.reason))
+                return False
+
         return True
+
+    def get_notebook_server_cookie(self):
+        # same user, so no need to request admin access
+        if not self.notebook_server_user:
+            return None
+
+        # we've already requested access
+        cookie_name = '{}-{}'.format(self.hubapi_cookie, self.notebook_server_user)
+        if not self.notebook_server_cookie:
+            # request admin access to the user's server
+            response = self._hubapi_request('/hub/api/users/{}/admin-access'.format(self.notebook_server_user), method='POST')
+            if response.status_code != 200:
+                self.log.warn("Failed to gain admin access to user {}'s server (response: {} {})".format(
+                    self.notebook_server_user, response.status_code, response.reason))
+                return None
+
+            self.log.info("Access to user {}'s server granted".format(self.notebook_server_user))
+            self.notebook_server_cookie = unquote(response.cookies[cookie_name][1:-1])
+
+        cookie = {
+            'key': cookie_name,
+            'value': self.notebook_server_cookie,
+            'path': '/user/{}'.format(self.notebook_server_user)
+        }
+
+        return cookie
 
     def get_notebook_url(self, relative_path):
         """Gets the notebook's url."""
         if self.notebook_url_prefix is not None:
             relative_path = self.notebook_url_prefix + '/' + relative_path
-        return self.hub_base_url + "/user/{}/notebooks/{}".format(
-            self._user,
-            relative_path)
+        if self.notebook_server_user:
+            user = self.notebook_server_user
+        else:
+            user = self._user
+        return "{}/user/{}/notebooks/{}".format(self.hub_base_url, user, relative_path)
 
     def _hubapi_request(self, *args, **kwargs):
         return self._request('hubapi', *args, **kwargs)

--- a/nbgrader/auth/hubauth.py
+++ b/nbgrader/auth/hubauth.py
@@ -5,7 +5,7 @@ import json
 from subprocess import check_output
 from flask import request, redirect, abort
 from traitlets import Unicode, Int, List, Bool
-from urllib.parse import unquote
+from six.moves.urllib.parse import unquote
 
 from nbgrader.html.formgrade import blueprint
 from .base import BaseAuth

--- a/nbgrader/tests/formgrader/base.py
+++ b/nbgrader/tests/formgrader/base.py
@@ -44,7 +44,7 @@ class BaseTestFormgrade(object):
             element = self.browser.find_element_by_link_text(link_text)
         element.click()
 
-    def _wait_for_element(self, element_id, time=30):
+    def _wait_for_element(self, element_id, time=10):
         return WebDriverWait(self.browser, time).until(
             EC.presence_of_element_located((By.ID, element_id))
         )
@@ -98,7 +98,7 @@ class BaseTestFormgrade(object):
             return true;
             """)
         try:
-            WebDriverWait(self.browser, 30).until(page_loaded)
+            WebDriverWait(self.browser, 10).until(page_loaded)
         except TimeoutException:
             if retries == 0:
                 raise

--- a/nbgrader/tests/formgrader/base.py
+++ b/nbgrader/tests/formgrader/base.py
@@ -49,6 +49,11 @@ class BaseTestFormgrade(object):
             EC.presence_of_element_located((By.ID, element_id))
         )
 
+    def _wait_for_visibility_of_element(self, element_id, time=10):
+        return WebDriverWait(self.browser, time).until(
+            EC.visibility_of_element_located((By.ID, element_id))
+        )
+
     def _wait_for_gradebook_page(self, url):
         self._wait_for_element("gradebook")
         self._check_url(url)

--- a/nbgrader/tests/formgrader/base.py
+++ b/nbgrader/tests/formgrader/base.py
@@ -1,9 +1,4 @@
-try:
-    from urllib import unquote # Python 2
-    from urlparse import urljoin
-except ImportError:
-    from urllib.parse import urljoin, unquote # Python 3
-
+from six.moves.urllib.parse import urljoin, unquote
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait

--- a/nbgrader/tests/formgrader/conftest.py
+++ b/nbgrader/tests/formgrader/conftest.py
@@ -75,8 +75,8 @@ def _formgrader(request, manager_class, gradebook, tempdir):
     capabilities = DesiredCapabilities.PHANTOMJS
     capabilities['loggingPrefs'] = {'browser': 'ALL'}
     browser = webdriver.PhantomJS(desired_capabilities=capabilities)
-    browser.set_page_load_timeout(30)
-    browser.set_script_timeout(30)
+    browser.set_page_load_timeout(10)
+    browser.set_script_timeout(10)
 
     request.cls.manager = man
     request.cls.gradebook = gradebook

--- a/nbgrader/tests/formgrader/fakeuser.py
+++ b/nbgrader/tests/formgrader/fakeuser.py
@@ -18,6 +18,10 @@ class FakeUserAuth(LocalAuthenticator):
             return
         return username
 
+    @staticmethod
+    def system_user_exists(user):
+        return True
+
 
 class FakeUserSpawner(LocalProcessSpawner):
 

--- a/nbgrader/tests/formgrader/manager.py
+++ b/nbgrader/tests/formgrader/manager.py
@@ -93,7 +93,7 @@ class HubAuthManager(DefaultManager):
         c.JupyterHub.authenticator_class = 'nbgrader.tests.formgrader.fakeuser.FakeUserAuth'
         c.JupyterHub.spawner_class = 'nbgrader.tests.formgrader.fakeuser.FakeUserSpawner'
         c.Authenticator.admin_users = set(['admin'])
-        c.Authenticator.whitelist = set(['foobar'])
+        c.Authenticator.whitelist = set(['foobar', 'baz'])
         c.JupyterHub.log_level = "WARN"
         """
     )
@@ -202,7 +202,7 @@ class HubAuthNotebookServerUserManager(HubAuthManager):
         c.JupyterHub.admin_access = True
         c.JupyterHub.log_level = "WARN"
         c.Authenticator.admin_users = set(['admin'])
-        c.Authenticator.whitelist = set(['foobar', 'quux'])
+        c.Authenticator.whitelist = set(['foobar', 'baz', 'quux'])
         """
     )
 

--- a/nbgrader/tests/formgrader/manager.py
+++ b/nbgrader/tests/formgrader/manager.py
@@ -10,7 +10,8 @@ __all__ = [
     "DefaultManager",
     "HubAuthManager",
     "HubAuthTokenManager",
-    "HubAuthCustomUrlManager"
+    "HubAuthCustomUrlManager",
+    "HubAuthNotebookServerUserManager"
 ]
 
 class DefaultManager(object):
@@ -91,6 +92,8 @@ class HubAuthManager(DefaultManager):
         c = get_config()
         c.JupyterHub.authenticator_class = 'nbgrader.tests.formgrader.fakeuser.FakeUserAuth'
         c.JupyterHub.spawner_class = 'nbgrader.tests.formgrader.fakeuser.FakeUserSpawner'
+        c.Authenticator.admin_users = set(['admin'])
+        c.Authenticator.whitelist = set(['foobar'])
         c.JupyterHub.log_level = "WARN"
         """
     )
@@ -115,7 +118,7 @@ class HubAuthManager(DefaultManager):
 
     def _start_formgrader(self, configproxy_auth_token='foo'):
         print("Getting token from jupyterhub")
-        token = sp.check_output(['jupyterhub', 'token'], cwd=self.tempdir).decode().strip()
+        token = sp.check_output(['jupyterhub', 'token', 'admin'], cwd=self.tempdir).decode().strip()
         self.env['JPY_API_TOKEN'] = token
         self.env['CONFIGPROXY_AUTH_TOKEN'] = configproxy_auth_token
         super(HubAuthManager, self)._start_formgrader()
@@ -150,6 +153,7 @@ class HubAuthTokenManager(HubAuthManager):
         c.HubAuth.graders = ["foobar"]
         c.HubAuth.notebook_url_prefix = "class_files"
         c.HubAuth.proxy_token = 'foo'
+        c.HubAuth.hubapi_token_user = 'admin'
         c.HubAuth.generate_hubapi_token = True
         c.HubAuth.hub_db = '{tempdir}/jupyterhub.sqlite'
         """
@@ -174,3 +178,33 @@ class HubAuthCustomUrlManager(HubAuthManager):
     )
 
     base_formgrade_url = "http://localhost:8000/hub/grader/"
+
+
+class HubAuthNotebookServerUserManager(HubAuthManager):
+
+    nbgrader_config = dedent(
+        """
+        c = get_config()
+        c.NbGrader.course_id = 'course123ABC'
+        c.FormgradeApp.port = 9000
+        c.FormgradeApp.authenticator_class = "nbgrader.auth.hubauth.HubAuth"
+        c.HubAuth.graders = ["foobar", "quux"]
+        c.HubAuth.notebook_url_prefix = "class_files"
+        c.HubAuth.notebook_server_user = 'quux'
+        """
+    )
+
+    jupyterhub_config = dedent(
+        """
+        c = get_config()
+        c.JupyterHub.authenticator_class = 'nbgrader.tests.formgrader.fakeuser.FakeUserAuth'
+        c.JupyterHub.spawner_class = 'nbgrader.tests.formgrader.fakeuser.FakeUserSpawner'
+        c.JupyterHub.admin_access = True
+        c.JupyterHub.log_level = "WARN"
+        c.Authenticator.admin_users = set(['admin'])
+        c.Authenticator.whitelist = set(['foobar', 'quux'])
+        """
+    )
+
+    base_notebook_url = "http://localhost:8000/user/quux/notebooks/class_files/"
+

--- a/nbgrader/tests/formgrader/test_formgrader_js.py
+++ b/nbgrader/tests/formgrader/test_formgrader_js.py
@@ -31,14 +31,14 @@ class TestFormgraderJS(BaseTestFormgrade):
     def _save_comment(self, index):
         self._send_keys_to_body(Keys.ESCAPE)
         glyph = self.browser.find_elements_by_css_selector(".comment-saved")[index]
-        WebDriverWait(self.browser, 30).until(lambda browser: glyph.is_displayed())
-        WebDriverWait(self.browser, 30).until(lambda browser: not glyph.is_displayed())
+        WebDriverWait(self.browser, 10).until(lambda browser: glyph.is_displayed())
+        WebDriverWait(self.browser, 10).until(lambda browser: not glyph.is_displayed())
 
     def _save_score(self, index):
         self._send_keys_to_body(Keys.ESCAPE)
         glyph = self.browser.find_elements_by_css_selector(".score-saved")[index]
-        WebDriverWait(self.browser, 30).until(lambda browser: glyph.is_displayed())
-        WebDriverWait(self.browser, 30).until(lambda browser: not glyph.is_displayed())
+        WebDriverWait(self.browser, 10).until(lambda browser: glyph.is_displayed())
+        WebDriverWait(self.browser, 10).until(lambda browser: not glyph.is_displayed())
 
     def _get_needs_manual_grade(self, name):
         return self.browser.execute_script(
@@ -373,12 +373,12 @@ class TestFormgraderJS(BaseTestFormgrade):
         # show the help dialog
         self._click_element(".help")
         self._wait_for_element("help-dialog")
-        WebDriverWait(self.browser, 30).until(EC.visibility_of_element_located((By.CSS_SELECTOR, "#help-dialog button.btn-primary")))
+        WebDriverWait(self.browser, 10).until(EC.visibility_of_element_located((By.CSS_SELECTOR, "#help-dialog button.btn-primary")))
 
         # close it
         self._click_element("#help-dialog button.btn-primary")
         modal_not_present = lambda browser: browser.execute_script("""return $("#help-dialog").length === 0;""")
-        WebDriverWait(self.browser, 30).until(modal_not_present)
+        WebDriverWait(self.browser, 10).until(modal_not_present)
 
     def test_flag(self):
         self._load_formgrade()

--- a/nbgrader/tests/formgrader/test_gradebook_navigation.py
+++ b/nbgrader/tests/formgrader/test_gradebook_navigation.py
@@ -214,6 +214,7 @@ class TestGradebook(BaseTestFormgrade):
         # logout and wait for the login page to appear
         self._get("http://localhost:8000/hub")
         self._wait_for_element("logout")
+        self._wait_for_visibility_of_element("logout")
         element = self.browser.find_element_by_id("logout")
         element.click()
         self._wait_for_element("username_input")

--- a/nbgrader/tests/formgrader/test_gradebook_navigation.py
+++ b/nbgrader/tests/formgrader/test_gradebook_navigation.py
@@ -1,5 +1,7 @@
 import pytest
 
+from six.moves.urllib.parse import quote
+
 from nbgrader.api import MissingEntry
 from nbgrader.tests.formgrader.base import BaseTestFormgrade
 from nbgrader.tests.formgrader.manager import HubAuthNotebookServerUserManager
@@ -233,7 +235,9 @@ class TestGradebook(BaseTestFormgrade):
         # try going to a live notebook page
         problem = self.gradebook.find_assignment("Problem Set 1").notebooks[0]
         submission = sorted(problem.submissions, key=lambda x: x.id)[0]
-        self._get(self.notebook_url("autograded/{}/Problem Set 1/{}.ipynb".format(submission.student.id, problem.name)))
+        url = self.notebook_url("autograded/{}/Problem Set 1/{}.ipynb".format(submission.student.id, problem.name))
+        self._get(url)
         self._wait_for_element("username_input")
-        self._check_url("http://localhost:8000/hub/login")
+        next_url = quote(url.replace("http://localhost:8000", ""))
+        self._check_url("http://localhost:8000/hub/?next={}".format(next_url))
 


### PR DESCRIPTION
When using the formgrader with JupyterHub, you can specify the path to the autograded notebook files. However, this only really allows one grader to be able to access these notebooks. What would be nice is if *any* grader could access the notebook files.

This PR makes it possible by allowing any grader to access the notebook server of a specified "formgrader user". This requires that admin access be enabled in JupyterHub, and that the user whose token the formgrader is using is an admin user. Ideally, the "formgrader user" would *not* be an admin user, and should probably not even be a real account -- it should be a user specifically created for running nbgrader.