### PR TITLE
Fix UTF-8 encoding bug on python 2

### DIFF
--- a/nbgrader/tests/utils/test_utils.py
+++ b/nbgrader/tests/utils/test_utils.py
@@ -250,6 +250,7 @@ def test_compute_checksum_solution_cell():
 
 def test_compute_checksum_utf8():
     utils.compute_checksum(create_solution_cell("\u03b8", "markdown", "foo"))
+    utils.compute_checksum(create_solution_cell(u'$$\\int^\u221e_0 x^2dx$$', "markdown", "foo"))
 
 
 def test_is_ignored(temp_cwd):

--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -59,10 +59,10 @@ def to_bytes(string):
     encodes the string to utf-8.
 
     """
-    if sys.version_info[0] == 2:
-        return bytes(string)
-    else:
+    if sys.version_info[0] == 3 or (sys.version_info[0] == 2 and isinstance(string, unicode)):
         return bytes(string.encode('utf-8'))
+    else:
+        return bytes(string)
 
 def compute_checksum(cell):
     m = hashlib.md5()


### PR DESCRIPTION
There is a bug on python 2 where if there is a unicode string in the cell source, then computing the checksum will fail.