### PR TITLE
Redirect flask back to https

### DIFF
--- a/nbgrader/tests/formgrader/conftest.py
+++ b/nbgrader/tests/formgrader/conftest.py
@@ -74,7 +74,8 @@ def _formgrader(request, manager_class, gradebook, tempdir):
 
     capabilities = DesiredCapabilities.PHANTOMJS
     capabilities['loggingPrefs'] = {'browser': 'ALL'}
-    browser = webdriver.PhantomJS(desired_capabilities=capabilities)
+    capabilities['acceptSslCerts'] = True
+    browser = webdriver.PhantomJS(service_args=['--ignore-ssl-errors=true'], desired_capabilities=capabilities)
     browser.set_page_load_timeout(30)
     browser.set_script_timeout(30)
 

--- a/nbgrader/tests/formgrader/manager.py
+++ b/nbgrader/tests/formgrader/manager.py
@@ -10,7 +10,8 @@ __all__ = [
     "DefaultManager",
     "HubAuthManager",
     "HubAuthTokenManager",
-    "HubAuthCustomUrlManager"
+    "HubAuthCustomUrlManager",
+    "HubAuthSSLManager"
 ]
 
 class DefaultManager(object):
@@ -95,6 +96,7 @@ class HubAuthManager(DefaultManager):
         """
     )
 
+    base_url = "http://localhost:8000"
     base_formgrade_url = "http://localhost:8000/hub/nbgrader/course123ABC/"
     base_notebook_url = "http://localhost:8000/user/foobar/notebooks/class_files/"
 
@@ -174,3 +176,47 @@ class HubAuthCustomUrlManager(HubAuthManager):
     )
 
     base_formgrade_url = "http://localhost:8000/hub/grader/"
+
+class HubAuthSSLManager(HubAuthManager):
+
+    nbgrader_config = dedent(
+        """
+        c = get_config()
+        c.NbGrader.course_id = 'course123ABC'
+        c.FormgradeApp.ip = '127.0.0.1'
+        c.FormgradeApp.port = 9000
+        c.FormgradeApp.authenticator_class = "nbgrader.auth.hubauth.HubAuth"
+        c.HubAuth.graders = ["foobar"]
+        c.HubAuth.notebook_url_prefix = "class_files"
+        c.HubAuth.hub_base_url = "https://localhost:8000"
+        """
+    )
+
+    jupyterhub_config = dedent(
+        """
+        c = get_config()
+        c.JupyterHub.authenticator_class = 'nbgrader.tests.formgrader.fakeuser.FakeUserAuth'
+        c.JupyterHub.spawner_class = 'nbgrader.tests.formgrader.fakeuser.FakeUserSpawner'
+        c.JupyterHub.ssl_cert = '{tempdir}/jupyterhub_cert.pem'
+        c.JupyterHub.ssl_key = '{tempdir}/jupyterhub_key.pem'
+        c.JupyterHub.log_level = "WARN"
+        """
+    )
+
+    base_url = "https://localhost:8000"
+    base_formgrade_url = "https://localhost:8000/hub/nbgrader/course123ABC/"
+    base_notebook_url = "https://localhost:8000/user/foobar/notebooks/class_files/"
+
+    def _start_jupyterhub(self, *args, **kwargs):
+        sp.check_call([
+            "openssl",
+            "req", "-x509",
+            "-newkey", "rsa:2048",
+            "-keyout", "{}/jupyterhub_key.pem".format(self.tempdir),
+            "-out", "{}/jupyterhub_cert.pem".format(self.tempdir),
+            "-days", "1",
+            "-nodes",
+            "-batch"
+        ], cwd=self.tempdir)
+
+        super(HubAuthSSLManager, self)._start_jupyterhub(*args, **kwargs)

--- a/nbgrader/tests/formgrader/test_auth_failures.py
+++ b/nbgrader/tests/formgrader/test_auth_failures.py
@@ -15,8 +15,8 @@ class TestAuthFailures(BaseTestFormgrade):
     def test_login(self):
         self._get(self.manager.base_formgrade_url)
         self._wait_for_element("username_input")
-        next_url = self.formgrade_url().replace("http://localhost:8000", "")
-        self._check_url("http://localhost:8000/hub/login?next={}".format(next_url))
+        next_url = self.formgrade_url().replace(self.manager.base_url, "")
+        self._check_url("{}/hub/login?next={}".format(self.manager.base_url, next_url))
 
         # fill out the form
         self.browser.find_element_by_id("username_input").send_keys("foobar")
@@ -43,8 +43,8 @@ class TestInvalidGrader(BaseTestFormgrade):
 
         self._get(self.manager.base_formgrade_url)
         self._wait_for_element("username_input")
-        next_url = self.formgrade_url().replace("http://localhost:8000", "")
-        self._check_url("http://localhost:8000/hub/login?next={}".format(next_url))
+        next_url = self.formgrade_url().replace(self.manager.base_url, "")
+        self._check_url("{}/hub/login?next={}".format(self.manager.base_url, next_url))
 
         # fill out the form
         self.browser.find_element_by_id("username_input").send_keys("baz")
@@ -55,7 +55,7 @@ class TestInvalidGrader(BaseTestFormgrade):
         self._wait_for_element("error-403")
 
         # logout
-        self._get("http://localhost:8000/hub/logout")
+        self._get("{}/hub/logout".format(self.manager.base_url))
         self._wait_for_element("username_input")
 
     def test_expired_cookie(self):
@@ -64,8 +64,8 @@ class TestInvalidGrader(BaseTestFormgrade):
 
         self._get(self.manager.base_formgrade_url)
         self._wait_for_element("username_input")
-        next_url = self.formgrade_url().replace("http://localhost:8000", "")
-        self._check_url("http://localhost:8000/hub/login?next={}".format(next_url))
+        next_url = self.formgrade_url().replace(self.manager.base_url, "")
+        self._check_url("{}/hub/login?next={}".format(self.manager.base_url, next_url))
 
         # fill out the form
         self.browser.find_element_by_id("username_input").send_keys("foobar")

--- a/nbgrader/tests/formgrader/test_gradebook_navigation.py
+++ b/nbgrader/tests/formgrader/test_gradebook_navigation.py
@@ -20,8 +20,8 @@ class TestGradebook(BaseTestFormgrade):
 
         self._get(self.manager.base_formgrade_url)
         self._wait_for_element("username_input")
-        next_url = self.formgrade_url().replace("http://localhost:8000", "")
-        self._check_url("http://localhost:8000/hub/login?next={}".format(next_url))
+        next_url = self.formgrade_url().replace(self.manager.base_url, "")
+        self._check_url("{}/hub/login?next={}".format(self.manager.base_url, next_url))
 
         # fill out the form
         self.browser.find_element_by_id("username_input").send_keys("foobar")


### PR DESCRIPTION
Ok @jonathanmorgan, I think I finally figured out the https issue!

Flask automatically redirects requests that don't have a trailing slash, e.g. if you access `/hub/nbgrader/example_course`, it will redirect to `/hub/nbgrader/example_course/`. However, for some reason that I can't ascertain, when it does this redirect it will *also* redirect to `http://`, even if the original request was for `https://` and the appropriate header (`X-Forwarded-Proto`) is set in the request.

This PR intercepts all redirect requests and if they should start with `https://` but don't modifies the response to have the correct location. It's kind of a hack, but should work for now. In the 0.3.0 release of nbgrader this is fixed properly because we've switched to using tornado (see #397).

Fixes #400