### PR TITLE
Use relative imports

### DIFF
--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1,6 +1,6 @@
 from __future__ import division
 
-from nbgrader import utils
+from . import utils
 
 from sqlalchemy import (create_engine, ForeignKey, Column, String, Text,
     DateTime, Interval, Float, Enum, UniqueConstraint, Boolean)

--- a/nbgrader/apps/assignapp.py
+++ b/nbgrader/apps/assignapp.py
@@ -4,10 +4,10 @@ from textwrap import dedent
 
 from traitlets import List, Bool
 
-from nbgrader.api import Gradebook, MissingEntry
-from nbgrader.apps.baseapp import (
+from ..api import Gradebook, MissingEntry
+from .baseapp import (
     BaseNbConvertApp, nbconvert_aliases, nbconvert_flags)
-from nbgrader.preprocessors import (
+from ..preprocessors import (
     IncludeHeaderFooter,
     ClearSolutions,
     LockCells,

--- a/nbgrader/apps/autogradeapp.py
+++ b/nbgrader/apps/autogradeapp.py
@@ -4,11 +4,11 @@ import shutil
 from textwrap import dedent
 from traitlets import List, Bool
 
-from nbgrader.apps.baseapp import BaseNbConvertApp, nbconvert_aliases, nbconvert_flags
-from nbgrader.preprocessors import (
+from .baseapp import BaseNbConvertApp, nbconvert_aliases, nbconvert_flags
+from ..preprocessors import (
     ClearOutput, DeduplicateIds, OverwriteCells, SaveAutoGrades, Execute, LimitOutput)
-from nbgrader.api import Gradebook, MissingEntry
-from nbgrader import utils
+from ..api import Gradebook, MissingEntry
+from .. import utils
 
 aliases = {}
 aliases.update(nbconvert_aliases)

--- a/nbgrader/apps/baseapp.py
+++ b/nbgrader/apps/baseapp.py
@@ -23,7 +23,7 @@ from traitlets import Unicode, List, Bool, Instance, Dict, Integer
 from traitlets.config.application import catch_config_error
 from traitlets.config.loader import Config
 
-from nbgrader.utils import check_directory, parse_utc, find_all_files
+from ..utils import check_directory, parse_utc, find_all_files
 
 
 nbgrader_aliases = {

--- a/nbgrader/apps/collectapp.py
+++ b/nbgrader/apps/collectapp.py
@@ -5,8 +5,8 @@ from collections import defaultdict
 
 from traitlets import Bool
 
-from nbgrader.apps.baseapp import TransferApp, transfer_aliases, transfer_flags
-from nbgrader.utils import check_mode, parse_utc
+from .baseapp import TransferApp, transfer_aliases, transfer_flags
+from ..utils import check_mode, parse_utc
 
 
 aliases = {}

--- a/nbgrader/apps/extensionapp.py
+++ b/nbgrader/apps/extensionapp.py
@@ -12,7 +12,7 @@ from traitlets.config.application import catch_config_error
 from traitlets.config.application import Application
 from traitlets.config.loader import JSONFileConfigLoader, ConfigFileNotFound
 
-from nbgrader.apps.baseapp import NbGrader, format_excepthook
+from .baseapp import NbGrader, format_excepthook
 
 install_flags = {}
 install_flags.update(flags)

--- a/nbgrader/apps/feedbackapp.py
+++ b/nbgrader/apps/feedbackapp.py
@@ -4,8 +4,8 @@ from traitlets import List
 from nbconvert.exporters import HTMLExporter
 from nbconvert.preprocessors import CSSHTMLHeaderPreprocessor
 
-from nbgrader.apps.baseapp import BaseNbConvertApp, nbconvert_aliases, nbconvert_flags
-from nbgrader.preprocessors import GetGrades
+from .baseapp import BaseNbConvertApp, nbconvert_aliases, nbconvert_flags
+from ..preprocessors import GetGrades
 
 aliases = {}
 aliases.update(nbconvert_aliases)

--- a/nbgrader/apps/fetchapp.py
+++ b/nbgrader/apps/fetchapp.py
@@ -1,7 +1,7 @@
 import os
 
-from nbgrader.apps.baseapp import TransferApp, transfer_aliases, transfer_flags
-from nbgrader.utils import check_mode
+from .baseapp import TransferApp, transfer_aliases, transfer_flags
+from ..utils import check_mode
 
 
 aliases = {}

--- a/nbgrader/apps/formgradeapp.py
+++ b/nbgrader/apps/formgradeapp.py
@@ -8,10 +8,10 @@ from textwrap import dedent
 from traitlets import Unicode, Integer, Type, Instance
 from traitlets.config.application import catch_config_error
 
-from nbgrader.apps.baseapp import NbGrader, nbgrader_aliases, nbgrader_flags
-from nbgrader.formgrader import app
-from nbgrader.api import Gradebook
-from nbgrader.auth import BaseAuth, NoAuth
+from .baseapp import NbGrader, nbgrader_aliases, nbgrader_flags
+from ..formgrader import app
+from ..api import Gradebook
+from ..auth import BaseAuth, NoAuth
 
 aliases = {}
 aliases.update(nbgrader_aliases)

--- a/nbgrader/apps/listapp.py
+++ b/nbgrader/apps/listapp.py
@@ -6,7 +6,7 @@ import json
 
 from traitlets import Bool
 
-from nbgrader.apps.baseapp import TransferApp, transfer_aliases, transfer_flags
+from .baseapp import TransferApp, transfer_aliases, transfer_flags
 
 
 aliases = {}

--- a/nbgrader/apps/nbgraderapp.py
+++ b/nbgrader/apps/nbgraderapp.py
@@ -10,9 +10,9 @@ from traitlets.config.application import catch_config_error
 from traitlets import Bool
 
 import nbgrader
-from nbgrader import preprocessors
-from nbgrader.apps.baseapp import nbgrader_aliases, nbgrader_flags
-from nbgrader.apps import (
+from .. import preprocessors
+from .baseapp import nbgrader_aliases, nbgrader_flags
+from . import (
     NbGrader,
     AssignApp,
     AutogradeApp,

--- a/nbgrader/apps/releaseapp.py
+++ b/nbgrader/apps/releaseapp.py
@@ -9,8 +9,8 @@ from stat import (
 
 from traitlets import Bool
 
-from nbgrader.apps.baseapp import TransferApp, transfer_aliases, transfer_flags
-from nbgrader.utils import self_owned
+from .baseapp import TransferApp, transfer_aliases, transfer_flags
+from ..utils import self_owned
 
 
 aliases = {}

--- a/nbgrader/apps/submitapp.py
+++ b/nbgrader/apps/submitapp.py
@@ -6,8 +6,8 @@ from stat import (
     S_ISVTX, S_ISGID
 )
 
-from nbgrader.apps.baseapp import TransferApp, transfer_aliases, transfer_flags
-from nbgrader.utils import get_username, check_mode
+from .baseapp import TransferApp, transfer_aliases, transfer_flags
+from ..utils import get_username, check_mode
 
 
 aliases = {}

--- a/nbgrader/apps/validateapp.py
+++ b/nbgrader/apps/validateapp.py
@@ -1,7 +1,7 @@
 from traitlets import Unicode, List, Bool
 from nbconvert.nbconvertapp import NbConvertApp, DottedOrNone
-from nbgrader.preprocessors import DisplayAutoGrades, Execute, ClearOutput
-from nbgrader.apps.baseapp import NbGrader
+from ..preprocessors import DisplayAutoGrades, Execute, ClearOutput
+from .baseapp import NbGrader
 
 aliases = {}
 flags = {

--- a/nbgrader/auth/hubauth.py
+++ b/nbgrader/auth/hubauth.py
@@ -7,7 +7,7 @@ from flask import request, redirect, abort
 from traitlets import Unicode, Int, List, Bool
 from six.moves.urllib.parse import unquote
 
-from nbgrader.formgrader.formgrade import blueprint
+from ..formgrader.formgrade import blueprint
 from .base import BaseAuth
 
 

--- a/nbgrader/formgrader/formgrade.py
+++ b/nbgrader/formgrader/formgrade.py
@@ -1,9 +1,10 @@
 import json
 import os
 from functools import wraps
-from nbgrader.api import MissingEntry
 from flask import Flask, request, abort, redirect, url_for, render_template, \
     send_from_directory, Blueprint, g, make_response
+
+from ..api import MissingEntry
 
 app = Flask(__name__, static_url_path='')
 blueprint = Blueprint('formgrade', __name__)

--- a/nbgrader/preprocessors/checkcellmetadata.py
+++ b/nbgrader/preprocessors/checkcellmetadata.py
@@ -1,7 +1,7 @@
 import re
 
-from nbgrader import utils
-from nbgrader.preprocessors import NbGraderPreprocessor
+from .. import utils
+from . import NbGraderPreprocessor
 
 class CheckCellMetadata(NbGraderPreprocessor):
     """A preprocessor for checking that grade ids are unique."""

--- a/nbgrader/preprocessors/clearoutput.py
+++ b/nbgrader/preprocessors/clearoutput.py
@@ -1,5 +1,5 @@
 from nbconvert.preprocessors import ClearOutputPreprocessor
-from nbgrader.preprocessors import NbGraderPreprocessor
+from . import NbGraderPreprocessor
 
 class ClearOutput(NbGraderPreprocessor, ClearOutputPreprocessor):
     pass

--- a/nbgrader/preprocessors/clearsolutions.py
+++ b/nbgrader/preprocessors/clearsolutions.py
@@ -1,7 +1,7 @@
 from traitlets import Unicode
 
-from nbgrader import utils
-from nbgrader.preprocessors import NbGraderPreprocessor
+from .. import utils
+from . import NbGraderPreprocessor
 
 
 class ClearSolutions(NbGraderPreprocessor):

--- a/nbgrader/preprocessors/computechecksums.py
+++ b/nbgrader/preprocessors/computechecksums.py
@@ -1,5 +1,5 @@
-from nbgrader import utils
-from nbgrader.preprocessors import NbGraderPreprocessor
+from .. import utils
+from . import NbGraderPreprocessor
 
 class ComputeChecksums(NbGraderPreprocessor):
     """A preprocessor to compute checksums of grade cells."""

--- a/nbgrader/preprocessors/deduplicateids.py
+++ b/nbgrader/preprocessors/deduplicateids.py
@@ -1,5 +1,5 @@
-from nbgrader import utils
-from nbgrader.preprocessors import NbGraderPreprocessor
+from .. import utils
+from . import NbGraderPreprocessor
 
 class DeduplicateIds(NbGraderPreprocessor):
     """A preprocessor to overwrite information about grade and solution cells."""

--- a/nbgrader/preprocessors/displayautogrades.py
+++ b/nbgrader/preprocessors/displayautogrades.py
@@ -4,8 +4,8 @@ import json
 from traitlets import Unicode, Integer, Bool
 from nbconvert.filters import ansi2html, strip_ansi
 
-from nbgrader import utils
-from nbgrader.preprocessors import NbGraderPreprocessor
+from .. import utils
+from . import NbGraderPreprocessor
 
 from textwrap import fill, dedent
 

--- a/nbgrader/preprocessors/execute.py
+++ b/nbgrader/preprocessors/execute.py
@@ -1,7 +1,7 @@
 from nbconvert.preprocessors import ExecutePreprocessor
 from traitlets import Bool, List
 
-from nbgrader.preprocessors import NbGraderPreprocessor
+from . import NbGraderPreprocessor
 
 class Execute(NbGraderPreprocessor, ExecutePreprocessor):
 

--- a/nbgrader/preprocessors/getgrades.py
+++ b/nbgrader/preprocessors/getgrades.py
@@ -1,6 +1,6 @@
-from nbgrader import utils
-from nbgrader.api import Gradebook
-from nbgrader.preprocessors import NbGraderPreprocessor
+from .. import utils
+from ..api import Gradebook
+from . import NbGraderPreprocessor
 
 
 class GetGrades(NbGraderPreprocessor):

--- a/nbgrader/preprocessors/headerfooter.py
+++ b/nbgrader/preprocessors/headerfooter.py
@@ -2,7 +2,7 @@ from nbformat import read as read_nb
 from nbformat import current_nbformat
 from traitlets import Unicode
 
-from nbgrader.preprocessors import NbGraderPreprocessor
+from . import NbGraderPreprocessor
 
 
 class IncludeHeaderFooter(NbGraderPreprocessor):

--- a/nbgrader/preprocessors/limitoutput.py
+++ b/nbgrader/preprocessors/limitoutput.py
@@ -1,4 +1,4 @@
-from nbgrader.preprocessors import NbGraderPreprocessor
+from . import NbGraderPreprocessor
 
 from traitlets import Integer
 

--- a/nbgrader/preprocessors/lockcells.py
+++ b/nbgrader/preprocessors/lockcells.py
@@ -1,7 +1,7 @@
 from traitlets import Bool
 
-from nbgrader import utils
-from nbgrader.preprocessors import NbGraderPreprocessor
+from .. import utils
+from . import NbGraderPreprocessor
 
 class LockCells(NbGraderPreprocessor):
     """A preprocessor for making cells undeletable."""

--- a/nbgrader/preprocessors/overwritecells.py
+++ b/nbgrader/preprocessors/overwritecells.py
@@ -1,8 +1,8 @@
 from nbformat.v4.nbbase import validate
 
-from nbgrader import utils
-from nbgrader.api import Gradebook, MissingEntry
-from nbgrader.preprocessors import NbGraderPreprocessor
+from .. import utils
+from ..api import Gradebook, MissingEntry
+from . import NbGraderPreprocessor
 
 class OverwriteCells(NbGraderPreprocessor):
     """A preprocessor to overwrite information about grade and solution cells."""

--- a/nbgrader/preprocessors/saveautogrades.py
+++ b/nbgrader/preprocessors/saveautogrades.py
@@ -1,6 +1,6 @@
-from nbgrader import utils
-from nbgrader.api import Gradebook
-from nbgrader.preprocessors import NbGraderPreprocessor
+from .. import utils
+from ..api import Gradebook
+from . import NbGraderPreprocessor
 
 
 class SaveAutoGrades(NbGraderPreprocessor):

--- a/nbgrader/preprocessors/savecells.py
+++ b/nbgrader/preprocessors/savecells.py
@@ -1,6 +1,6 @@
-from nbgrader import utils
-from nbgrader.api import Gradebook, MissingEntry
-from nbgrader.preprocessors import NbGraderPreprocessor
+from .. import utils
+from ..api import Gradebook, MissingEntry
+from . import NbGraderPreprocessor
 
 class SaveCells(NbGraderPreprocessor):
     """A preprocessor to save information about grade and solution cells."""

--- a/nbgrader/tests/__init__.py
+++ b/nbgrader/tests/__init__.py
@@ -5,7 +5,7 @@ import subprocess as sp
 
 from nbformat.v4 import new_code_cell, new_markdown_cell
 
-from nbgrader.utils import compute_checksum
+from ..utils import compute_checksum
 
 
 def create_code_cell():

--- a/nbgrader/tests/api/test_gradebook.py
+++ b/nbgrader/tests/api/test_gradebook.py
@@ -1,9 +1,9 @@
 import pytest
 
 from datetime import datetime
-from nbgrader import api
-from nbgrader import utils
-from nbgrader.api import InvalidEntry, MissingEntry
+from ... import api
+from ... import utils
+from ...api import InvalidEntry, MissingEntry
 
 @pytest.fixture
 def gradebook(request):

--- a/nbgrader/tests/api/test_models.py
+++ b/nbgrader/tests/api/test_models.py
@@ -5,7 +5,8 @@ import json
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, scoped_session
 from sqlalchemy.sql import and_
-from nbgrader import api
+
+from ... import api
 
 
 @pytest.fixture

--- a/nbgrader/tests/apps/conftest.py
+++ b/nbgrader/tests/apps/conftest.py
@@ -3,7 +3,7 @@ import tempfile
 import shutil
 import pytest
 
-from nbgrader.api import Gradebook
+from ...api import Gradebook
 
 
 @pytest.fixture

--- a/nbgrader/tests/apps/test_nbgrader.py
+++ b/nbgrader/tests/apps/test_nbgrader.py
@@ -1,7 +1,7 @@
 import os
 
-from nbgrader.tests import run_command
-from nbgrader.tests.apps.base import BaseTestApp
+from .. import run_command
+from .base import BaseTestApp
 
 
 class TestNbGrader(BaseTestApp):

--- a/nbgrader/tests/apps/test_nbgrader_assign.py
+++ b/nbgrader/tests/apps/test_nbgrader_assign.py
@@ -3,9 +3,9 @@ import pytest
 
 from sqlalchemy.exc import InvalidRequestError
 
-from nbgrader.api import Gradebook
-from nbgrader.tests import run_command
-from nbgrader.tests.apps.base import BaseTestApp
+from ...api import Gradebook
+from .. import run_command
+from .base import BaseTestApp
 
 
 class TestNbGraderAssign(BaseTestApp):

--- a/nbgrader/tests/apps/test_nbgrader_autograde.py
+++ b/nbgrader/tests/apps/test_nbgrader_autograde.py
@@ -1,8 +1,8 @@
 import os
 
-from nbgrader.api import Gradebook
-from nbgrader.tests import run_command
-from nbgrader.tests.apps.base import BaseTestApp
+from ...api import Gradebook
+from .. import run_command
+from .base import BaseTestApp
 
 
 class TestNbGraderAutograde(BaseTestApp):

--- a/nbgrader/tests/apps/test_nbgrader_collect.py
+++ b/nbgrader/tests/apps/test_nbgrader_collect.py
@@ -1,8 +1,8 @@
 import os
 
-from nbgrader.tests import run_command
-from nbgrader.tests.apps.base import BaseTestApp
-from nbgrader.utils import parse_utc
+from .. import run_command
+from .base import BaseTestApp
+from ...utils import parse_utc
 
 
 class TestNbGraderCollect(BaseTestApp):

--- a/nbgrader/tests/apps/test_nbgrader_extension.py
+++ b/nbgrader/tests/apps/test_nbgrader_extension.py
@@ -3,8 +3,8 @@ import os
 import json
 import six
 
-from nbgrader.tests import run_command
-from nbgrader.tests.apps.base import BaseTestApp
+from .. import run_command
+from .base import BaseTestApp
 
 
 class TestNbGraderExtension(BaseTestApp):

--- a/nbgrader/tests/apps/test_nbgrader_feedback.py
+++ b/nbgrader/tests/apps/test_nbgrader_feedback.py
@@ -1,7 +1,7 @@
 import os
 
-from nbgrader.tests import run_command
-from nbgrader.tests.apps.base import BaseTestApp
+from .. import run_command
+from .base import BaseTestApp
 
 
 class TestNbGraderFeedback(BaseTestApp):

--- a/nbgrader/tests/apps/test_nbgrader_fetch.py
+++ b/nbgrader/tests/apps/test_nbgrader_fetch.py
@@ -1,7 +1,7 @@
 import os
 
-from nbgrader.tests import run_command
-from nbgrader.tests.apps.base import BaseTestApp
+from .. import run_command
+from .base import BaseTestApp
 
 
 class TestNbGraderFetch(BaseTestApp):

--- a/nbgrader/tests/apps/test_nbgrader_list.py
+++ b/nbgrader/tests/apps/test_nbgrader_list.py
@@ -3,8 +3,8 @@ import json
 
 from textwrap import dedent
 
-from nbgrader.tests import run_command
-from nbgrader.tests.apps.base import BaseTestApp
+from .. import run_command
+from .base import BaseTestApp
 
 
 class TestNbGraderList(BaseTestApp):

--- a/nbgrader/tests/apps/test_nbgrader_release.py
+++ b/nbgrader/tests/apps/test_nbgrader_release.py
@@ -1,7 +1,7 @@
 import os
 
-from nbgrader.tests import run_command
-from nbgrader.tests.apps.base import BaseTestApp
+from .. import run_command
+from .base import BaseTestApp
 
 
 class TestNbGraderRelease(BaseTestApp):

--- a/nbgrader/tests/apps/test_nbgrader_submit.py
+++ b/nbgrader/tests/apps/test_nbgrader_submit.py
@@ -2,9 +2,9 @@ import os
 import datetime
 import time
 
-from nbgrader.utils import parse_utc
-from nbgrader.tests import run_command
-from nbgrader.tests.apps.base import BaseTestApp
+from ...utils import parse_utc
+from .. import run_command
+from .base import BaseTestApp
 
 
 class TestNbGraderSubmit(BaseTestApp):

--- a/nbgrader/tests/apps/test_nbgrader_validate.py
+++ b/nbgrader/tests/apps/test_nbgrader_validate.py
@@ -1,7 +1,7 @@
 import json
 
-from nbgrader.tests import run_command
-from nbgrader.tests.apps.base import BaseTestApp
+from .. import run_command
+from .base import BaseTestApp
 
 
 class TestNbGraderValidate(BaseTestApp):

--- a/nbgrader/tests/formgrader/bad_manager.py
+++ b/nbgrader/tests/formgrader/bad_manager.py
@@ -1,4 +1,4 @@
-from nbgrader.tests.formgrader.manager import HubAuthManager
+from .manager import HubAuthManager
 
 __all__ = [
     'BadHubAuthManager'

--- a/nbgrader/tests/formgrader/conftest.py
+++ b/nbgrader/tests/formgrader/conftest.py
@@ -5,12 +5,12 @@ import tempfile
 import sys
 import logging
 
-from nbgrader.api import Gradebook
 from selenium import webdriver
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 
-from nbgrader.tests import run_command
-from nbgrader.tests.formgrader import manager, bad_manager
+from ...api import Gradebook
+from .. import run_command
+from . import manager, bad_manager
 
 
 @pytest.fixture(scope="session")

--- a/nbgrader/tests/formgrader/manager.py
+++ b/nbgrader/tests/formgrader/manager.py
@@ -3,7 +3,7 @@ import os
 import subprocess as sp
 
 from textwrap import dedent
-from nbgrader.tests import start_subprocess, copy_coverage_files
+from .. import start_subprocess, copy_coverage_files
 
 # to add a new manager for the tests, you MUST add it to this list of classes
 __all__ = [

--- a/nbgrader/tests/formgrader/test_auth_failures.py
+++ b/nbgrader/tests/formgrader/test_auth_failures.py
@@ -1,6 +1,6 @@
 import pytest
 
-from nbgrader.tests.formgrader.base import BaseTestFormgrade
+from .base import BaseTestFormgrade
 
 @pytest.mark.js
 @pytest.mark.usefixtures("bad_formgrader")

--- a/nbgrader/tests/formgrader/test_configproxy_auth_failure.py
+++ b/nbgrader/tests/formgrader/test_configproxy_auth_failure.py
@@ -1,7 +1,7 @@
 import pytest
 
-from nbgrader.tests.formgrader.manager import HubAuthManager
-from nbgrader.tests.formgrader.conftest import jupyterhub, minversion
+from .manager import HubAuthManager
+from .conftest import jupyterhub, minversion
 
 
 @jupyterhub

--- a/nbgrader/tests/formgrader/test_formgrader_js.py
+++ b/nbgrader/tests/formgrader/test_formgrader_js.py
@@ -5,7 +5,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
 
-from nbgrader.tests.formgrader.base import BaseTestFormgrade
+from .base import BaseTestFormgrade
 
 
 @pytest.mark.js

--- a/nbgrader/tests/formgrader/test_gradebook_navigation.py
+++ b/nbgrader/tests/formgrader/test_gradebook_navigation.py
@@ -2,9 +2,9 @@ import pytest
 
 from six.moves.urllib.parse import quote
 
-from nbgrader.api import MissingEntry
-from nbgrader.tests.formgrader.base import BaseTestFormgrade
-from nbgrader.tests.formgrader.manager import HubAuthNotebookServerUserManager
+from ...api import MissingEntry
+from .base import BaseTestFormgrade
+from .manager import HubAuthNotebookServerUserManager
 
 
 @pytest.mark.js

--- a/nbgrader/tests/formgrader/test_nbgrader_formgrade.py
+++ b/nbgrader/tests/formgrader/test_nbgrader_formgrade.py
@@ -1,4 +1,4 @@
-from nbgrader.tests import run_command
+from .. import run_command
 
 
 def test_help():

--- a/nbgrader/tests/nbextensions/conftest.py
+++ b/nbgrader/tests/nbextensions/conftest.py
@@ -13,8 +13,8 @@ from textwrap import dedent
 from nbformat import write as write_nb
 from nbformat.v4 import new_notebook
 
-from nbgrader.tests import run_command, copy_coverage_files
-from nbgrader.api import Gradebook
+from .. import run_command, copy_coverage_files
+from ...api import Gradebook
 
 @pytest.fixture(scope="module")
 def tempdir(request):

--- a/nbgrader/tests/nbextensions/test_assignment_list.py
+++ b/nbgrader/tests/nbextensions/test_assignment_list.py
@@ -6,7 +6,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException, NoSuchElementException
 
-from nbgrader.tests import run_command
+from .. import run_command
 
 
 def _wait(browser):

--- a/nbgrader/tests/preprocessors/test_checkcellmetadata.py
+++ b/nbgrader/tests/preprocessors/test_checkcellmetadata.py
@@ -1,7 +1,7 @@
 import pytest
-from nbgrader.preprocessors import CheckCellMetadata
-from nbgrader.tests.preprocessors.base import BaseTestPreprocessor
-from nbgrader.tests import create_grade_cell, create_solution_cell
+from ...preprocessors import CheckCellMetadata
+from .base import BaseTestPreprocessor
+from .. import create_grade_cell, create_solution_cell
 
 @pytest.fixture
 def preprocessor():

--- a/nbgrader/tests/preprocessors/test_clearsolutions.py
+++ b/nbgrader/tests/preprocessors/test_clearsolutions.py
@@ -1,9 +1,9 @@
 import pytest
 
 from textwrap import dedent
-from nbgrader.preprocessors import ClearSolutions
-from nbgrader.tests.preprocessors.base import BaseTestPreprocessor
-from nbgrader.tests import create_code_cell, create_text_cell
+from ...preprocessors import ClearSolutions
+from .base import BaseTestPreprocessor
+from .. import create_code_cell, create_text_cell
 
 
 @pytest.fixture

--- a/nbgrader/tests/preprocessors/test_computechecksums.py
+++ b/nbgrader/tests/preprocessors/test_computechecksums.py
@@ -1,9 +1,9 @@
 import pytest
 
-from nbgrader.preprocessors import ComputeChecksums
-from nbgrader.utils import compute_checksum
-from nbgrader.tests.preprocessors.base import BaseTestPreprocessor
-from nbgrader.tests import (
+from ...preprocessors import ComputeChecksums
+from ...utils import compute_checksum
+from .base import BaseTestPreprocessor
+from .. import (
     create_code_cell, create_text_cell,
     create_grade_cell, create_solution_cell, create_locked_cell)
 

--- a/nbgrader/tests/preprocessors/test_deduplicateids.py
+++ b/nbgrader/tests/preprocessors/test_deduplicateids.py
@@ -2,9 +2,9 @@ import pytest
 
 from nbformat.v4 import new_notebook
 
-from nbgrader.preprocessors import DeduplicateIds
-from nbgrader.tests.preprocessors.base import BaseTestPreprocessor
-from nbgrader.tests import (
+from ...preprocessors import DeduplicateIds
+from .base import BaseTestPreprocessor
+from .. import (
     create_grade_cell, create_solution_cell, create_locked_cell)
 
 

--- a/nbgrader/tests/preprocessors/test_displayautogrades.py
+++ b/nbgrader/tests/preprocessors/test_displayautogrades.py
@@ -5,9 +5,9 @@ import six
 from textwrap import dedent
 from nbformat.v4 import new_output
 
-from nbgrader.preprocessors import DisplayAutoGrades
-from nbgrader.tests.preprocessors.base import BaseTestPreprocessor
-from nbgrader.tests import (
+from ...preprocessors import DisplayAutoGrades
+from .base import BaseTestPreprocessor
+from .. import (
     create_code_cell, create_text_cell)
 
 @pytest.fixture

--- a/nbgrader/tests/preprocessors/test_getgrades.py
+++ b/nbgrader/tests/preprocessors/test_getgrades.py
@@ -2,11 +2,11 @@ import pytest
 
 from nbformat.v4 import new_notebook, new_output
 
-from nbgrader.preprocessors import SaveCells, SaveAutoGrades, GetGrades
-from nbgrader.api import Gradebook
-from nbgrader.utils import compute_checksum
-from nbgrader.tests.preprocessors.base import BaseTestPreprocessor
-from nbgrader.tests import (
+from ...preprocessors import SaveCells, SaveAutoGrades, GetGrades
+from ...api import Gradebook
+from ...utils import compute_checksum
+from .base import BaseTestPreprocessor
+from .. import (
     create_grade_cell, create_solution_cell, create_grade_and_solution_cell)
 
 

--- a/nbgrader/tests/preprocessors/test_headerfooter.py
+++ b/nbgrader/tests/preprocessors/test_headerfooter.py
@@ -1,8 +1,8 @@
 import pytest
 import os
 
-from nbgrader.preprocessors import IncludeHeaderFooter
-from nbgrader.tests.preprocessors.base import BaseTestPreprocessor
+from ...preprocessors import IncludeHeaderFooter
+from .base import BaseTestPreprocessor
 
 
 @pytest.fixture

--- a/nbgrader/tests/preprocessors/test_limitoutput.py
+++ b/nbgrader/tests/preprocessors/test_limitoutput.py
@@ -1,9 +1,9 @@
 import pytest
 
 from textwrap import dedent
-from nbgrader.preprocessors import LimitOutput
-from nbgrader.tests.preprocessors.base import BaseTestPreprocessor
-from nbgrader.tests import create_code_cell, create_text_cell
+from ...preprocessors import LimitOutput
+from .base import BaseTestPreprocessor
+from .. import create_code_cell, create_text_cell
 
 
 @pytest.fixture

--- a/nbgrader/tests/preprocessors/test_lockcells.py
+++ b/nbgrader/tests/preprocessors/test_lockcells.py
@@ -1,9 +1,9 @@
 import pytest
 import itertools
 
-from nbgrader.preprocessors import LockCells
-from nbgrader.tests.preprocessors.base import BaseTestPreprocessor
-from nbgrader.tests import create_code_cell
+from ...preprocessors import LockCells
+from .base import BaseTestPreprocessor
+from .. import create_code_cell
 
 
 @pytest.fixture

--- a/nbgrader/tests/preprocessors/test_overwritecells.py
+++ b/nbgrader/tests/preprocessors/test_overwritecells.py
@@ -2,11 +2,11 @@ import pytest
 
 from nbformat.v4 import new_notebook
 
-from nbgrader.preprocessors import SaveCells, OverwriteCells
-from nbgrader.api import Gradebook
-from nbgrader.utils import compute_checksum
-from nbgrader.tests.preprocessors.base import BaseTestPreprocessor
-from nbgrader.tests import (
+from ...preprocessors import SaveCells, OverwriteCells
+from ...api import Gradebook
+from ...utils import compute_checksum
+from .base import BaseTestPreprocessor
+from .. import (
     create_grade_cell, create_solution_cell, create_grade_and_solution_cell,
     create_locked_cell)
 

--- a/nbgrader/tests/preprocessors/test_saveautogrades.py
+++ b/nbgrader/tests/preprocessors/test_saveautogrades.py
@@ -2,11 +2,11 @@ import pytest
 
 from nbformat.v4 import new_notebook, new_output
 
-from nbgrader.preprocessors import SaveCells, SaveAutoGrades
-from nbgrader.api import Gradebook
-from nbgrader.utils import compute_checksum
-from nbgrader.tests.preprocessors.base import BaseTestPreprocessor
-from nbgrader.tests import (
+from ...preprocessors import SaveCells, SaveAutoGrades
+from ...api import Gradebook
+from ...utils import compute_checksum
+from .base import BaseTestPreprocessor
+from .. import (
     create_grade_cell, create_grade_and_solution_cell, create_solution_cell)
 
 

--- a/nbgrader/tests/preprocessors/test_savecells.py
+++ b/nbgrader/tests/preprocessors/test_savecells.py
@@ -2,11 +2,11 @@ import pytest
 
 from nbformat.v4 import new_notebook
 
-from nbgrader.preprocessors import SaveCells
-from nbgrader.api import Gradebook
-from nbgrader.utils import compute_checksum
-from nbgrader.tests.preprocessors.base import BaseTestPreprocessor
-from nbgrader.tests import (
+from ...preprocessors import SaveCells
+from ...api import Gradebook
+from ...utils import compute_checksum
+from .base import BaseTestPreprocessor
+from .. import (
     create_grade_cell, create_solution_cell, create_grade_and_solution_cell,
     create_locked_cell)
 

--- a/nbgrader/tests/utils/test_utils.py
+++ b/nbgrader/tests/utils/test_utils.py
@@ -5,8 +5,8 @@ import shutil
 
 from nbformat.v4 import new_output
 
-from nbgrader import utils
-from nbgrader.tests import (
+from ... import utils
+from .. import (
     create_code_cell,
     create_grade_cell, create_solution_cell,
     create_grade_and_solution_cell)


### PR DESCRIPTION
It is better practice to use relative imports within the package itself to make sure that's the code that is actually getting imported. This fixes (I think) all of the nbgrader imports so that's the case.