### PR TITLE
Add --no-metadata option to nbgrader assign

### DIFF
--- a/nbgrader/preprocessors/clearsolutions.py
+++ b/nbgrader/preprocessors/clearsolutions.py
@@ -1,4 +1,5 @@
-from traitlets import Unicode
+from traitlets import Unicode, Bool
+from textwrap import dedent
 
 from .. import utils
 from . import NbGraderPreprocessor
@@ -30,6 +31,20 @@ class ClearSolutions(NbGraderPreprocessor):
         "## END SOLUTION",
         config=True,
         help="The delimiter marking the end of a solution (excluding comment mark)")
+
+    enforce_metadata = Bool(
+        True,
+        config=True,
+        help=dedent(
+            """
+            Whether or not to complain if cells containing solutions regions are
+            not marked as solution cells. WARNING: this will potentially cause
+            things to break if you are using the full nbgrader pipeline. ONLY
+            disable this option if you are only ever planning to use nbgrader
+            assign.
+            """
+        )
+    )
 
     @property
     def begin_solution(self):
@@ -113,10 +128,11 @@ class ClearSolutions(NbGraderPreprocessor):
         # region -- if it's not, then this is a problem, because the cell needs
         # to be given an id
         if not is_solution and replaced_solution:
-            raise RuntimeError(
-                "Solution region detected in a non-solution cell; "
-                "please make sure all solution regions are within "
-                "solution cells")
+            if self.enforce_metadata:
+                raise RuntimeError(
+                    "Solution region detected in a non-solution cell; please make sure "
+                    "all solution regions are within solution cells."
+                )
 
         # replace solution cells with the code/text stub -- but not if
         # we already replaced a solution region, because that means

--- a/nbgrader/tests/apps/files/test-no-metadata.ipynb
+++ b/nbgrader/tests/apps/files/test-no-metadata.ipynb
@@ -1,0 +1,220 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+   },
+   "source": [
+    "For this problem set, we'll be using the Jupyter notebook:\n",
+    "\n",
+    "![](jupyter.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+   },
+   "source": [
+    "---\n",
+    "## Part A (2 points)\n",
+    "\n",
+    "Write a function that returns a list of numbers, such that $x_i=i^2$, for $1\\leq i \\leq n$. Make sure it handles the case where $n<1$ by raising a `ValueError`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def squares(n):\n",
+    "    \"\"\"Compute the squares of numbers from 1 to n, such that the \n",
+    "    ith element of the returned list equals i^2.\n",
+    "    \n",
+    "    \"\"\"\n",
+    "    ### BEGIN SOLUTION\n",
+    "    if n < 1:\n",
+    "        raise ValueError(\"n must be greater than or equal to 1\")\n",
+    "    return [i ** 2 for i in range(1, n + 1)]\n",
+    "    ### END SOLUTION"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+   },
+   "source": [
+    "Your function should print `[1, 4, 9, 16, 25, 36, 49, 64, 81, 100]` for $n=10$. Check that it does:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "squares(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "\"\"\"Check that squares returns the correct output for several inputs\"\"\"\n",
+    "from nose.tools import assert_equal\n",
+    "assert_equal(squares(1), [1])\n",
+    "assert_equal(squares(2), [1, 4])\n",
+    "assert_equal(squares(10), [1, 4, 9, 16, 25, 36, 49, 64, 81, 100])\n",
+    "assert_equal(squares(11), [1, 4, 9, 16, 25, 36, 49, 64, 81, 100, 121])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "\"\"\"Check that squares raises an error for invalid inputs\"\"\"\n",
+    "from nose.tools import assert_raises\n",
+    "assert_raises(ValueError, squares, 0)\n",
+    "assert_raises(ValueError, squares, -4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## Part B (1 point)\n",
+    "\n",
+    "Using your `squares` function, write a function that computes the sum of the squares of the numbers from 1 to $n$. Your function should call the `squares` function -- it should NOT reimplement its functionality."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def sum_of_squares(n):\n",
+    "    \"\"\"Compute the sum of the squares of numbers from 1 to n.\"\"\"\n",
+    "    ### BEGIN SOLUTION\n",
+    "    return sum(squares(n))\n",
+    "    ### END SOLUTION"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+   },
+   "source": [
+    "The sum of squares from 1 to 10 should be 385. Verify that this is the answer you get:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "sum_of_squares(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "\"\"\"Check that sum_of_squares returns the correct answer for various inputs.\"\"\"\n",
+    "assert_equal(sum_of_squares(1), 1)\n",
+    "assert_equal(sum_of_squares(2), 5)\n",
+    "assert_equal(sum_of_squares(10), 385)\n",
+    "assert_equal(sum_of_squares(11), 506)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "\"\"\"Check that sum_of_squares relies on squares.\"\"\"\n",
+    "orig_squares = squares\n",
+    "del squares\n",
+    "try:\n",
+    "    assert_raises(NameError, sum_of_squares, 1)\n",
+    "except AssertionError:\n",
+    "    raise AssertionError(\"sum_of_squares does not use squares\")\n",
+    "finally:\n",
+    "    squares = orig_squares"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+   },
+   "source": [
+    "---\n",
+    "## Part C (1 point)\n",
+    "\n",
+    "Using LaTeX math notation, write out the equation that is implemented by your `sum_of_squares` function."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+   },
+   "source": [
+    "$\\sum_{i=1}^n i^2$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+   },
+   "source": [
+    "---\n",
+    "## Part D (2 points)\n",
+    "\n",
+    "Find a usecase for your `sum_of_squares` function and implement that usecase in the cell below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def pyramidal_number(n):\n",
+    "    \"\"\"Returns the n^th pyramidal number\"\"\"\n",
+    "    return sum_of_squares(n)"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/nbgrader/tests/apps/test_nbgrader_assign.py
+++ b/nbgrader/tests/apps/test_nbgrader_assign.py
@@ -238,3 +238,14 @@ class TestNbGraderAssign(BaseTestApp):
 
     def test_fail_no_notebooks(self):
         run_python_module(["nbgrader", "assign", "ps1", "--create"], retcode=1)
+
+    def test_no_metadata(self, course_dir):
+        self._copy_file(join("files", "test-no-metadata.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
+
+        # it should fail because of the solution regions
+        run_python_module(["nbgrader", "assign", "ps1", "--no-db"], retcode=1)
+
+        # it should pass now that we're not enforcing metadata
+        run_python_module(["nbgrader", "assign", "ps1", "--no-db", "--no-metadata"])
+        assert os.path.exists(join(course_dir, "release", "ps1", "p1.ipynb"))
+

--- a/nbgrader/tests/preprocessors/test_clearsolutions.py
+++ b/nbgrader/tests/preprocessors/test_clearsolutions.py
@@ -182,6 +182,12 @@ class TestClearSolutions(BaseTestPreprocessor):
         with pytest.raises(RuntimeError):
             preprocessor.preprocess_cell(cell, {}, 1)
 
+        # now disable enforcing metadata
+        preprocessor.enforce_metadata = False
+        cell, _ = preprocessor.preprocess_cell(cell, {}, 1)
+        assert cell.source == "something something\nYOUR ANSWER HERE"
+        assert 'nbgrader' not in cell.metadata
+
     def test_preprocess_notebook(self, preprocessor):
         """Is the test notebook processed without error?"""
         nb = self._read_nb("files/test.ipynb")


### PR DESCRIPTION
Fixes #403

This allows you to run `nbgrader assign --no-metadata` and it will not perform any metadata validation or modify it either. Can be used in conjunction with `--no-db` to just replace solution regions and not use the "Create Assignment" toolbar or save anything into the database.

cc @jklymak 