### PR TITLE
Specify root course directory

### DIFF
--- a/nbgrader/apps/autogradeapp.py
+++ b/nbgrader/apps/autogradeapp.py
@@ -137,10 +137,7 @@ class AutogradeApp(BaseNbConvertApp):
         # copy files over from the source directory
         self.log.info("Overwriting files with master versions from the source directory")
         dest_path = self._format_dest(assignment_id, student_id)
-        source_path = self.directory_structure.format(
-            nbgrader_step=self.source_directory,
-            student_id='.',
-            assignment_id=assignment_id)
+        source_path = self._format_path(self.source_directory, '.', assignment_id)
         source_files = utils.find_all_files(source_path, self.ignore + ["*.ipynb"])
 
         # copy them to the build directory

--- a/nbgrader/apps/baseapp.py
+++ b/nbgrader/apps/baseapp.py
@@ -73,7 +73,20 @@ class NbGrader(JupyterApp):
     def _log_format_default(self):
         return "%(color)s[%(name)s | %(levelname)s]%(end_color)s %(message)s"
 
-    db_url = Unicode("sqlite:///gradebook.db", config=True, help="URL to the database")
+    db_url = Unicode(
+        "",
+        config=True,
+        help=dedent(
+            """
+            URL to the database. Defaults to sqlite:///<course_directory>/gradebook.db,
+            where <course_directory> is another configurable variable.
+            """
+        )
+    )
+
+    def _db_url_default(self):
+        return "sqlite:///{}".format(
+            os.path.abspath(os.path.join(self.course_directory, "gradebook.db")))
 
     student_id = Unicode(
         "*",

--- a/nbgrader/apps/baseapp.py
+++ b/nbgrader/apps/baseapp.py
@@ -295,6 +295,12 @@ class NbGrader(JupyterApp):
         self.update_config(self.build_extra_config())
         super(NbGrader, self).initialize(argv)
 
+    def _format_path(self, nbgrader_step, student_id, assignment_id):
+        return self.directory_structure.format(
+            nbgrader_step=nbgrader_step,
+            student_id=student_id,
+            assignment_id=assignment_id)
+
 
 # These are the aliases and flags for nbgrader apps that inherit only from
 # TransferApp
@@ -458,18 +464,10 @@ class BaseNbConvertApp(NbGrader, NbConvertApp):
         raise NotImplementedError
 
     def _format_source(self, assignment_id, student_id):
-        return self.directory_structure.format(
-            nbgrader_step=self._input_directory,
-            student_id=student_id,
-            assignment_id=assignment_id
-        )
+        return self._format_path(self._input_directory, student_id, assignment_id)
 
     def _format_dest(self, assignment_id, student_id):
-        return self.directory_structure.format(
-            nbgrader_step=self._output_directory,
-            student_id=student_id,
-            assignment_id=assignment_id
-        )
+        return self._format_path(self._output_directory, student_id, assignment_id)
 
     def build_extra_config(self):
         extra_config = super(BaseNbConvertApp, self).build_extra_config()

--- a/nbgrader/apps/collectapp.py
+++ b/nbgrader/apps/collectapp.py
@@ -104,19 +104,16 @@ class CollectApp(TransferApp):
         self.src_records = [self._sort_by_timestamp(v)[0] for v in usergroups.values()]
 
     def init_dest(self):
-        submit_dir = os.path.abspath(self.submitted_directory)
-        if not os.path.isdir(submit_dir):
-            os.mkdir(submit_dir)
+        pass
 
     def copy_files(self):
         for rec in self.src_records:
             student_id = rec['username']
             src_path = os.path.join(self.inbound_path, rec['filename'])
-            dest_path = os.path.abspath(self.directory_structure.format(
-                nbgrader_step=self.submitted_directory,
-                student_id=student_id,
-                assignment_id=self.assignment_id
-            ))
+            dest_path = self._format_path(self.submitted_directory, student_id, self.assignment_id)
+            if not os.path.exists(os.path.dirname(dest_path)):
+                os.makedirs(os.path.dirname(dest_path))
+
             copy = False
             updating = False
             if os.path.isdir(dest_path):
@@ -127,6 +124,7 @@ class CollectApp(TransferApp):
                     updating = True
             else:
                 copy = True
+
             if copy:
                 if updating:
                     self.log.info("Updating submission: {} {}".format(student_id, self.assignment_id))

--- a/nbgrader/apps/releaseapp.py
+++ b/nbgrader/apps/releaseapp.py
@@ -70,22 +70,22 @@ class ReleaseApp(TransferApp):
 
     force = Bool(False, config=True, help="Force overwrite existing files in the exchange.")
 
+    def build_extra_config(self):
+        extra_config = super(ReleaseApp, self).build_extra_config()
+        extra_config.NbGrader.student_id = '.'
+        extra_config.NbGrader.notebook_id = '*'
+        return extra_config
+
     def init_src(self):
-        self.src_path = os.path.abspath(os.path.join(self.release_directory, self.assignment_id))
+        self.src_path = self._format_path(self.release_directory, self.student_id, self.assignment_id)
         if not os.path.isdir(self.src_path):
-            self.log.error("Assignment not found: {}/{}".format(
-                self.release_directory, self.assignment_id
-            ))
-            if os.path.isdir(os.path.join(self.source_directory, self.assignment_id)):
+            source = self._format_path(self.source_directory, self.student_id, self.assignment_id)
+            if os.path.isdir(source):
                 # Looks like the instructor forgot to assign
-                self.fail("Assignment found in ./{} but not ./{}, run `nbgrader assign` first.".format(
-                    self.source_directory, self.release_directory
-                ))
+                self.fail("Assignment found in '{}' but not '{}', run `nbgrader assign` first.".format(
+                    source, self.src_path))
             else:
-                self.fail(
-                    "You have to run `nbgrader release {}` from your main nbgrader directory.".format(
-                    self.assignment_id
-                ))
+                self.fail("Assignment not found: {}".format(self.src_path))
 
     def init_dest(self):
         if self.course_id == '':

--- a/nbgrader/tests/apps/base.py
+++ b/nbgrader/tests/apps/base.py
@@ -11,28 +11,25 @@ class BaseTestApp(object):
 
     def _empty_notebook(self, path):
         nb = new_notebook()
-        full_dest = os.path.join(os.getcwd(), path)
-        if not os.path.exists(os.path.dirname(full_dest)):
-            os.makedirs(os.path.dirname(full_dest))
-        if os.path.exists(full_dest):
-            os.remove(full_dest)
-        with open(full_dest, 'w') as f:
+        if not os.path.exists(os.path.dirname(path)):
+            os.makedirs(os.path.dirname(path))
+        if os.path.exists(path):
+            os.remove(path)
+        with open(path, 'w') as f:
             write_nb(nb, f, 4)
 
     def _copy_file(self, src, dest):
         full_src = os.path.join(os.path.dirname(__file__), src)
-        full_dest = os.path.join(os.getcwd(), dest)
-        if not os.path.exists(os.path.dirname(full_dest)):
-            os.makedirs(os.path.dirname(full_dest))
-        shutil.copy(full_src, full_dest)
+        if not os.path.exists(os.path.dirname(dest)):
+            os.makedirs(os.path.dirname(dest))
+        shutil.copy(full_src, dest)
 
     def _make_file(self, path, contents=""):
-        full_dest = os.path.join(os.getcwd(), path)
-        if not os.path.exists(os.path.dirname(full_dest)):
-            os.makedirs(os.path.dirname(full_dest))
-        if os.path.exists(full_dest):
-            os.remove(full_dest)
-        with open(full_dest, "w") as fh:
+        if not os.path.exists(os.path.dirname(path)):
+            os.makedirs(os.path.dirname(path))
+        if os.path.exists(path):
+            os.remove(path)
+        with open(path, "w") as fh:
             fh.write(contents)
 
     def _get_permissions(self, filename):

--- a/nbgrader/tests/apps/base.py
+++ b/nbgrader/tests/apps/base.py
@@ -11,24 +11,27 @@ class BaseTestApp(object):
 
     def _empty_notebook(self, path):
         nb = new_notebook()
-        if not os.path.exists(os.path.dirname(path)):
-            os.makedirs(os.path.dirname(path))
-        if os.path.exists(path):
-            os.remove(path)
-        with open(path, 'w') as f:
+        full_dest = os.path.abspath(path)
+        if not os.path.exists(os.path.dirname(full_dest)):
+            os.makedirs(os.path.dirname(full_dest))
+        if os.path.exists(full_dest):
+            os.remove(full_dest)
+        with open(full_dest, 'w') as f:
             write_nb(nb, f, 4)
 
     def _copy_file(self, src, dest):
         full_src = os.path.join(os.path.dirname(__file__), src)
-        if not os.path.exists(os.path.dirname(dest)):
-            os.makedirs(os.path.dirname(dest))
-        shutil.copy(full_src, dest)
+        full_dest = os.path.abspath(dest)
+        if not os.path.exists(os.path.dirname(full_dest)):
+            os.makedirs(os.path.dirname(full_dest))
+        shutil.copy(full_src, full_dest)
 
     def _make_file(self, path, contents=""):
-        if not os.path.exists(os.path.dirname(path)):
-            os.makedirs(os.path.dirname(path))
-        if os.path.exists(path):
-            os.remove(path)
+        full_dest = os.path.abspath(path)
+        if not os.path.exists(os.path.dirname(full_dest)):
+            os.makedirs(os.path.dirname(full_dest))
+        if os.path.exists(full_dest):
+            os.remove(full_dest)
         with open(path, "w") as fh:
             fh.write(contents)
 

--- a/nbgrader/tests/apps/conftest.py
+++ b/nbgrader/tests/apps/conftest.py
@@ -3,6 +3,8 @@ import tempfile
 import shutil
 import pytest
 
+from textwrap import dedent
+
 from ...api import Gradebook
 
 
@@ -28,13 +30,10 @@ def gradebook(db):
 
 
 @pytest.fixture
-def temp_cwd(request):
-    orig_dir = os.getcwd()
+def course_dir(request):
     path = tempfile.mkdtemp()
-    os.chdir(path)
 
     def fin():
-        os.chdir(orig_dir)
         shutil.rmtree(path)
     request.addfinalizer(fin)
 
@@ -42,10 +41,21 @@ def temp_cwd(request):
 
 
 @pytest.fixture
-def temp_dir(request):
+def temp_cwd(request, course_dir):
+    orig_dir = os.getcwd()
     path = tempfile.mkdtemp()
+    os.chdir(path)
+
+    with open("nbgrader_config.py", "w") as fh:
+        fh.write(dedent(
+            """
+            c = get_config()
+            c.NbGrader.course_directory = "{}"
+            """.format(course_dir)
+        ))
 
     def fin():
+        os.chdir(orig_dir)
         shutil.rmtree(path)
     request.addfinalizer(fin)
 

--- a/nbgrader/tests/apps/test_nbgrader.py
+++ b/nbgrader/tests/apps/test_nbgrader.py
@@ -17,6 +17,10 @@ class TestNbGrader(BaseTestApp):
     def test_generate_config(self):
         """Is the config file properly generated?"""
 
+        # it already exists, because we create it in conftest.py
+        os.remove("nbgrader_config.py")
+
+        # try recreating it
         run_python_module(["nbgrader", "--generate-config"])
         assert os.path.isfile("nbgrader_config.py")
 

--- a/nbgrader/tests/apps/test_nbgrader_assign.py
+++ b/nbgrader/tests/apps/test_nbgrader_assign.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 
+from os.path import join
 from sqlalchemy.exc import InvalidRequestError
 
 from ...api import Gradebook
@@ -26,46 +27,46 @@ class TestNbGraderAssign(BaseTestApp):
         """Is there an error if multiple arguments are given?"""
         run_python_module(["nbgrader", "assign", "foo", "bar"], retcode=1)
 
-    def test_no_assignment(self):
+    def test_no_assignment(self, course_dir):
         """Is an error thrown if the assignment doesn't exist?"""
-        self._empty_notebook('source/ps1/foo.ipynb')
+        self._empty_notebook(join(course_dir, 'source', 'ps1', 'foo.ipynb'))
         run_python_module(["nbgrader", "assign", "ps1"], retcode=1)
 
-    def test_single_file(self):
+    def test_single_file(self, course_dir):
         """Can a single file be assigned?"""
-        self._empty_notebook('source/ps1/foo.ipynb')
+        self._empty_notebook(join(course_dir, 'source', 'ps1', 'foo.ipynb'))
         run_python_module(["nbgrader", "assign", "ps1", "--create"])
-        assert os.path.isfile("release/ps1/foo.ipynb")
+        assert os.path.isfile(join(course_dir, "release", "ps1", "foo.ipynb"))
 
-    def test_multiple_files(self):
+    def test_multiple_files(self, course_dir):
         """Can multiple files be assigned?"""
-        self._empty_notebook('source/ps1/foo.ipynb')
-        self._empty_notebook('source/ps1/bar.ipynb')
+        self._empty_notebook(join(course_dir, 'source', 'ps1', 'foo.ipynb'))
+        self._empty_notebook(join(course_dir, 'source', 'ps1', 'bar.ipynb'))
         run_python_module(["nbgrader", "assign", "ps1", "--create"])
-        assert os.path.isfile("release/ps1/foo.ipynb")
-        assert os.path.isfile("release/ps1/bar.ipynb")
+        assert os.path.isfile(join(course_dir, 'release', 'ps1', 'foo.ipynb'))
+        assert os.path.isfile(join(course_dir, 'release', 'ps1', 'bar.ipynb'))
 
-    def test_dependent_files(self):
+    def test_dependent_files(self, course_dir):
         """Are dependent files properly linked?"""
-        self._make_file('source/ps1/data/foo.csv', 'foo')
-        self._make_file('source/ps1/data/bar.csv', 'bar')
-        self._empty_notebook('source/ps1/foo.ipynb')
-        self._empty_notebook('source/ps1/bar.ipynb')
+        self._make_file(join(course_dir, 'source', 'ps1', 'data', 'foo.csv'), 'foo')
+        self._make_file(join(course_dir, 'source', 'ps1', 'data', 'bar.csv'), 'bar')
+        self._empty_notebook(join(course_dir, 'source', 'ps1', 'foo.ipynb'))
+        self._empty_notebook(join(course_dir, 'source', 'ps1', 'bar.ipynb'))
         run_python_module(["nbgrader", "assign", "ps1", "--create"])
 
-        assert os.path.isfile("release/ps1/foo.ipynb")
-        assert os.path.isfile("release/ps1/bar.ipynb")
-        assert os.path.isfile("release/ps1/data/foo.csv")
-        assert os.path.isfile("release/ps1/data/bar.csv")
+        assert os.path.isfile(join(course_dir, 'release', 'ps1', 'foo.ipynb'))
+        assert os.path.isfile(join(course_dir, 'release', 'ps1', 'bar.ipynb'))
+        assert os.path.isfile(join(course_dir, 'release', 'ps1', 'data', 'foo.csv'))
+        assert os.path.isfile(join(course_dir, 'release', 'ps1', 'data', 'bar.csv'))
 
-        with open('release/ps1/data/foo.csv', 'r') as fh:
+        with open(join(course_dir, 'release', 'ps1', 'data', 'foo.csv'), 'r') as fh:
             assert fh.read() == 'foo'
-        with open('release/ps1/data/bar.csv', 'r') as fh:
+        with open(join(course_dir, 'release', 'ps1', 'data', 'bar.csv'), 'r') as fh:
             assert fh.read() == 'bar'
 
-    def test_save_cells(self, db):
+    def test_save_cells(self, db, course_dir):
         """Ensure cells are saved into the database"""
-        self._copy_file("files/test.ipynb", "source/ps1/test.ipynb")
+        self._copy_file(join('files', 'test.ipynb'), join(course_dir, 'source', 'ps1', 'test.ipynb'))
 
         gb = Gradebook(db)
         gb.add_assignment("ps1")
@@ -75,71 +76,71 @@ class TestNbGraderAssign(BaseTestApp):
         notebook = gb.find_notebook("test", "ps1")
         assert len(notebook.grade_cells) == 6
 
-    def test_force(self):
+    def test_force(self, course_dir):
         """Ensure the force option works properly"""
-        self._copy_file("files/test.ipynb", "source/ps1/test.ipynb")
-        self._make_file("source/ps1/foo.txt", "foo")
-        self._make_file("source/ps1/data/bar.txt", "bar")
-        self._make_file("source/ps1/blah.pyc", "asdf")
+        self._copy_file(join('files', 'test.ipynb'), join(course_dir, 'source', 'ps1', 'test.ipynb'))
+        self._make_file(join(course_dir, 'source', 'ps1', 'foo.txt'), "foo")
+        self._make_file(join(course_dir, 'source', 'ps1', 'data', 'bar.txt'), "bar")
+        self._make_file(join(course_dir, 'source', 'ps1', 'blah.pyc'), "asdf")
 
         run_python_module(["nbgrader", "assign", "ps1", "--create"])
-        assert os.path.isfile("release/ps1/test.ipynb")
-        assert os.path.isfile("release/ps1/foo.txt")
-        assert os.path.isfile("release/ps1/data/bar.txt")
-        assert not os.path.isfile("release/ps1/blah.pyc")
+        assert os.path.isfile(join(course_dir, 'release', 'ps1', 'test.ipynb'))
+        assert os.path.isfile(join(course_dir, 'release', 'ps1', 'foo.txt'))
+        assert os.path.isfile(join(course_dir, 'release', 'ps1', 'data', 'bar.txt'))
+        assert not os.path.isfile(join(course_dir, 'release', 'ps1', 'blah.pyc'))
 
         # check that it skips the existing directory
-        os.remove("release/ps1/foo.txt")
+        os.remove(join(course_dir, 'release', 'ps1', 'foo.txt'))
         run_python_module(["nbgrader", "assign", "ps1"])
-        assert not os.path.isfile("release/ps1/foo.txt")
+        assert not os.path.isfile(join(course_dir, 'release', 'ps1', 'foo.txt'))
 
         # force overwrite the supplemental files
         run_python_module(["nbgrader", "assign", "ps1", "--force"])
-        assert os.path.isfile("release/ps1/foo.txt")
+        assert os.path.isfile(join(course_dir, 'release', 'ps1', 'foo.txt'))
 
         # force overwrite
-        os.remove("source/ps1/foo.txt")
+        os.remove(join(course_dir, 'source', 'ps1', 'foo.txt'))
         run_python_module(["nbgrader", "assign", "ps1", "--force"])
-        assert os.path.isfile("release/ps1/test.ipynb")
-        assert os.path.isfile("release/ps1/data/bar.txt")
-        assert not os.path.isfile("release/ps1/foo.txt")
-        assert not os.path.isfile("release/ps1/blah.pyc")
+        assert os.path.isfile(join(course_dir, "release", "ps1", "test.ipynb"))
+        assert os.path.isfile(join(course_dir, "release", "ps1", "data", "bar.txt"))
+        assert not os.path.isfile(join(course_dir, "release", "ps1", "foo.txt"))
+        assert not os.path.isfile(join(course_dir, "release", "ps1", "blah.pyc"))
 
-    def test_permissions(self):
+    def test_permissions(self, course_dir):
         """Are permissions properly set?"""
-        self._empty_notebook('source/ps1/foo.ipynb')
-        self._make_file("source/ps1/foo.txt", "foo")
+        self._empty_notebook(join(course_dir, 'source', 'ps1', 'foo.ipynb'))
+        self._make_file(join(course_dir, 'source', 'ps1', 'foo.txt'), 'foo')
         run_python_module(["nbgrader", "assign", "ps1", "--create"])
 
-        assert os.path.isfile("release/ps1/foo.ipynb")
-        assert os.path.isfile("release/ps1/foo.txt")
-        assert self._get_permissions("release/ps1/foo.ipynb") == "644"
-        assert self._get_permissions("release/ps1/foo.txt") == "644"
+        assert os.path.isfile(join(course_dir, "release", "ps1", "foo.ipynb"))
+        assert os.path.isfile(join(course_dir, "release", "ps1", "foo.txt"))
+        assert self._get_permissions(join(course_dir, "release", "ps1", "foo.ipynb")) == "644"
+        assert self._get_permissions(join(course_dir, "release", "ps1", "foo.txt")) == "644"
 
-    def test_custom_permissions(self):
+    def test_custom_permissions(self, course_dir):
         """Are custom permissions properly set?"""
-        self._empty_notebook('source/ps1/foo.ipynb')
-        self._make_file("source/ps1/foo.txt", "foo")
+        self._empty_notebook(join(course_dir, 'source', 'ps1', 'foo.ipynb'))
+        self._make_file(join(course_dir, 'source', 'ps1', 'foo.txt'), 'foo')
         run_python_module(["nbgrader", "assign", "ps1", "--create", "--AssignApp.permissions=666"])
 
-        assert os.path.isfile("release/ps1/foo.ipynb")
-        assert os.path.isfile("release/ps1/foo.txt")
-        assert self._get_permissions("release/ps1/foo.ipynb") == "666"
-        assert self._get_permissions("release/ps1/foo.txt") == "666"
+        assert os.path.isfile(join(course_dir, "release", "ps1", "foo.ipynb"))
+        assert os.path.isfile(join(course_dir, "release", "ps1", "foo.txt"))
+        assert self._get_permissions(join(course_dir, "release", "ps1", "foo.ipynb")) == "666"
+        assert self._get_permissions(join(course_dir, "release", "ps1", "foo.txt")) == "666"
 
-    def test_add_remove_extra_notebooks(self, db):
+    def test_add_remove_extra_notebooks(self, db, course_dir):
         """Are extra notebooks added and removed?"""
         gb = Gradebook(db)
         assignment = gb.add_assignment("ps1")
 
-        self._copy_file("files/test.ipynb", "source/ps1/test.ipynb")
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "test.ipynb"))
         run_python_module(["nbgrader", "assign", "ps1", "--db", db])
 
         gb.db.refresh(assignment)
         assert len(assignment.notebooks) == 1
         notebook1 = gb.find_notebook("test", "ps1")
 
-        self._copy_file("files/test.ipynb", "source/ps1/test2.ipynb")
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "test2.ipynb"))
         run_python_module(["nbgrader", "assign", "ps1", "--db", db, "--force"])
 
         gb.db.refresh(assignment)
@@ -147,7 +148,7 @@ class TestNbGraderAssign(BaseTestApp):
         gb.db.refresh(notebook1)
         notebook2 = gb.find_notebook("test2", "ps1")
 
-        os.remove("source/ps1/test2.ipynb")
+        os.remove(join(course_dir, "source", "ps1", "test2.ipynb"))
         run_python_module(["nbgrader", "assign", "ps1", "--db", db, "--force"])
 
         gb.db.refresh(assignment)
@@ -156,12 +157,12 @@ class TestNbGraderAssign(BaseTestApp):
         with pytest.raises(InvalidRequestError):
             gb.db.refresh(notebook2)
 
-    def test_add_extra_notebooks_with_submissions(self, db):
+    def test_add_extra_notebooks_with_submissions(self, db, course_dir):
         """Is an error thrown when new notebooks are added and there are existing submissions?"""
         gb = Gradebook(db)
         assignment = gb.add_assignment("ps1")
 
-        self._copy_file("files/test.ipynb", "source/ps1/test.ipynb")
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "test.ipynb"))
         run_python_module(["nbgrader", "assign", "ps1", "--db", db])
 
         gb.db.refresh(assignment)
@@ -170,16 +171,16 @@ class TestNbGraderAssign(BaseTestApp):
         gb.add_student("hacker123")
         gb.add_submission("ps1", "hacker123")
 
-        self._copy_file("files/test.ipynb", "source/ps1/test2.ipynb")
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "test2.ipynb"))
         run_python_module(["nbgrader", "assign", "ps1", "--db", db, "--force"], retcode=1)
 
-    def test_remove_extra_notebooks_with_submissions(self, db):
+    def test_remove_extra_notebooks_with_submissions(self, db, course_dir):
         """Is an error thrown when notebooks are removed and there are existing submissions?"""
         gb = Gradebook(db)
         assignment = gb.add_assignment("ps1")
 
-        self._copy_file("files/test.ipynb", "source/ps1/test.ipynb")
-        self._copy_file("files/test.ipynb", "source/ps1/test2.ipynb")
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "test.ipynb"))
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "test2.ipynb"))
         run_python_module(["nbgrader", "assign", "ps1", "--db", db])
 
         gb.db.refresh(assignment)
@@ -188,15 +189,15 @@ class TestNbGraderAssign(BaseTestApp):
         gb.add_student("hacker123")
         gb.add_submission("ps1", "hacker123")
 
-        os.remove("source/ps1/test2.ipynb")
+        os.remove(join(course_dir, "source", "ps1", "test2.ipynb"))
         run_python_module(["nbgrader", "assign", "ps1", "--db", db, "--force"], retcode=1)
 
-    def test_same_notebooks_with_submissions(self, db):
+    def test_same_notebooks_with_submissions(self, db, course_dir):
         """Is it ok to run nbgrader assign with the same notebooks and existing submissions?"""
         gb = Gradebook(db)
         assignment = gb.add_assignment("ps1")
 
-        self._copy_file("files/test.ipynb", "source/ps1/test.ipynb")
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "test.ipynb"))
         run_python_module(["nbgrader", "assign", "ps1", "--db", db])
 
         gb.db.refresh(assignment)
@@ -215,25 +216,25 @@ class TestNbGraderAssign(BaseTestApp):
         gb.db.refresh(submission)
         gb.db.refresh(submission_notebook)
 
-    def test_force_single_notebook(self):
-        self._copy_file("files/test.ipynb", "source/ps1/p1.ipynb")
-        self._copy_file("files/test.ipynb", "source/ps1/p2.ipynb")
+    def test_force_single_notebook(self, course_dir):
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p2.ipynb"))
         run_python_module(["nbgrader", "assign", "ps1", "--create"])
 
-        assert os.path.exists("release/ps1/p1.ipynb")
-        assert os.path.exists("release/ps1/p2.ipynb")
-        p1 = self._file_contents("release/ps1/p1.ipynb")
-        p2 = self._file_contents("release/ps1/p2.ipynb")
+        assert os.path.exists(join(course_dir, "release", "ps1", "p1.ipynb"))
+        assert os.path.exists(join(course_dir, "release", "ps1", "p2.ipynb"))
+        p1 = self._file_contents(join(course_dir, "release", "ps1", "p1.ipynb"))
+        p2 = self._file_contents(join(course_dir, "release", "ps1", "p2.ipynb"))
         assert p1 == p2
 
-        self._copy_file("files/submitted-changed.ipynb", "source/ps1/p1.ipynb")
-        self._copy_file("files/submitted-changed.ipynb", "source/ps1/p2.ipynb")
+        self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
+        self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "source", "ps1", "p2.ipynb"))
         run_python_module(["nbgrader", "assign", "ps1", "--notebook", "p1", "--force"])
 
-        assert os.path.exists("release/ps1/p1.ipynb")
-        assert os.path.exists("release/ps1/p2.ipynb")
-        assert p1 != self._file_contents("release/ps1/p1.ipynb")
-        assert p2 == self._file_contents("release/ps1/p2.ipynb")
+        assert os.path.exists(join(course_dir, "release", "ps1", "p1.ipynb"))
+        assert os.path.exists(join(course_dir, "release", "ps1", "p2.ipynb"))
+        assert p1 != self._file_contents(join(course_dir, "release", "ps1", "p1.ipynb"))
+        assert p2 == self._file_contents(join(course_dir, "release", "ps1", "p2.ipynb"))
 
     def test_fail_no_notebooks(self):
         run_python_module(["nbgrader", "assign", "ps1", "--create"], retcode=1)

--- a/nbgrader/tests/apps/test_nbgrader_autograde.py
+++ b/nbgrader/tests/apps/test_nbgrader_autograde.py
@@ -1,5 +1,7 @@
 import os
 
+from os.path import join
+
 from ...api import Gradebook
 from .. import run_python_module
 from .base import BaseTestApp
@@ -11,45 +13,45 @@ class TestNbGraderAutograde(BaseTestApp):
         """Does the help display without error?"""
         run_python_module(["nbgrader", "autograde", "--help-all"])
 
-    def test_missing_student(self, gradebook):
+    def test_missing_student(self, gradebook, course_dir):
         """Is an error thrown when the student is missing?"""
-        self._copy_file("files/submitted-changed.ipynb", "source/ps1/p1.ipynb")
+        self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         run_python_module(["nbgrader", "assign", "ps1", "--db", gradebook])
 
-        self._copy_file("files/submitted-changed.ipynb", "submitted/baz/ps1/p1.ipynb")
+        self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "baz", "ps1", "p1.ipynb"))
         run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook], retcode=1)
 
-    def test_add_missing_student(self, gradebook):
+    def test_add_missing_student(self, gradebook, course_dir):
         """Can a missing student be added?"""
-        self._copy_file("files/submitted-changed.ipynb", "source/ps1/p1.ipynb")
+        self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         run_python_module(["nbgrader", "assign", "ps1", "--db", gradebook])
 
-        self._copy_file("files/submitted-changed.ipynb", "submitted/baz/ps1/p1.ipynb")
+        self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "baz", "ps1", "p1.ipynb"))
         run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook, "--create"])
 
-        assert os.path.isfile("autograded/baz/ps1/p1.ipynb")
+        assert os.path.isfile(join(course_dir, "autograded", "baz", "ps1", "p1.ipynb"))
 
-    def test_missing_assignment(self, gradebook):
+    def test_missing_assignment(self, gradebook, course_dir):
         """Is an error thrown when the assignment is missing?"""
-        self._copy_file("files/submitted-changed.ipynb", "source/ps1/p1.ipynb")
+        self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         run_python_module(["nbgrader", "assign", "ps1", "--db", gradebook])
 
-        self._copy_file("files/submitted-changed.ipynb", "submitted/ps2/foo/p1.ipynb")
+        self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "ps2", "foo", "p1.ipynb"))
         run_python_module(["nbgrader", "autograde", "ps2", "--db", gradebook], retcode=1)
 
-    def test_grade(self, gradebook):
+    def test_grade(self, gradebook, course_dir):
         """Can files be graded?"""
-        self._copy_file("files/submitted-unchanged.ipynb", "source/ps1/p1.ipynb")
+        self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         run_python_module(["nbgrader", "assign", "ps1", "--db", gradebook])
 
-        self._copy_file("files/submitted-unchanged.ipynb", "submitted/foo/ps1/p1.ipynb")
-        self._copy_file("files/submitted-changed.ipynb", "submitted/bar/ps1/p1.ipynb")
+        self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
+        self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "bar", "ps1", "p1.ipynb"))
         run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook])
 
-        assert os.path.isfile("autograded/foo/ps1/p1.ipynb")
-        assert not os.path.isfile("autograded/foo/ps1/timestamp.txt")
-        assert os.path.isfile("autograded/bar/ps1/p1.ipynb")
-        assert not os.path.isfile("autograded/bar/ps1/timestamp.txt")
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
+        assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "timestamp.txt"))
+        assert os.path.isfile(join(course_dir, "autograded", "bar", "ps1", "p1.ipynb"))
+        assert not os.path.isfile(join(course_dir, "autograded", "bar", "ps1", "timestamp.txt"))
 
         gb = Gradebook(gradebook)
         notebook = gb.find_submission_notebook("p1", "ps1", "foo")
@@ -75,285 +77,285 @@ class TestNbGraderAutograde(BaseTestApp):
         assert comment1.comment == None
         assert comment2.comment == None
 
-    def test_grade_timestamp(self, gradebook):
+    def test_grade_timestamp(self, gradebook, course_dir):
         """Is a timestamp correctly read in?"""
-        self._copy_file("files/submitted-unchanged.ipynb", "source/ps1/p1.ipynb")
+        self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         run_python_module(["nbgrader", "assign", "ps1", "--db", gradebook])
 
-        self._copy_file("files/submitted-unchanged.ipynb", "submitted/foo/ps1/p1.ipynb")
-        self._make_file('submitted/foo/ps1/timestamp.txt', "2015-02-02 15:58:23.948203 PST")
+        self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
+        self._make_file(join(course_dir, "submitted", "foo", "ps1", "timestamp.txt"), "2015-02-02 15:58:23.948203 PST")
 
-        self._copy_file("files/submitted-changed.ipynb", "submitted/bar/ps1/p1.ipynb")
-        self._make_file('submitted/bar/ps1/timestamp.txt', "2015-02-01 14:58:23.948203 PST")
+        self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "bar", "ps1", "p1.ipynb"))
+        self._make_file(join(course_dir, "submitted", "bar", "ps1", "timestamp.txt"), "2015-02-01 14:58:23.948203 PST")
 
         run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook])
 
-        assert os.path.isfile("autograded/foo/ps1/p1.ipynb")
-        assert os.path.isfile("autograded/foo/ps1/timestamp.txt")
-        assert os.path.isfile("autograded/bar/ps1/p1.ipynb")
-        assert os.path.isfile("autograded/bar/ps1/timestamp.txt")
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "timestamp.txt"))
+        assert os.path.isfile(join(course_dir, "autograded", "bar", "ps1", "p1.ipynb"))
+        assert os.path.isfile(join(course_dir, "autograded", "bar", "ps1", "timestamp.txt"))
 
         gb = Gradebook(gradebook)
-        submission = gb.find_submission('ps1', 'foo')
+        submission = gb.find_submission("ps1", "foo")
         assert submission.total_seconds_late > 0
-        submission = gb.find_submission('ps1', 'bar')
+        submission = gb.find_submission("ps1", "bar")
         assert submission.total_seconds_late == 0
 
         # make sure it still works to run it a second time
         run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook])
 
-    def test_force(self, gradebook):
+    def test_force(self, gradebook, course_dir):
         """Ensure the force option works properly"""
-        self._copy_file("files/submitted-unchanged.ipynb", "source/ps1/p1.ipynb")
-        self._make_file("source/ps1/foo.txt", "foo")
-        self._make_file("source/ps1/data/bar.txt", "bar")
+        self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
+        self._make_file(join(course_dir, "source", "ps1", "foo.txt"), "foo")
+        self._make_file(join(course_dir, "source", "ps1", "data", "bar.txt"), "bar")
         run_python_module(["nbgrader", "assign", "ps1", "--db", gradebook])
 
-        self._copy_file("files/submitted-unchanged.ipynb", "submitted/foo/ps1/p1.ipynb")
-        self._make_file("submitted/foo/ps1/foo.txt", "foo")
-        self._make_file("submitted/foo/ps1/data/bar.txt", "bar")
-        self._make_file("submitted/foo/ps1/blah.pyc", "asdf")
+        self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
+        self._make_file(join(course_dir, "submitted", "foo", "ps1", "foo.txt"), "foo")
+        self._make_file(join(course_dir, "submitted", "foo", "ps1", "data", "bar.txt"), "bar")
+        self._make_file(join(course_dir, "submitted", "foo", "ps1", "blah.pyc"), "asdf")
         run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook])
 
-        assert os.path.isfile("autograded/foo/ps1/p1.ipynb")
-        assert os.path.isfile("autograded/foo/ps1/foo.txt")
-        assert os.path.isfile("autograded/foo/ps1/data/bar.txt")
-        assert not os.path.isfile("autograded/foo/ps1/blah.pyc")
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "data", "bar.txt"))
+        assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "blah.pyc"))
 
         # check that it skips the existing directory
-        os.remove("autograded/foo/ps1/foo.txt")
+        os.remove(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
         run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook])
-        assert not os.path.isfile("autograded/foo/ps1/foo.txt")
+        assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
 
         # force overwrite the supplemental files
         run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook, "--force"])
-        assert os.path.isfile("autograded/foo/ps1/foo.txt")
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
 
         # force overwrite
-        os.remove("source/ps1/foo.txt")
-        os.remove("submitted/foo/ps1/foo.txt")
+        os.remove(join(course_dir, "source", "ps1", "foo.txt"))
+        os.remove(join(course_dir, "submitted", "foo", "ps1", "foo.txt"))
         run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook, "--force"])
-        assert os.path.isfile("autograded/foo/ps1/p1.ipynb")
-        assert not os.path.isfile("autograded/foo/ps1/foo.txt")
-        assert os.path.isfile("autograded/foo/ps1/data/bar.txt")
-        assert not os.path.isfile("autograded/foo/ps1/blah.pyc")
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
+        assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "data", "bar.txt"))
+        assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "blah.pyc"))
 
-    def test_filter_notebook(self, gradebook):
+    def test_filter_notebook(self, gradebook, course_dir):
         """Does autograding filter by notebook properly?"""
-        self._copy_file("files/submitted-unchanged.ipynb", "source/ps1/p1.ipynb")
-        self._make_file("source/ps1/foo.txt", "foo")
-        self._make_file("source/ps1/data/bar.txt", "bar")
+        self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
+        self._make_file(join(course_dir, "source", "ps1", "foo.txt"), "foo")
+        self._make_file(join(course_dir, "source", "ps1", "data", "bar.txt"), "bar")
         run_python_module(["nbgrader", "assign", "ps1", "--db", gradebook])
 
-        self._copy_file("files/submitted-unchanged.ipynb", "submitted/foo/ps1/p1.ipynb")
-        self._make_file("submitted/foo/ps1/foo.txt", "foo")
-        self._make_file("submitted/foo/ps1/data/bar.txt", "bar")
-        self._make_file("submitted/foo/ps1/blah.pyc", "asdf")
+        self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
+        self._make_file(join(course_dir, "submitted", "foo", "ps1", "foo.txt"), "foo")
+        self._make_file(join(course_dir, "submitted", "foo", "ps1", "data", "bar.txt"), "bar")
+        self._make_file(join(course_dir, "submitted", "foo", "ps1", "blah.pyc"), "asdf")
         run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook, "--notebook", "p1"])
 
-        assert os.path.isfile("autograded/foo/ps1/p1.ipynb")
-        assert os.path.isfile("autograded/foo/ps1/foo.txt")
-        assert os.path.isfile("autograded/foo/ps1/data/bar.txt")
-        assert not os.path.isfile("autograded/foo/ps1/blah.pyc")
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "data", "bar.txt"))
+        assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "blah.pyc"))
 
         # check that removing the notebook still causes the autograder to run
-        os.remove("autograded/foo/ps1/p1.ipynb")
-        os.remove("autograded/foo/ps1/foo.txt")
+        os.remove(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
+        os.remove(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
         run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook, "--notebook", "p1"])
 
-        assert os.path.isfile("autograded/foo/ps1/p1.ipynb")
-        assert os.path.isfile("autograded/foo/ps1/foo.txt")
-        assert os.path.isfile("autograded/foo/ps1/data/bar.txt")
-        assert not os.path.isfile("autograded/foo/ps1/blah.pyc")
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "data", "bar.txt"))
+        assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "blah.pyc"))
 
-        # check that running it again doesn't do anything
-        os.remove("autograded/foo/ps1/foo.txt")
+        # check that running it again doesn"t do anything
+        os.remove(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
         run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook, "--notebook", "p1"])
 
-        assert os.path.isfile("autograded/foo/ps1/p1.ipynb")
-        assert not os.path.isfile("autograded/foo/ps1/foo.txt")
-        assert os.path.isfile("autograded/foo/ps1/data/bar.txt")
-        assert not os.path.isfile("autograded/foo/ps1/blah.pyc")
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
+        assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "data", "bar.txt"))
+        assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "blah.pyc"))
 
-        # check that removing the notebook doesn't caus the autograder to run
-        os.remove("autograded/foo/ps1/p1.ipynb")
+        # check that removing the notebook doesn"t caus the autograder to run
+        os.remove(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook])
 
-        assert not os.path.isfile("autograded/foo/ps1/p1.ipynb")
-        assert not os.path.isfile("autograded/foo/ps1/foo.txt")
-        assert os.path.isfile("autograded/foo/ps1/data/bar.txt")
-        assert not os.path.isfile("autograded/foo/ps1/blah.pyc")
+        assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
+        assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "data", "bar.txt"))
+        assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "blah.pyc"))
 
-    def test_grade_overwrite_files(self, gradebook):
+    def test_grade_overwrite_files(self, gradebook, course_dir):
         """Are dependent files properly linked and overwritten?"""
-        self._copy_file("files/submitted-unchanged.ipynb", "source/ps1/p1.ipynb")
-        self._make_file("source/ps1/data.csv", "some,data\n")
+        self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
+        self._make_file(join(course_dir, "source", "ps1", "data.csv"), "some,data\n")
         run_python_module(["nbgrader", "assign", "ps1", "--db", gradebook])
 
-        self._copy_file("files/submitted-unchanged.ipynb", "submitted/foo/ps1/p1.ipynb")
-        self._make_file('submitted/foo/ps1/timestamp.txt', "2015-02-02 15:58:23.948203 PST")
-        self._make_file("submitted/foo/ps1/data.csv", "some,other,data\n")
+        self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
+        self._make_file(join(course_dir, "submitted", "foo", "ps1", "timestamp.txt"), "2015-02-02 15:58:23.948203 PST")
+        self._make_file(join(course_dir, "submitted", "foo", "ps1", "data.csv"), "some,other,data\n")
         run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook])
 
-        assert os.path.isfile("autograded/foo/ps1/p1.ipynb")
-        assert os.path.isfile("autograded/foo/ps1/timestamp.txt")
-        assert os.path.isfile("autograded/foo/ps1/data.csv")
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "timestamp.txt"))
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "data.csv"))
 
-        with open("autograded/foo/ps1/timestamp.txt", "r") as fh:
+        with open(join(course_dir, "autograded", "foo", "ps1", "timestamp.txt"), "r") as fh:
             contents = fh.read()
         assert contents == "2015-02-02 15:58:23.948203 PST"
 
-        with open("autograded/foo/ps1/data.csv", "r") as fh:
+        with open(join(course_dir, "autograded", "foo", "ps1", "data.csv"), "r") as fh:
             contents = fh.read()
         assert contents == "some,data\n"
 
-    def test_side_effects(self, gradebook):
-        self._copy_file("files/side-effects.ipynb", "source/ps1/p1.ipynb")
+    def test_side_effects(self, gradebook, course_dir):
+        self._copy_file(join("files", "side-effects.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         run_python_module(["nbgrader", "assign", "ps1", "--db", gradebook])
 
-        self._copy_file("files/side-effects.ipynb", "submitted/foo/ps1/p1.ipynb")
+        self._copy_file(join("files", "side-effects.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook])
 
-        assert os.path.isfile("autograded/foo/ps1/side-effect.txt")
-        assert not os.path.isfile("submitted/foo/ps1/side-effect.txt")
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "side-effect.txt"))
+        assert not os.path.isfile(join(course_dir, "submitted", "foo", "ps1", "side-effect.txt"))
 
-    def test_skip_extra_notebooks(self, gradebook):
-        self._copy_file("files/submitted-unchanged.ipynb", "source/ps1/p1.ipynb")
+    def test_skip_extra_notebooks(self, gradebook, course_dir):
+        self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         run_python_module(["nbgrader", "assign", "ps1", "--db", gradebook])
 
-        self._copy_file("files/submitted-unchanged.ipynb", "submitted/foo/ps1/p1 copy.ipynb")
-        self._copy_file("files/submitted-changed.ipynb", "submitted/foo/ps1/p1.ipynb")
+        self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1 copy.ipynb"))
+        self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook])
 
-        assert os.path.isfile("autograded/foo/ps1/p1.ipynb")
-        assert not os.path.isfile("autograded/foo/ps1/p1 copy.ipynb")
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
+        assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1 copy.ipynb"))
 
-    def test_permissions(self):
+    def test_permissions(self, course_dir):
         """Are permissions properly set?"""
-        self._empty_notebook('source/ps1/foo.ipynb')
-        self._make_file("source/ps1/foo.txt", "foo")
+        self._empty_notebook(join(course_dir, "source", "ps1", "foo.ipynb"))
+        self._make_file(join(course_dir, "source", "ps1", "foo.txt"), "foo")
         run_python_module(["nbgrader", "assign", "ps1", "--create"])
 
-        self._empty_notebook('submitted/foo/ps1/foo.ipynb')
-        self._make_file("source/foo/ps1/foo.txt", "foo")
+        self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "foo.ipynb"))
+        self._make_file(join(course_dir, "source", "foo", "ps1", "foo.txt"), "foo")
         run_python_module(["nbgrader", "autograde", "ps1", "--create"])
 
-        assert os.path.isfile("autograded/foo/ps1/foo.ipynb")
-        assert os.path.isfile("autograded/foo/ps1/foo.txt")
-        assert self._get_permissions("autograded/foo/ps1/foo.ipynb") == "444"
-        assert self._get_permissions("autograded/foo/ps1/foo.txt") == "444"
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "foo.ipynb"))
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
+        assert self._get_permissions(join(course_dir, "autograded", "foo", "ps1", "foo.ipynb")) == "444"
+        assert self._get_permissions(join(course_dir, "autograded", "foo", "ps1", "foo.txt")) == "444"
 
-    def test_custom_permissions(self):
+    def test_custom_permissions(self, course_dir):
         """Are custom permissions properly set?"""
-        self._empty_notebook('source/ps1/foo.ipynb')
-        self._make_file("source/ps1/foo.txt", "foo")
+        self._empty_notebook(join(course_dir, "source", "ps1", "foo.ipynb"))
+        self._make_file(join(course_dir, "source", "ps1", "foo.txt"), "foo")
         run_python_module(["nbgrader", "assign", "ps1", "--create"])
 
-        self._empty_notebook('submitted/foo/ps1/foo.ipynb')
-        self._make_file("source/foo/ps1/foo.txt", "foo")
+        self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "foo.ipynb"))
+        self._make_file(join(course_dir, "source", "foo", "ps1", "foo.txt"), "foo")
         run_python_module(["nbgrader", "autograde", "ps1", "--create", "--AutogradeApp.permissions=644"])
 
-        assert os.path.isfile("autograded/foo/ps1/foo.ipynb")
-        assert os.path.isfile("autograded/foo/ps1/foo.txt")
-        assert self._get_permissions("autograded/foo/ps1/foo.ipynb") == "644"
-        assert self._get_permissions("autograded/foo/ps1/foo.txt") == "644"
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "foo.ipynb"))
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
+        assert self._get_permissions(join(course_dir, "autograded", "foo", "ps1", "foo.ipynb")) == "644"
+        assert self._get_permissions(join(course_dir, "autograded", "foo", "ps1", "foo.txt")) == "644"
 
-    def test_force_single_notebook(self):
-        self._copy_file("files/test.ipynb", "source/ps1/p1.ipynb")
-        self._copy_file("files/test.ipynb", "source/ps1/p2.ipynb")
+    def test_force_single_notebook(self, course_dir):
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p2.ipynb"))
         run_python_module(["nbgrader", "assign", "ps1", "--create"])
 
-        self._copy_file("files/test.ipynb", "submitted/foo/ps1/p1.ipynb")
-        self._copy_file("files/test.ipynb", "submitted/foo/ps1/p2.ipynb")
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p2.ipynb"))
         run_python_module(["nbgrader", "autograde", "ps1", "--create"])
 
-        assert os.path.exists("autograded/foo/ps1/p1.ipynb")
-        assert os.path.exists("autograded/foo/ps1/p2.ipynb")
-        p1 = self._file_contents("autograded/foo/ps1/p1.ipynb")
-        p2 = self._file_contents("autograded/foo/ps1/p2.ipynb")
+        assert os.path.exists(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
+        assert os.path.exists(join(course_dir, "autograded", "foo", "ps1", "p2.ipynb"))
+        p1 = self._file_contents(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
+        p2 = self._file_contents(join(course_dir, "autograded", "foo", "ps1", "p2.ipynb"))
         assert p1 == p2
 
-        self._empty_notebook("submitted/foo/ps1/p1.ipynb")
-        self._empty_notebook("submitted/foo/ps1/p2.ipynb")
+        self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
+        self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "p2.ipynb"))
         run_python_module(["nbgrader", "autograde", "ps1", "--notebook", "p1", "--force"])
 
-        assert os.path.exists("autograded/foo/ps1/p1.ipynb")
-        assert os.path.exists("autograded/foo/ps1/p2.ipynb")
-        assert p1 != self._file_contents("autograded/foo/ps1/p1.ipynb")
-        assert p2 == self._file_contents("autograded/foo/ps1/p2.ipynb")
+        assert os.path.exists(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
+        assert os.path.exists(join(course_dir, "autograded", "foo", "ps1", "p2.ipynb"))
+        assert p1 != self._file_contents(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
+        assert p2 == self._file_contents(join(course_dir, "autograded", "foo", "ps1", "p2.ipynb"))
 
-    def test_update_newer(self):
-        self._copy_file("files/test.ipynb", "source/ps1/p1.ipynb")
+    def test_update_newer(self, course_dir):
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         run_python_module(["nbgrader", "assign", "ps1", "--create"])
 
-        self._copy_file("files/test.ipynb", "submitted/foo/ps1/p1.ipynb")
-        self._make_file('submitted/foo/ps1/timestamp.txt', "2015-02-02 15:58:23.948203 PST")
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
+        self._make_file(join(course_dir, "submitted", "foo", "ps1", "timestamp.txt"), "2015-02-02 15:58:23.948203 PST")
         run_python_module(["nbgrader", "autograde", "ps1", "--create"])
 
-        assert os.path.isfile("autograded/foo/ps1/p1.ipynb")
-        assert os.path.isfile("autograded/foo/ps1/timestamp.txt")
-        assert self._file_contents("autograded/foo/ps1/timestamp.txt") == "2015-02-02 15:58:23.948203 PST"
-        p = self._file_contents("autograded/foo/ps1/p1.ipynb")
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "timestamp.txt"))
+        assert self._file_contents(join(course_dir, "autograded", "foo", "ps1", "timestamp.txt")) == "2015-02-02 15:58:23.948203 PST"
+        p = self._file_contents(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
 
-        self._empty_notebook("submitted/foo/ps1/p1.ipynb")
-        self._make_file('submitted/foo/ps1/timestamp.txt', "2015-02-02 16:58:23.948203 PST")
+        self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
+        self._make_file(join(course_dir, "submitted", "foo", "ps1", "timestamp.txt"), "2015-02-02 16:58:23.948203 PST")
         run_python_module(["nbgrader", "autograde", "ps1", "--create"])
 
-        assert os.path.isfile("autograded/foo/ps1/p1.ipynb")
-        assert os.path.isfile("autograded/foo/ps1/timestamp.txt")
-        assert self._file_contents("autograded/foo/ps1/timestamp.txt") == "2015-02-02 16:58:23.948203 PST"
-        assert p != self._file_contents("autograded/foo/ps1/p1.ipynb")
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "timestamp.txt"))
+        assert self._file_contents(join(course_dir, "autograded", "foo", "ps1", "timestamp.txt")) == "2015-02-02 16:58:23.948203 PST"
+        assert p != self._file_contents(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
 
-    def test_update_newer_single_notebook(self):
-        self._copy_file("files/test.ipynb", "source/ps1/p1.ipynb")
-        self._copy_file("files/test.ipynb", "source/ps1/p2.ipynb")
+    def test_update_newer_single_notebook(self, course_dir):
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p2.ipynb"))
         run_python_module(["nbgrader", "assign", "ps1", "--create"])
 
-        self._copy_file("files/test.ipynb", "submitted/foo/ps1/p1.ipynb")
-        self._copy_file("files/test.ipynb", "submitted/foo/ps1/p2.ipynb")
-        self._make_file('submitted/foo/ps1/timestamp.txt', "2015-02-02 15:58:23.948203 PST")
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p2.ipynb"))
+        self._make_file(join(course_dir, "submitted", "foo", "ps1", "timestamp.txt"), "2015-02-02 15:58:23.948203 PST")
         run_python_module(["nbgrader", "autograde", "ps1", "--create"])
 
-        assert os.path.exists("autograded/foo/ps1/p1.ipynb")
-        assert os.path.exists("autograded/foo/ps1/p2.ipynb")
-        assert os.path.isfile("autograded/foo/ps1/timestamp.txt")
-        assert self._file_contents("autograded/foo/ps1/timestamp.txt") == "2015-02-02 15:58:23.948203 PST"
-        p1 = self._file_contents("autograded/foo/ps1/p1.ipynb")
-        p2 = self._file_contents("autograded/foo/ps1/p2.ipynb")
+        assert os.path.exists(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
+        assert os.path.exists(join(course_dir, "autograded", "foo", "ps1", "p2.ipynb"))
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "timestamp.txt"))
+        assert self._file_contents(join(course_dir, "autograded", "foo", "ps1", "timestamp.txt")) == "2015-02-02 15:58:23.948203 PST"
+        p1 = self._file_contents(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
+        p2 = self._file_contents(join(course_dir, "autograded", "foo", "ps1", "p2.ipynb"))
         assert p1 == p2
 
-        self._empty_notebook("submitted/foo/ps1/p1.ipynb")
-        self._empty_notebook("submitted/foo/ps1/p2.ipynb")
-        self._make_file('submitted/foo/ps1/timestamp.txt', "2015-02-02 16:58:23.948203 PST")
+        self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
+        self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "p2.ipynb"))
+        self._make_file(join(course_dir, "submitted", "foo", "ps1", "timestamp.txt"), "2015-02-02 16:58:23.948203 PST")
         run_python_module(["nbgrader", "autograde", "ps1", "--notebook", "p1"])
 
-        assert os.path.exists("autograded/foo/ps1/p1.ipynb")
-        assert os.path.exists("autograded/foo/ps1/p2.ipynb")
-        assert os.path.isfile("autograded/foo/ps1/timestamp.txt")
-        assert self._file_contents("autograded/foo/ps1/timestamp.txt") == "2015-02-02 16:58:23.948203 PST"
-        assert p1 != self._file_contents("autograded/foo/ps1/p1.ipynb")
-        assert p2 == self._file_contents("autograded/foo/ps1/p2.ipynb")
+        assert os.path.exists(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
+        assert os.path.exists(join(course_dir, "autograded", "foo", "ps1", "p2.ipynb"))
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "timestamp.txt"))
+        assert self._file_contents(join(course_dir, "autograded", "foo", "ps1", "timestamp.txt")) == "2015-02-02 16:58:23.948203 PST"
+        assert p1 != self._file_contents(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
+        assert p2 == self._file_contents(join(course_dir, "autograded", "foo", "ps1", "p2.ipynb"))
 
-    def test_handle_failure(self):
-        self._empty_notebook("source/ps1/p1.ipynb")
-        self._empty_notebook("source/ps1/p2.ipynb")
+    def test_handle_failure(self, course_dir):
+        self._empty_notebook(join(course_dir, "source", "ps1", "p1.ipynb"))
+        self._empty_notebook(join(course_dir, "source", "ps1", "p2.ipynb"))
         run_python_module(["nbgrader", "assign", "ps1", "--create"])
 
-        self._empty_notebook("submitted/foo/ps1/p1.ipynb")
-        self._copy_file("files/test.ipynb", "submitted/foo/ps1/p2.ipynb")
+        self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p2.ipynb"))
         run_python_module(["nbgrader", "autograde", "ps1", "--create"], retcode=1)
 
-        assert not os.path.exists("autograded/foo/ps1")
+        assert not os.path.exists(join(course_dir, "autograded", "foo", "ps1"))
 
-    def test_handle_failure_single_notebook(self):
-        self._empty_notebook("source/ps1/p1.ipynb")
-        self._empty_notebook("source/ps1/p2.ipynb")
+    def test_handle_failure_single_notebook(self, course_dir):
+        self._empty_notebook(join(course_dir, "source", "ps1", "p1.ipynb"))
+        self._empty_notebook(join(course_dir, "source", "ps1", "p2.ipynb"))
         run_python_module(["nbgrader", "assign", "ps1", "--create"])
 
-        self._empty_notebook("submitted/foo/ps1/p1.ipynb")
-        self._copy_file("files/test.ipynb", "submitted/foo/ps1/p2.ipynb")
+        self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p2.ipynb"))
         run_python_module(["nbgrader", "autograde", "ps1", "--create", "--notebook", "p*"], retcode=1)
 
-        assert os.path.exists("autograded/foo/ps1")
-        assert not os.path.isfile("autograded/foo/ps1/p1.ipynb")
-        assert not os.path.isfile("autograded/foo/ps1/p2.ipynb")
+        assert os.path.exists(join(course_dir, "autograded", "foo", "ps1"))
+        assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
+        assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p2.ipynb"))

--- a/nbgrader/tests/apps/test_nbgrader_collect.py
+++ b/nbgrader/tests/apps/test_nbgrader_collect.py
@@ -1,5 +1,7 @@
 import os
 
+from os.path import join
+
 from .. import run_python_module
 from .base import BaseTestApp
 from ...utils import parse_utc
@@ -7,31 +9,31 @@ from ...utils import parse_utc
 
 class TestNbGraderCollect(BaseTestApp):
 
-    def _release_and_fetch(self, assignment, exchange):
-        self._copy_file("files/test.ipynb", "release/ps1/p1.ipynb")
+    def _release_and_fetch(self, assignment, exchange, course_dir):
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "release", "ps1", "p1.ipynb"))
         run_python_module([
-            'nbgrader', 'release', assignment,
-            '--course', 'abc101',
-            '--TransferApp.exchange_directory={}'.format(exchange)
+            "nbgrader", "release", assignment,
+            "--course", "abc101",
+            "--TransferApp.exchange_directory={}".format(exchange)
         ])
         run_python_module([
-            'nbgrader', 'fetch', assignment,
-            '--course', 'abc101',
-            '--TransferApp.exchange_directory={}'.format(exchange)
+            "nbgrader", "fetch", assignment,
+            "--course", "abc101",
+            "--TransferApp.exchange_directory={}".format(exchange)
         ])
 
     def _submit(self, assignment, exchange):
         run_python_module([
-            'nbgrader', 'submit', assignment,
-            '--course', 'abc101',
-            '--TransferApp.exchange_directory={}'.format(exchange)
+            "nbgrader", "submit", assignment,
+            "--course", "abc101",
+            "--TransferApp.exchange_directory={}".format(exchange)
         ])
 
     def _collect(self, assignment, exchange, flags=None, retcode=0):
         cmd = [
-            'nbgrader', 'collect', assignment,
-            '--course', 'abc101',
-            '--TransferApp.exchange_directory={}'.format(exchange)
+            "nbgrader", "collect", assignment,
+            "--course", "abc101",
+            "--TransferApp.exchange_directory={}".format(exchange)
         ]
 
         if flags is not None:
@@ -48,9 +50,9 @@ class TestNbGraderCollect(BaseTestApp):
         """Does the help display without error?"""
         run_python_module(["nbgrader", "collect", "--help-all"])
 
-    def test_no_course_id(self, exchange):
+    def test_no_course_id(self, exchange, course_dir):
         """Does releasing without a course id thrown an error?"""
-        self._release_and_fetch("ps1", exchange)
+        self._release_and_fetch("ps1", exchange, course_dir)
         self._submit("ps1", exchange)
         cmd = [
             "nbgrader", "collect", "ps1",
@@ -58,13 +60,13 @@ class TestNbGraderCollect(BaseTestApp):
         ]
         run_python_module(cmd, retcode=1)
 
-    def test_collect(self, exchange):
-        self._release_and_fetch("ps1", exchange)
+    def test_collect(self, exchange, course_dir):
+        self._release_and_fetch("ps1", exchange, course_dir)
 
-        # try to collect when there's nothing to collect
+        # try to collect when there"s nothing to collect
         self._collect("ps1", exchange)
-        root = os.path.join("submitted/{}/ps1".format(os.environ['USER']))
-        assert not os.path.isdir("submitted")
+        root = os.path.join(join(course_dir, "submitted", os.environ["USER"], "ps1"))
+        assert not os.path.isdir(join(course_dir, "submitted"))
 
         # submit something
         self._submit("ps1", exchange)

--- a/nbgrader/tests/apps/test_nbgrader_collect.py
+++ b/nbgrader/tests/apps/test_nbgrader_collect.py
@@ -64,8 +64,7 @@ class TestNbGraderCollect(BaseTestApp):
         # try to collect when there's nothing to collect
         self._collect("ps1", exchange)
         root = os.path.join("submitted/{}/ps1".format(os.environ['USER']))
-        assert os.path.isdir("submitted")
-        assert not os.path.isdir(root)
+        assert not os.path.isdir("submitted")
 
         # submit something
         self._submit("ps1", exchange)

--- a/nbgrader/tests/apps/test_nbgrader_feedback.py
+++ b/nbgrader/tests/apps/test_nbgrader_feedback.py
@@ -1,4 +1,5 @@
 import os
+from os.path import join, exists, isfile
 
 from .. import run_python_module
 from .base import BaseTestApp
@@ -10,198 +11,198 @@ class TestNbGraderFeedback(BaseTestApp):
         """Does the help display without error?"""
         run_python_module(["nbgrader", "feedback", "--help-all"])
 
-    def test_single_file(self, gradebook):
+    def test_single_file(self, gradebook, course_dir):
         """Can feedback be generated for an unchanged assignment?"""
-        self._copy_file("files/submitted-unchanged.ipynb", "source/ps1/p1.ipynb")
+        self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         run_python_module(["nbgrader", "assign", "ps1", "--db", gradebook])
 
-        self._copy_file("files/submitted-unchanged.ipynb", "submitted/foo/ps1/p1.ipynb")
+        self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook])
         run_python_module(["nbgrader", "feedback", "ps1", "--db", gradebook])
 
-        assert os.path.exists('feedback/foo/ps1/p1.html')
+        assert exists(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
 
-    def test_force(self, gradebook):
+    def test_force(self, gradebook, course_dir):
         """Ensure the force option works properly"""
-        self._copy_file("files/submitted-unchanged.ipynb", "source/ps1/p1.ipynb")
-        self._make_file("source/ps1/foo.txt", "foo")
-        self._make_file("source/ps1/data/bar.txt", "bar")
+        self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
+        self._make_file(join(course_dir, "source", "ps1", "foo.txt"), "foo")
+        self._make_file(join(course_dir, "source", "ps1", "data", "bar.txt"), "bar")
         run_python_module(["nbgrader", "assign", "ps1", "--db", gradebook])
 
-        self._copy_file("files/submitted-unchanged.ipynb", "submitted/foo/ps1/p1.ipynb")
-        self._make_file("submitted/foo/ps1/foo.txt", "foo")
-        self._make_file("submitted/foo/ps1/data/bar.txt", "bar")
+        self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
+        self._make_file(join(course_dir, "submitted", "foo", "ps1", "foo.txt"), "foo")
+        self._make_file(join(course_dir, "submitted", "foo", "ps1", "data", "bar.txt"), "bar")
         run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook])
 
-        self._make_file("autograded/foo/ps1/blah.pyc", "asdf")
+        self._make_file(join(course_dir, "autograded", "foo", "ps1", "blah.pyc"), "asdf")
         run_python_module(["nbgrader", "feedback", "ps1", "--db", gradebook])
 
-        assert os.path.isfile("feedback/foo/ps1/p1.html")
-        assert os.path.isfile("feedback/foo/ps1/foo.txt")
-        assert os.path.isfile("feedback/foo/ps1/data/bar.txt")
-        assert not os.path.isfile("feedback/foo/ps1/blah.pyc")
+        assert isfile(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
+        assert isfile(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))
+        assert isfile(join(course_dir, "feedback", "foo", "ps1", "data", "bar.txt"))
+        assert not isfile(join(course_dir, "feedback", "foo", "ps1", "blah.pyc"))
 
         # check that it skips the existing directory
-        os.remove("feedback/foo/ps1/foo.txt")
+        os.remove(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))
         run_python_module(["nbgrader", "feedback", "ps1", "--db", gradebook])
-        assert not os.path.isfile("feedback/foo/ps1/foo.txt")
+        assert not isfile(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))
 
         # force overwrite the supplemental files
         run_python_module(["nbgrader", "feedback", "ps1", "--db", gradebook, "--force"])
-        assert os.path.isfile("feedback/foo/ps1/foo.txt")
+        assert isfile(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))
 
         # force overwrite
-        os.remove("autograded/foo/ps1/foo.txt")
+        os.remove(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
         run_python_module(["nbgrader", "feedback", "ps1", "--db", gradebook, "--force"])
-        assert os.path.isfile("feedback/foo/ps1/p1.html")
-        assert not os.path.isfile("feedback/foo/ps1/foo.txt")
-        assert os.path.isfile("feedback/foo/ps1/data/bar.txt")
-        assert not os.path.isfile("feedback/foo/ps1/blah.pyc")
+        assert isfile(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
+        assert not isfile(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))
+        assert isfile(join(course_dir, "feedback", "foo", "ps1", "data", "bar.txt"))
+        assert not isfile(join(course_dir, "feedback", "foo", "ps1", "blah.pyc"))
 
-    def test_filter_notebook(self, gradebook):
+    def test_filter_notebook(self, gradebook, course_dir):
         """Does feedback filter by notebook properly?"""
-        self._copy_file("files/submitted-unchanged.ipynb", "source/ps1/p1.ipynb")
-        self._make_file("source/ps1/foo.txt", "foo")
-        self._make_file("source/ps1/data/bar.txt", "bar")
+        self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
+        self._make_file(join(course_dir, "source", "ps1", "foo.txt"), "foo")
+        self._make_file(join(course_dir, "source", "ps1", "data", "bar.txt"), "bar")
         run_python_module(["nbgrader", "assign", "ps1", "--db", gradebook])
 
-        self._copy_file("files/submitted-unchanged.ipynb", "submitted/foo/ps1/p1.ipynb")
-        self._make_file("submitted/foo/ps1/foo.txt", "foo")
-        self._make_file("submitted/foo/ps1/data/bar.txt", "bar")
-        self._make_file("submitted/foo/ps1/blah.pyc", "asdf")
+        self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
+        self._make_file(join(course_dir, "submitted", "foo", "ps1", "foo.txt"), "foo")
+        self._make_file(join(course_dir, "submitted", "foo", "ps1", "data", "bar.txt"), "bar")
+        self._make_file(join(course_dir, "submitted", "foo", "ps1", "blah.pyc"), "asdf")
         run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook])
         run_python_module(["nbgrader", "feedback", "ps1", "--db", gradebook, "--notebook", "p1"])
 
-        assert os.path.isfile("feedback/foo/ps1/p1.html")
-        assert os.path.isfile("feedback/foo/ps1/foo.txt")
-        assert os.path.isfile("feedback/foo/ps1/data/bar.txt")
-        assert not os.path.isfile("feedback/foo/ps1/blah.pyc")
+        assert isfile(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
+        assert isfile(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))
+        assert isfile(join(course_dir, "feedback", "foo", "ps1", "data", "bar.txt"))
+        assert not isfile(join(course_dir, "feedback", "foo", "ps1", "blah.pyc"))
 
         # check that removing the notebook still causes it to run
-        os.remove("feedback/foo/ps1/p1.html")
-        os.remove("feedback/foo/ps1/foo.txt")
+        os.remove(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
+        os.remove(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))
         run_python_module(["nbgrader", "feedback", "ps1", "--db", gradebook, "--notebook", "p1"])
 
-        assert os.path.isfile("feedback/foo/ps1/p1.html")
-        assert os.path.isfile("feedback/foo/ps1/foo.txt")
-        assert os.path.isfile("feedback/foo/ps1/data/bar.txt")
-        assert not os.path.isfile("feedback/foo/ps1/blah.pyc")
+        assert isfile(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
+        assert isfile(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))
+        assert isfile(join(course_dir, "feedback", "foo", "ps1", "data", "bar.txt"))
+        assert not isfile(join(course_dir, "feedback", "foo", "ps1", "blah.pyc"))
 
-        # check that running it again doesn't do anything
-        os.remove("feedback/foo/ps1/foo.txt")
+        # check that running it again doesn"t do anything
+        os.remove(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))
         run_python_module(["nbgrader", "feedback", "ps1", "--db", gradebook, "--notebook", "p1"])
 
-        assert os.path.isfile("feedback/foo/ps1/p1.html")
-        assert not os.path.isfile("feedback/foo/ps1/foo.txt")
-        assert os.path.isfile("feedback/foo/ps1/data/bar.txt")
-        assert not os.path.isfile("feedback/foo/ps1/blah.pyc")
+        assert isfile(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
+        assert not isfile(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))
+        assert isfile(join(course_dir, "feedback", "foo", "ps1", "data", "bar.txt"))
+        assert not isfile(join(course_dir, "feedback", "foo", "ps1", "blah.pyc"))
 
-        # check that removing the notebook doesn't cause it to run
-        os.remove("feedback/foo/ps1/p1.html")
+        # check that removing the notebook doesn"t cause it to run
+        os.remove(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
         run_python_module(["nbgrader", "feedback", "ps1", "--db", gradebook])
 
-        assert not os.path.isfile("feedback/foo/ps1/p1.html")
-        assert not os.path.isfile("feedback/foo/ps1/foo.txt")
-        assert os.path.isfile("feedback/foo/ps1/data/bar.txt")
-        assert not os.path.isfile("feedback/foo/ps1/blah.pyc")
+        assert not isfile(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
+        assert not isfile(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))
+        assert isfile(join(course_dir, "feedback", "foo", "ps1", "data", "bar.txt"))
+        assert not isfile(join(course_dir, "feedback", "foo", "ps1", "blah.pyc"))
 
-    def test_permissions(self):
+    def test_permissions(self, course_dir):
         """Are permissions properly set?"""
-        self._empty_notebook('source/ps1/foo.ipynb')
+        self._empty_notebook(join(course_dir, "source", "ps1", "foo.ipynb"))
         run_python_module(["nbgrader", "assign", "ps1", "--create"])
 
-        self._empty_notebook('submitted/foo/ps1/foo.ipynb')
+        self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "foo.ipynb"))
         run_python_module(["nbgrader", "autograde", "ps1", "--create"])
         run_python_module(["nbgrader", "feedback", "ps1"])
 
-        assert os.path.isfile("feedback/foo/ps1/foo.html")
-        assert self._get_permissions("feedback/foo/ps1/foo.html") == "444"
+        assert isfile(join(course_dir, "feedback", "foo", "ps1", "foo.html"))
+        assert self._get_permissions(join(course_dir, "feedback", "foo", "ps1", "foo.html")) == "444"
 
-    def test_custom_permissions(self):
+    def test_custom_permissions(self, course_dir):
         """Are custom permissions properly set?"""
-        self._empty_notebook('source/ps1/foo.ipynb')
+        self._empty_notebook(join(course_dir, "source", "ps1", "foo.ipynb"))
         run_python_module(["nbgrader", "assign", "ps1", "--create"])
 
-        self._empty_notebook('submitted/foo/ps1/foo.ipynb')
+        self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "foo.ipynb"))
         run_python_module(["nbgrader", "autograde", "ps1", "--create"])
         run_python_module(["nbgrader", "feedback", "ps1", "--FeedbackApp.permissions=644"])
 
-        assert os.path.isfile("feedback/foo/ps1/foo.html")
-        assert self._get_permissions("feedback/foo/ps1/foo.html") == "644"
+        assert isfile(join(course_dir, "feedback", "foo", "ps1", "foo.html"))
+        assert self._get_permissions(join(course_dir, "feedback", "foo", "ps1", "foo.html")) == "644"
 
-    def test_force_single_notebook(self):
-        self._copy_file("files/test.ipynb", "source/ps1/p1.ipynb")
-        self._copy_file("files/test.ipynb", "source/ps1/p2.ipynb")
+    def test_force_single_notebook(self, course_dir):
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p2.ipynb"))
         run_python_module(["nbgrader", "assign", "ps1", "--create"])
 
-        self._copy_file("files/test.ipynb", "submitted/foo/ps1/p1.ipynb")
-        self._copy_file("files/test.ipynb", "submitted/foo/ps1/p2.ipynb")
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p2.ipynb"))
         run_python_module(["nbgrader", "autograde", "ps1", "--create"])
         run_python_module(["nbgrader", "feedback", "ps1"])
 
-        assert os.path.exists("feedback/foo/ps1/p1.html")
-        assert os.path.exists("feedback/foo/ps1/p2.html")
-        p1 = self._file_contents("feedback/foo/ps1/p1.html")
-        p2 = self._file_contents("feedback/foo/ps1/p2.html")
+        assert exists(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
+        assert exists(join(course_dir, "feedback", "foo", "ps1", "p2.html"))
+        p1 = self._file_contents(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
+        p2 = self._file_contents(join(course_dir, "feedback", "foo", "ps1", "p2.html"))
 
-        self._empty_notebook("autograded/foo/ps1/p1.ipynb")
-        self._empty_notebook("autograded/foo/ps1/p2.ipynb")
+        self._empty_notebook(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
+        self._empty_notebook(join(course_dir, "autograded", "foo", "ps1", "p2.ipynb"))
         run_python_module(["nbgrader", "feedback", "ps1", "--notebook", "p1", "--force"])
 
-        assert os.path.exists("feedback/foo/ps1/p1.html")
-        assert os.path.exists("feedback/foo/ps1/p2.html")
-        assert p1 != self._file_contents("feedback/foo/ps1/p1.html")
-        assert p2 == self._file_contents("feedback/foo/ps1/p2.html")
+        assert exists(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
+        assert exists(join(course_dir, "feedback", "foo", "ps1", "p2.html"))
+        assert p1 != self._file_contents(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
+        assert p2 == self._file_contents(join(course_dir, "feedback", "foo", "ps1", "p2.html"))
 
-    def test_update_newer(self):
-        self._copy_file("files/test.ipynb", "source/ps1/p1.ipynb")
+    def test_update_newer(self, course_dir):
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         run_python_module(["nbgrader", "assign", "ps1", "--create"])
 
-        self._copy_file("files/test.ipynb", "submitted/foo/ps1/p1.ipynb")
-        self._make_file('submitted/foo/ps1/timestamp.txt', "2015-02-02 15:58:23.948203 PST")
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
+        self._make_file(join(course_dir, "submitted", "foo", "ps1", "timestamp.txt"), "2015-02-02 15:58:23.948203 PST")
         run_python_module(["nbgrader", "autograde", "ps1", "--create"])
         run_python_module(["nbgrader", "feedback", "ps1"])
 
-        assert os.path.isfile("feedback/foo/ps1/p1.html")
-        assert os.path.isfile("feedback/foo/ps1/timestamp.txt")
-        assert self._file_contents("feedback/foo/ps1/timestamp.txt") == "2015-02-02 15:58:23.948203 PST"
-        p = self._file_contents("feedback/foo/ps1/p1.html")
+        assert isfile(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
+        assert isfile(join(course_dir, "feedback", "foo", "ps1", "timestamp.txt"))
+        assert self._file_contents(join(course_dir, "feedback", "foo", "ps1", "timestamp.txt")) == "2015-02-02 15:58:23.948203 PST"
+        p = self._file_contents(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
 
-        self._empty_notebook("autograded/foo/ps1/p1.ipynb")
-        self._make_file('autograded/foo/ps1/timestamp.txt', "2015-02-02 16:58:23.948203 PST")
+        self._empty_notebook(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
+        self._make_file(join(course_dir, "autograded", "foo", "ps1", "timestamp.txt"), "2015-02-02 16:58:23.948203 PST")
         run_python_module(["nbgrader", "feedback", "ps1"])
 
-        assert os.path.isfile("feedback/foo/ps1/p1.html")
-        assert os.path.isfile("feedback/foo/ps1/timestamp.txt")
-        assert self._file_contents("feedback/foo/ps1/timestamp.txt") == "2015-02-02 16:58:23.948203 PST"
-        assert p != self._file_contents("feedback/foo/ps1/p1.html")
+        assert isfile(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
+        assert isfile(join(course_dir, "feedback", "foo", "ps1", "timestamp.txt"))
+        assert self._file_contents(join(course_dir, "feedback", "foo", "ps1", "timestamp.txt")) == "2015-02-02 16:58:23.948203 PST"
+        assert p != self._file_contents(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
 
-    def test_update_newer_single_notebook(self):
-        self._copy_file("files/test.ipynb", "source/ps1/p1.ipynb")
-        self._copy_file("files/test.ipynb", "source/ps1/p2.ipynb")
+    def test_update_newer_single_notebook(self, course_dir):
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p2.ipynb"))
         run_python_module(["nbgrader", "assign", "ps1", "--create"])
 
-        self._copy_file("files/test.ipynb", "submitted/foo/ps1/p1.ipynb")
-        self._copy_file("files/test.ipynb", "submitted/foo/ps1/p2.ipynb")
-        self._make_file('submitted/foo/ps1/timestamp.txt', "2015-02-02 15:58:23.948203 PST")
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p2.ipynb"))
+        self._make_file(join(course_dir, "submitted", "foo", "ps1", "timestamp.txt"), "2015-02-02 15:58:23.948203 PST")
         run_python_module(["nbgrader", "autograde", "ps1", "--create"])
         run_python_module(["nbgrader", "feedback", "ps1"])
 
-        assert os.path.exists("feedback/foo/ps1/p1.html")
-        assert os.path.exists("feedback/foo/ps1/p2.html")
-        assert os.path.isfile("feedback/foo/ps1/timestamp.txt")
-        assert self._file_contents("feedback/foo/ps1/timestamp.txt") == "2015-02-02 15:58:23.948203 PST"
-        p1 = self._file_contents("feedback/foo/ps1/p1.html")
-        p2 = self._file_contents("feedback/foo/ps1/p2.html")
+        assert exists(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
+        assert exists(join(course_dir, "feedback", "foo", "ps1", "p2.html"))
+        assert isfile(join(course_dir, "feedback", "foo", "ps1", "timestamp.txt"))
+        assert self._file_contents(join(course_dir, "feedback", "foo", "ps1", "timestamp.txt")) == "2015-02-02 15:58:23.948203 PST"
+        p1 = self._file_contents(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
+        p2 = self._file_contents(join(course_dir, "feedback", "foo", "ps1", "p2.html"))
 
-        self._empty_notebook("autograded/foo/ps1/p1.ipynb")
-        self._empty_notebook("autograded/foo/ps1/p2.ipynb")
-        self._make_file('autograded/foo/ps1/timestamp.txt', "2015-02-02 16:58:23.948203 PST")
+        self._empty_notebook(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
+        self._empty_notebook(join(course_dir, "autograded", "foo", "ps1", "p2.ipynb"))
+        self._make_file(join(course_dir, "autograded", "foo", "ps1", "timestamp.txt"), "2015-02-02 16:58:23.948203 PST")
         run_python_module(["nbgrader", "feedback", "ps1", "--notebook", "p1"])
 
-        assert os.path.exists("feedback/foo/ps1/p1.html")
-        assert os.path.exists("feedback/foo/ps1/p2.html")
-        assert os.path.isfile("feedback/foo/ps1/timestamp.txt")
-        assert self._file_contents("feedback/foo/ps1/timestamp.txt") == "2015-02-02 16:58:23.948203 PST"
-        assert p1 != self._file_contents("feedback/foo/ps1/p1.html")
-        assert p2 == self._file_contents("feedback/foo/ps1/p2.html")
+        assert exists(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
+        assert exists(join(course_dir, "feedback", "foo", "ps1", "p2.html"))
+        assert isfile(join(course_dir, "feedback", "foo", "ps1", "timestamp.txt"))
+        assert self._file_contents(join(course_dir, "feedback", "foo", "ps1", "timestamp.txt")) == "2015-02-02 16:58:23.948203 PST"
+        assert p1 != self._file_contents(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
+        assert p2 == self._file_contents(join(course_dir, "feedback", "foo", "ps1", "p2.html"))

--- a/nbgrader/tests/apps/test_nbgrader_fetch.py
+++ b/nbgrader/tests/apps/test_nbgrader_fetch.py
@@ -1,4 +1,5 @@
 import os
+from os.path import join
 
 from .. import run_python_module
 from .base import BaseTestApp
@@ -6,8 +7,8 @@ from .base import BaseTestApp
 
 class TestNbGraderFetch(BaseTestApp):
 
-    def _release(self, assignment, exchange):
-        self._copy_file("files/test.ipynb", "release/ps1/p1.ipynb")
+    def _release(self, assignment, exchange, course_dir):
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "release", "ps1", "p1.ipynb"))
         run_python_module([
             "nbgrader", "release", assignment,
             "--course", "abc101",
@@ -30,23 +31,23 @@ class TestNbGraderFetch(BaseTestApp):
         """Does the help display without error?"""
         run_python_module(["nbgrader", "fetch", "--help-all"])
 
-    def test_no_course_id(self, exchange):
+    def test_no_course_id(self, exchange, course_dir):
         """Does releasing without a course id thrown an error?"""
-        self._release("ps1", exchange)
+        self._release("ps1", exchange, course_dir)
         cmd = [
             "nbgrader", "fetch", "ps1",
             "--TransferApp.exchange_directory={}".format(exchange)
         ]
         run_python_module(cmd, retcode=1)
 
-    def test_fetch(self, exchange):
-        self._release("ps1", exchange)
+    def test_fetch(self, exchange, course_dir):
+        self._release("ps1", exchange, course_dir)
         self._fetch("ps1", exchange)
-        assert os.path.isfile("ps1/p1.ipynb")
+        assert os.path.isfile(join("ps1", "p1.ipynb"))
 
         # make sure it fails if the assignment already exists
         self._fetch("ps1", exchange, retcode=1)
 
         # make sure it fails even if the assignment is incomplete
-        os.remove("ps1/p1.ipynb")
+        os.remove(join("ps1", "p1.ipynb"))
         self._fetch("ps1", exchange, retcode=1)

--- a/nbgrader/tests/apps/test_nbgrader_release.py
+++ b/nbgrader/tests/apps/test_nbgrader_release.py
@@ -1,4 +1,5 @@
 import os
+from os.path import join
 
 from .. import run_python_module
 from .base import BaseTestApp
@@ -30,20 +31,20 @@ class TestNbGraderRelease(BaseTestApp):
         ]
         run_python_module(cmd, retcode=1)
 
-    def test_release(self, exchange):
-        self._copy_file("files/test.ipynb", "release/ps1/p1.ipynb")
+    def test_release(self, exchange, course_dir):
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "release", "ps1", "p1.ipynb"))
         self._release("ps1", exchange)
-        assert os.path.isfile(os.path.join(exchange, "abc101/outbound/ps1/p1.ipynb"))
+        assert os.path.isfile(join(exchange, "abc101", "outbound", "ps1", "p1.ipynb"))
 
-    def test_force_release(self, exchange):
-        self._copy_file("files/test.ipynb", "release/ps1/p1.ipynb")
+    def test_force_release(self, exchange, course_dir):
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "release", "ps1", "p1.ipynb"))
         self._release("ps1", exchange)
-        assert os.path.isfile(os.path.join(exchange, "abc101/outbound/ps1/p1.ipynb"))
+        assert os.path.isfile(join(exchange, "abc101", "outbound", "ps1", "p1.ipynb"))
 
         self._release("ps1", exchange, retcode=1)
 
-        os.remove(os.path.join(exchange, "abc101/outbound/ps1/p1.ipynb"))
+        os.remove(join(exchange, join("abc101", "outbound", "ps1", "p1.ipynb")))
         self._release("ps1", exchange, retcode=1)
 
-        self._release("ps1", exchange, flags=['--force'])
-        assert os.path.isfile(os.path.join(exchange, "abc101/outbound/ps1/p1.ipynb"))
+        self._release("ps1", exchange, flags=["--force"])
+        assert os.path.isfile(join(exchange, "abc101", "outbound", "ps1", "p1.ipynb"))

--- a/nbgrader/tests/apps/test_nbgrader_submit.py
+++ b/nbgrader/tests/apps/test_nbgrader_submit.py
@@ -2,6 +2,8 @@ import os
 import datetime
 import time
 
+from os.path import join, isfile
+
 from ...utils import parse_utc
 from .. import run_python_module
 from .base import BaseTestApp
@@ -9,8 +11,8 @@ from .base import BaseTestApp
 
 class TestNbGraderSubmit(BaseTestApp):
 
-    def _release_and_fetch(self, assignment, exchange, cache):
-        self._copy_file("files/test.ipynb", "release/ps1/p1.ipynb")
+    def _release_and_fetch(self, assignment, exchange, cache, course_dir):
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "release", "ps1", "p1.ipynb"))
         run_python_module([
             "nbgrader", "release", assignment,
             "--course", "abc101",
@@ -41,9 +43,9 @@ class TestNbGraderSubmit(BaseTestApp):
         """Does the help display without error?"""
         run_python_module(["nbgrader", "submit", "--help-all"])
 
-    def test_no_course_id(self, exchange, cache):
+    def test_no_course_id(self, exchange, cache, course_dir):
         """Does releasing without a course id thrown an error?"""
-        self._release_and_fetch("ps1", exchange, cache)
+        self._release_and_fetch("ps1", exchange, cache, course_dir)
         cmd = [
             "nbgrader", "submit", "ps1",
             "--TransferApp.cache_directory={}".format(cache),
@@ -51,54 +53,54 @@ class TestNbGraderSubmit(BaseTestApp):
         ]
         run_python_module(cmd, retcode=1)
 
-    def test_submit(self, exchange, cache):
-        self._release_and_fetch("ps1", exchange, cache)
+    def test_submit(self, exchange, cache, course_dir):
+        self._release_and_fetch("ps1", exchange, cache, course_dir)
         now = datetime.datetime.now()
 
         time.sleep(1)
         self._submit("ps1", exchange, cache)
 
-        filename, = os.listdir(os.path.join(exchange, "abc101", "inbound"))
+        filename, = os.listdir(join(exchange, "abc101", "inbound"))
         username, assignment, timestamp1 = filename.split("+")
-        assert username == os.environ['USER']
+        assert username == os.environ["USER"]
         assert assignment == "ps1"
         assert parse_utc(timestamp1) > now
-        assert os.path.isfile(os.path.join(exchange, "abc101", "inbound", filename, "p1.ipynb"))
-        assert os.path.isfile(os.path.join(exchange, "abc101", "inbound", filename, "timestamp.txt"))
-        with open(os.path.join(exchange, "abc101", "inbound", filename, "timestamp.txt"), "r") as fh:
+        assert isfile(join(exchange, "abc101", "inbound", filename, "p1.ipynb"))
+        assert isfile(join(exchange, "abc101", "inbound", filename, "timestamp.txt"))
+        with open(join(exchange, "abc101", "inbound", filename, "timestamp.txt"), "r") as fh:
             assert fh.read() == timestamp1
 
-        filename, = os.listdir(os.path.join(cache, "abc101"))
+        filename, = os.listdir(join(cache, "abc101"))
         username, assignment, timestamp1 = filename.split("+")
-        assert username == os.environ['USER']
+        assert username == os.environ["USER"]
         assert assignment == "ps1"
         assert parse_utc(timestamp1) > now
-        assert os.path.isfile(os.path.join(cache, "abc101", filename, "p1.ipynb"))
-        assert os.path.isfile(os.path.join(cache, "abc101", filename, "timestamp.txt"))
-        with open(os.path.join(cache, "abc101", filename, "timestamp.txt"), "r") as fh:
+        assert isfile(join(cache, "abc101", filename, "p1.ipynb"))
+        assert isfile(join(cache, "abc101", filename, "timestamp.txt"))
+        with open(join(cache, "abc101", filename, "timestamp.txt"), "r") as fh:
             assert fh.read() == timestamp1
 
         time.sleep(1)
         self._submit("ps1", exchange, cache)
 
-        assert len(os.listdir(os.path.join(exchange, "abc101", "inbound"))) == 2
-        filename = sorted(os.listdir(os.path.join(exchange, "abc101", "inbound")))[1]
+        assert len(os.listdir(join(exchange, "abc101", "inbound"))) == 2
+        filename = sorted(os.listdir(join(exchange, "abc101", "inbound")))[1]
         username, assignment, timestamp2 = filename.split("+")
-        assert username == os.environ['USER']
+        assert username == os.environ["USER"]
         assert assignment == "ps1"
         assert parse_utc(timestamp2) > parse_utc(timestamp1)
-        assert os.path.isfile(os.path.join(exchange, "abc101", "inbound", filename, "p1.ipynb"))
-        assert os.path.isfile(os.path.join(exchange, "abc101", "inbound", filename, "timestamp.txt"))
-        with open(os.path.join(exchange, "abc101", "inbound", filename, "timestamp.txt"), "r") as fh:
+        assert isfile(join(exchange, "abc101", "inbound", filename, "p1.ipynb"))
+        assert isfile(join(exchange, "abc101", "inbound", filename, "timestamp.txt"))
+        with open(join(exchange, "abc101", "inbound", filename, "timestamp.txt"), "r") as fh:
             assert fh.read() == timestamp2
 
-        assert len(os.listdir(os.path.join(cache, "abc101"))) == 2
-        filename = sorted(os.listdir(os.path.join(cache, "abc101")))[1]
+        assert len(os.listdir(join(cache, "abc101"))) == 2
+        filename = sorted(os.listdir(join(cache, "abc101")))[1]
         username, assignment, timestamp2 = filename.split("+")
-        assert username == os.environ['USER']
+        assert username == os.environ["USER"]
         assert assignment == "ps1"
         assert parse_utc(timestamp2) > parse_utc(timestamp1)
-        assert os.path.isfile(os.path.join(cache, "abc101", filename, "p1.ipynb"))
-        assert os.path.isfile(os.path.join(cache, "abc101", filename, "timestamp.txt"))
-        with open(os.path.join(cache, "abc101", filename, "timestamp.txt"), "r") as fh:
+        assert isfile(join(cache, "abc101", filename, "p1.ipynb"))
+        assert isfile(join(cache, "abc101", filename, "timestamp.txt"))
+        with open(join(cache, "abc101", filename, "timestamp.txt"), "r") as fh:
             assert fh.read() == timestamp2

--- a/nbgrader/tests/apps/test_nbgrader_validate.py
+++ b/nbgrader/tests/apps/test_nbgrader_validate.py
@@ -1,5 +1,7 @@
 import json
 
+from os.path import join
+
 from .. import run_python_module
 from .base import BaseTestApp
 
@@ -12,37 +14,37 @@ class TestNbGraderValidate(BaseTestApp):
 
     def test_validate_unchanged(self):
         """Does the validation fail on an unchanged notebook?"""
-        self._copy_file("files/submitted-unchanged.ipynb", "submitted-unchanged.ipynb")
+        self._copy_file(join("files", "submitted-unchanged.ipynb"), "submitted-unchanged.ipynb")
         output = run_python_module(["nbgrader", "validate", "submitted-unchanged.ipynb"])
         assert output.split("\n")[0] == "VALIDATION FAILED ON 3 CELL(S)! If you submit your assignment as it is, you WILL NOT"
 
     def test_validate_changed(self):
         """Does the validation pass on an changed notebook?"""
-        self._copy_file("files/submitted-changed.ipynb", "submitted-changed.ipynb")
+        self._copy_file(join("files", "submitted-changed.ipynb"), "submitted-changed.ipynb")
         output = run_python_module(["nbgrader", "validate", "submitted-changed.ipynb"])
         assert output == "Success! Your notebook passes all the tests.\n"
 
     def test_invert_validate_unchanged(self):
         """Does the inverted validation pass on an unchanged notebook?"""
-        self._copy_file("files/submitted-unchanged.ipynb", "submitted-unchanged.ipynb")
+        self._copy_file(join("files", "submitted-unchanged.ipynb"), "submitted-unchanged.ipynb")
         output = run_python_module(["nbgrader", "validate", "submitted-unchanged.ipynb", "--invert"])
         assert output.split("\n")[0] == "NOTEBOOK PASSED ON 1 CELL(S)!"
 
     def test_invert_validate_changed(self):
         """Does the inverted validation fail on a changed notebook?"""
-        self._copy_file("files/submitted-changed.ipynb", "submitted-changed.ipynb")
+        self._copy_file(join("files", "submitted-changed.ipynb"), "submitted-changed.ipynb")
         output = run_python_module(["nbgrader", "validate", "submitted-changed.ipynb", "--invert"])
         assert output.split("\n")[0] == "NOTEBOOK PASSED ON 2 CELL(S)!"
 
     def test_grade_cell_changed(self):
         """Does the validate fail if a grade cell has changed?"""
-        self._copy_file("files/submitted-grade-cell-changed.ipynb", "submitted-grade-cell-changed.ipynb")
+        self._copy_file(join("files", "submitted-grade-cell-changed.ipynb"), "submitted-grade-cell-changed.ipynb")
         output = run_python_module(["nbgrader", "validate", "submitted-grade-cell-changed.ipynb"])
         assert output.split("\n")[0] == "THE CONTENTS OF 1 TEST CELL(S) HAVE CHANGED! This might mean that even though the tests"
 
     def test_grade_cell_changed_ignore_checksums(self):
         """Does the validate pass if a grade cell has changed but we're ignoring checksums?"""
-        self._copy_file("files/submitted-grade-cell-changed.ipynb", "submitted-grade-cell-changed.ipynb")
+        self._copy_file(join("files", "submitted-grade-cell-changed.ipynb"), "submitted-grade-cell-changed.ipynb")
         output = run_python_module([
             "nbgrader", "validate", "submitted-grade-cell-changed.ipynb",
             "--DisplayAutoGrades.ignore_checksums=True"
@@ -51,13 +53,13 @@ class TestNbGraderValidate(BaseTestApp):
 
     def test_invert_grade_cell_changed(self):
         """Does the validate fail if a grade cell has changed, even with --invert?"""
-        self._copy_file("files/submitted-grade-cell-changed.ipynb", "submitted-grade-cell-changed.ipynb")
+        self._copy_file(join("files", "submitted-grade-cell-changed.ipynb"), "submitted-grade-cell-changed.ipynb")
         output = run_python_module(["nbgrader", "validate", "submitted-grade-cell-changed.ipynb", "--invert"])
         assert output.split("\n")[0] == "THE CONTENTS OF 1 TEST CELL(S) HAVE CHANGED! This might mean that even though the tests"
 
     def test_invert_grade_cell_changed_ignore_checksums(self):
         """Does the validate fail if a grade cell has changed with --invert and ignoring checksums?"""
-        self._copy_file("files/submitted-grade-cell-changed.ipynb", "submitted-grade-cell-changed.ipynb")
+        self._copy_file(join("files", "submitted-grade-cell-changed.ipynb"), "submitted-grade-cell-changed.ipynb")
         output = run_python_module([
             "nbgrader", "validate", "submitted-grade-cell-changed.ipynb",
             "--invert",
@@ -67,7 +69,7 @@ class TestNbGraderValidate(BaseTestApp):
 
     def test_validate_unchanged_ignore_checksums(self):
         """Does the validation fail on an unchanged notebook with ignoring checksums?"""
-        self._copy_file("files/submitted-unchanged.ipynb", "submitted-unchanged.ipynb")
+        self._copy_file(join("files", "submitted-unchanged.ipynb"), "submitted-unchanged.ipynb")
         output = run_python_module([
             "nbgrader", "validate", "submitted-unchanged.ipynb",
             "--DisplayAutoGrades.ignore_checksums=True"
@@ -76,13 +78,13 @@ class TestNbGraderValidate(BaseTestApp):
 
     def test_locked_cell_changed(self):
         """Does the validate fail if a locked cell has changed?"""
-        self._copy_file("files/submitted-locked-cell-changed.ipynb", "submitted-locked-cell-changed.ipynb")
+        self._copy_file(join("files", "submitted-locked-cell-changed.ipynb"), "submitted-locked-cell-changed.ipynb")
         output = run_python_module(["nbgrader", "validate", "submitted-locked-cell-changed.ipynb"])
         assert output.split("\n")[0] == "THE CONTENTS OF 2 TEST CELL(S) HAVE CHANGED! This might mean that even though the tests"
 
     def test_locked_cell_changed_ignore_checksums(self):
         """Does the validate pass if a locked cell has changed but we're ignoring checksums?"""
-        self._copy_file("files/submitted-locked-cell-changed.ipynb", "submitted-locked-cell-changed.ipynb")
+        self._copy_file(join("files", "submitted-locked-cell-changed.ipynb"), "submitted-locked-cell-changed.ipynb")
         output = run_python_module([
             "nbgrader", "validate", "submitted-locked-cell-changed.ipynb",
             "--DisplayAutoGrades.ignore_checksums=True"
@@ -91,13 +93,13 @@ class TestNbGraderValidate(BaseTestApp):
 
     def test_invert_locked_cell_changed(self):
         """Does the validate fail if a locked cell has changed, even with --invert?"""
-        self._copy_file("files/submitted-locked-cell-changed.ipynb", "submitted-locked-cell-changed.ipynb")
+        self._copy_file(join("files", "submitted-locked-cell-changed.ipynb"), "submitted-locked-cell-changed.ipynb")
         output = run_python_module(["nbgrader", "validate", "submitted-locked-cell-changed.ipynb", "--invert"])
         assert output.split("\n")[0] == "THE CONTENTS OF 2 TEST CELL(S) HAVE CHANGED! This might mean that even though the tests"
 
     def test_invert_locked_cell_changed_ignore_checksums(self):
         """Does the validate fail if a locked cell has changed with --invert and ignoring checksums?"""
-        self._copy_file("files/submitted-locked-cell-changed.ipynb", "submitted-locked-cell-changed.ipynb")
+        self._copy_file(join("files", "submitted-locked-cell-changed.ipynb"), "submitted-locked-cell-changed.ipynb")
         output = run_python_module([
             "nbgrader", "validate", "submitted-locked-cell-changed.ipynb",
             "--invert",
@@ -107,7 +109,7 @@ class TestNbGraderValidate(BaseTestApp):
 
     def test_invert_locked_cell_changed_ignore_checksums_json(self):
         """Does the validate fail if a locked cell has changed with --invert and ignoring checksums?"""
-        self._copy_file("files/submitted-locked-cell-changed.ipynb", "submitted-locked-cell-changed.ipynb")
+        self._copy_file(join("files", "submitted-locked-cell-changed.ipynb"), "submitted-locked-cell-changed.ipynb")
         output = run_python_module([
             "nbgrader", "validate", "submitted-locked-cell-changed.ipynb",
             "--invert",


### PR DESCRIPTION
This allows an instructor to specify the root course directory in `nbgrader_config.py` so that the commands don't always need to be run from the root of the directory but can be run from anywhere on the system. Closes #383 

In the process I also fixed a bunch of places in the app tests where they were using hardcoded paths rather than `os.path.join`.

cc @jonathanmorgan