### PR TITLE
Make a friendlier development install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   - wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
   - tar -xvf $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -C $PWD/travis-phantomjs
   - export PATH=$PWD/travis-phantomjs:$PATH
-  - invoke install --group="$GROUP" --python-version="$TRAVIS_PYTHON_VERSION"
+  - invoke install --group="$GROUP"
 script:
   - invoke tests --group="$GROUP"
 after_success:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,10 +33,9 @@ First, clone the git repository:
     git clone https://github.com/jupyter/nbgrader
     cd nbgrader
 
-Then, you must install nbgrader using [flit](https://github.com/takluyver/flit) (note that flit requires Python 3):
+Then, you install nbgrader with the following command:
 
-    pip3 install flit
-    flit install --symlink
+    python setup.py develop
 
 You will probably also want to install the notebook extension using a symlink, so that it updates whenever you update the repository:
 

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,66 @@
-import subprocess as sp
+import argparse
 import sys
+import subprocess as sp
+import warnings
 
-print('Warning: this setup.py uses flit, not setuptools.')
-print('Behavior may not be exactly what you expect. Use at your own risk!')
 
-cmd = [sys.executable, '-m', 'flit', 'install', '--deps', 'production']
-print(" ".join(cmd))
-sp.check_call(cmd)
+def install_flit():
+    if sys.version_info[0] == 2:
+        package = 'flit-install-py2'
+    else:
+        package = 'flit'
+
+    sp.check_call([sys.executable, '-m', 'pip', 'install', package])
+
+
+def install_nbgrader(symlink):
+    args = []
+
+    if sys.version_info[0] == 2:
+        command = ['flit_install_py2']
+    else:
+        command = ['flit', 'install']
+        args.extend(['--deps', 'all'])
+
+    if symlink:
+        args += ['--symlink']
+
+    sp.check_call([sys.executable, '-m'] + command + args)
+
+
+def install():
+    install_flit()
+    install_nbgrader(symlink=False)
+
+
+def develop():
+    install_flit()
+    install_nbgrader(symlink=True)
+
+
+def egg_info():
+    print("This setup.py does not support egg_info. Please re-run with:")
+    print("    python setup.py develop")
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    warnings.warn(
+        'Warning: this setup.py uses flit, not setuptools. '
+        'Behavior may not be exactly what you expect!'
+    )
+
+    parser = argparse.ArgumentParser('install_dev')
+    subparsers = parser.add_subparsers()
+
+    install_parser = subparsers.add_parser('install')
+    install_parser.set_defaults(func=install)
+
+    develop_parser = subparsers.add_parser('develop')
+    develop_parser.set_defaults(func=develop)
+
+    egg_info_parser = subparsers.add_parser('egg_info')
+    egg_info_parser.set_defaults(func=egg_info)
+
+    args = parser.parse_args()
+    args.func()

--- a/tasks.py
+++ b/tasks.py
@@ -169,12 +169,6 @@ def before_install(group, python_version):
     # clone travis wheels repo to make installing requirements easier
     run('git clone --quiet --depth 1 https://github.com/minrk/travis-wheels ~/travis-wheels')
 
-    # if we're on python 2, install flit-install-py2, otherwise install flit
-    if python_version == '3.4':
-        run('pip install flit')
-    else:
-        run('pip install flit-install-py2')
-
     # install jupyterhub
     if python_version == '3.4' and group == 'js':
         run('npm install -g configurable-http-proxy')
@@ -182,16 +176,12 @@ def before_install(group, python_version):
 
 
 @task
-def install(group, python_version):
-    # build the command depending on python version
-    if python_version == '3.4':
-        cmd = 'flit install'
-    else:
-        cmd = 'flit-install-py2'
-
-    # add --symlink flag, depending on whether it's docs or not
+def install(group):
+    # symlink, depending on whether it's docs or not
     if group != 'docs':
-        cmd += ' --symlink'
+        cmd = 'python setup.py develop'
+    else:
+        cmd = 'python setup.py install'
 
     # install
     run('PIP_FIND_LINKS=~/travis-wheels/wheelhouse {}'.format(cmd))


### PR DESCRIPTION
This makes it possible to install with `python setup.py develop` regardless of whether you're running python 2 or python 3. It may not always work exactly the same way as it does with setuptools since this uses flit on the backend, but for basic usage it should be consistent, at least.

cc @jklymak