### PR TITLE
Add `requests` to dependencies.

### DIFF
--- a/flit.ini
+++ b/flit.ini
@@ -13,6 +13,7 @@ requires = sqlalchemy
     jupyter_core
     tornado
     six
+    requests
 dev-requires = nose
     pytest
     pytest-cov


### PR DESCRIPTION
Needed for extension installing.
and

closes #338

(it was present in tests because its a flit dependency)