### PR TITLE
[WIP] Restructure user guide TOC and doc flow to support new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ system and command line tools using:
 
     pip install nbgrader
     
-For detailed instructions for installing nbgrader and the nbgrader extensions
+For detailed instructions on installing nbgrader and the nbgrader extensions
 for Jupyter notebook, please see [Installation](https://nbgrader.readthedocs.org/en/stable/user_guide/01a_installation.html)
 section in the User Guide.
 

--- a/README.md
+++ b/README.md
@@ -36,39 +36,17 @@ and grade notebooks.
 
 
 ## Installation
-
-### The nbgrader system and command line tools
 You may install the current version of nbgrader which includes the grading
-system and command line tools:
+system and command line tools using:
 
     pip install nbgrader
-
-### nbgrader extensions
-You may then install the nbgrader extensions for Jupyter notebook. This will
-install both the *create assignment* toolbar extension and *assignment list*
-notebook server extension:
-
-    nbgrader extension install
-
-To use the toolbar extension as either an instructor or a student, activate the
-extension with:
-
-    nbgrader extension activate
-
-If you want to install the extension for only your user environment and not
-systemwide, use `nbgrader extension install --user`.
-If you don't want to have to reinstall the extension when nbgrader is updated,
-use `nbgrader extension install --symlink`.
-
-To get help and see all the options you can pass while installing or activating
-the nbgrader notebook extension, use:
-
-    nbgrader extension install --help-all
-    nbgrader extension activate --help-all
+    
+For detailed instructions for installing nbgrader and the nbgrader extensions
+for Jupyter notebook, please see [Installation](https://nbgrader.readthedocs.org/en/stable/user_guide/01a_installation.html)
+section in the User Guide.
 
 
 ## Contributing
-
 Please see the [contributing guidelines and documentation](CONTRIBUTING.md).
 
 If you want to develop features for nbgrader, please follow the

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A system for assigning and grading Jupyter notebooks.
 [Documentation can be found on Read the Docs.](http://nbgrader.readthedocs.org)
 
 
-## Visual highlights of nbgrader
+## Highlights of nbgrader
 
 ### Instructor toolbar extension for Jupyter notebooks
 The nbgrader toolbar extension for Jupyter notebooks guides the instructor through
@@ -27,13 +27,6 @@ submit, and validate their assignments.
 [Command line tools](https://nbgrader.readthedocs.org/en/stable/command_line_tools/index.html)
 offer an efficient way for the instructor to generate, assign, release, collect,
 and grade notebooks.
-
-* `nbgrader assign`: create a student version of a notebook
-* `nbgrader release`: release a notebook to students
-* `nbgrader collect`: collect students' submissions
-* `nbgrader autograde`: autograde students' submissions
-* `nbgrader formgrade`: launch the formgrader
-
 
 ## Installation
 You may install the current version of nbgrader which includes the grading

--- a/docs/source/user_guide/01_philosophy.rst
+++ b/docs/source/user_guide/01_philosophy.rst
@@ -1,7 +1,13 @@
 
-The philosophy
-==============
+The philosophy and the approach
+===============================
 
-TODO: Provide a high-level project overview with benefits to instructor and student
+The `nbgrader` project evolved from my experiences as an instructor and a
+student. This `excerpt from David Marr's book, Vision,
+<http://web.stanford.edu/class/psych209a/ReadingsByDate/01_07/Marr82Philosophy.pdf>`_ 
+inspired the creation of `nbgrader`. Dr. Marr was an originator of the field
+of computational neuroscience. On behalf of the many individuals who
+contribute to `nbgrader`, I hope you find this project enhances your teaching
+and learning experiences.
 
-nbgrader is awesomesauce!
+-- *Jess Hamrick*, UC Berkeley

--- a/docs/source/user_guide/01_philosophy.rst
+++ b/docs/source/user_guide/01_philosophy.rst
@@ -1,55 +1,7 @@
 
-The philosophy and the approach
-===============================
+The philosophy
+==============
 
-nbgrader makes a few assumptions about how the files for your
-assignments are organized. By default, nbgrader assumes that your
-assignments will be organized with the following directory structure:
+TODO: Provide a high-level project overview with benefits to instructor and student
 
-::
-
-    {course_directory}/{nbgrader_step}/{student_id}/{assignment_id}/{notebook_id}.ipynb
-
-By default, the ``course_directory`` variable is wherever you run the nbgrader commands.
-This means that you can place your class files directory wherever you want.
-However, this location can also be customized (see the :doc:`configuration options </config_options>`) so that you can run the nbgrader commands from anywhere on your system, but still have them operate on the same directory.
-
-Each subcommand of nbgrader (e.g. ``assign``, ``autograde``, etc.) has
-different input and output folders associated with it. These correspond
-to the ``nbgrader_step`` variable -- for example, the default input step
-directory for ``nbgrader autograde`` is "submitted", while the default
-output step directory is "autograded".
-
-The other variables are more self-explanatory: ``student_id``
-corresponds to the unique ID of a student, ``assignment_id`` corresponds
-to the unique name of an assignment, and ``notebook_id`` corresponds to
-the name of a notebook within an assignment (excluding the .ipynb
-extension).
-
-Additionally, nbgrader needs access to a database to store information about the assignments.
-This database is, by default, a sqlite database that lives at ``{course_directory}/gradebook.db``, but you can also configure this to be any location of your choosing.
-You do not need to manually create this database yourself, as nbgrader will create it for you, but you probably want to prepopulate it with some information about assignment due dates and students (see :doc:`03_generating_assignments` and :doc:`04_autograding`).
-Additionally, nbgrader uses SQLAlchemy, so you should be able to also use MySQL or PostgreSQL backends as well (though in these cases, you *will* need to create the database ahead of time, as this is just how MySQL and PostgreSQL work).
-
-Example
--------
-
-Taking the autograde step as an example, when we run the command
-``nbgrader autograde "Problem Set 1"``, nbgrader will look for all
-notebooks that match the following path:
-
-::
-
-    submitted/*/Problem Set 1/*.ipynb
-
-For each notebook that it finds, it will extract the ``student_id``,
-``assignment_id``, and ``notebook_id`` according to the directory
-structure described above. It will then autograde the notebook, and save
-the autograded version to:
-
-::
-
-    autograded/{student_id}/Problem Set 1/{notebook_id}.ipynb
-
-where ``student_id`` and ``notebook_id`` were parsed from the input file
-path.
+nbgrader is awesomesauce!

--- a/docs/source/user_guide/01a_filestructure.rst
+++ b/docs/source/user_guide/01a_filestructure.rst
@@ -1,0 +1,63 @@
+
+Recommended file structure
+==========================
+For instructor ease of use and developer maintenance, nbgrader makes a few
+assumptions about how your assignment files are organized. By default, nbgrader
+assumes that your assignments will be organized with the following directory
+structure:
+
+::
+
+    {course_directory}/{nbgrader_step}/{student_id}/{assignment_id}/{notebook_id}.ipynb
+
+course_directory
+----------------
+ ``course_directory`` variable is the root directory where you run the nbgrader commands.
+  This means that you can place your class files directory wherever you want.
+  However, this location can also be customized (see the :doc:`configuration options </config_options>`) so that you can run the nbgrader commands from anywhere on your system, but still have them operate on the same directory.
+
+nbgrader_step
+-------------
+Each subcommand of nbgrader (e.g. ``assign``, ``autograde``, etc.) has
+different input and output folders associated with it. These correspond
+to the ``nbgrader_step`` variable -- for example, the default input step
+directory for ``nbgrader autograde`` is "submitted", while the default
+output step directory is "autograded".
+
+identifiers
+-----------
+The other variables are more self-explanatory: ``student_id``
+corresponds to the unique ID of a student, ``assignment_id`` corresponds
+to the unique name of an assignment, and ``notebook_id`` corresponds to
+the name of a notebook within an assignment (excluding the .ipynb
+extension).
+
+Database of assignments
+-----------------------
+Additionally, nbgrader needs access to a database to store information about the assignments.
+This database is, by default, a sqlite database that lives at ``{course_directory}/gradebook.db``, but you can also configure this to be any location of your choosing.
+You do not need to manually create this database yourself, as nbgrader will create it for you, but you probably want to prepopulate it with some information about assignment due dates and students (see :doc:`03_generating_assignments` and :doc:`04_autograding`).
+Additionally, nbgrader uses SQLAlchemy, so you should be able to also use MySQL or PostgreSQL backends as well (though in these cases, you *will* need to create the database ahead of time, as this is just how MySQL and PostgreSQL work).
+
+
+Example
+-------
+Taking the autograde step as an example, when we run the command
+``nbgrader autograde "Problem Set 1"``, nbgrader will look for all
+notebooks that match the following path:
+
+::
+
+    submitted/*/Problem Set 1/*.ipynb
+
+For each notebook that it finds, it will extract the ``student_id``,
+``assignment_id``, and ``notebook_id`` according to the directory
+structure described above. It will then autograde the notebook, and save
+the autograded version to:
+
+::
+
+    autograded/{student_id}/Problem Set 1/{notebook_id}.ipynb
+
+where ``student_id`` and ``notebook_id`` were parsed from the input file
+path.

--- a/docs/source/user_guide/01a_filestructure.rst
+++ b/docs/source/user_guide/01a_filestructure.rst
@@ -1,44 +1,50 @@
 
-Recommended file structure
-==========================
+How to structure course files
+=============================
 For instructor ease of use and developer maintenance, nbgrader makes a few
-assumptions about how your assignment files are organized. By default, nbgrader
-assumes that your assignments will be organized with the following directory
-structure:
+assumptions about how your assignment files are organized. By default,
+nbgrader assumes that your assignments will be organized with the following
+directory structure:
 
 ::
 
     {course_directory}/{nbgrader_step}/{student_id}/{assignment_id}/{notebook_id}.ipynb
+    
+where:
 
-course_directory
-----------------
- ``course_directory`` variable is the root directory where you run the nbgrader commands.
-  This means that you can place your class files directory wherever you want.
-  However, this location can also be customized (see the :doc:`configuration options </config_options>`) so that you can run the nbgrader commands from anywhere on your system, but still have them operate on the same directory.
+* ``course_directory`` variable is the root directory where you run the
+  nbgrader commands. This means that you can place your class files directory
+  wherever you want. However, this location can also be customized (see the
+  :doc:`configuration options </config_options>`) so that you can run the
+  nbgrader commands from anywhere on your system, but still have them
+  operate on the same directory.
+  
+* ``nbgrader_step`` - Each subcommand of nbgrader (e.g. ``assign``,
+  ``autograde``, etc.) has different input and output folders associated with
+  it. These correspond to the ``nbgrader_step`` variable -- for example, the
+  default input step directory for ``nbgrader autograde`` is "submitted",
+  while the default output step directory is "autograded".
 
-nbgrader_step
--------------
-Each subcommand of nbgrader (e.g. ``assign``, ``autograde``, etc.) has
-different input and output folders associated with it. These correspond
-to the ``nbgrader_step`` variable -- for example, the default input step
-directory for ``nbgrader autograde`` is "submitted", while the default
-output step directory is "autograded".
+* ``student_id`` corresponds to the unique ID of a student.
 
-identifiers
------------
-The other variables are more self-explanatory: ``student_id``
-corresponds to the unique ID of a student, ``assignment_id`` corresponds
-to the unique name of an assignment, and ``notebook_id`` corresponds to
-the name of a notebook within an assignment (excluding the .ipynb
-extension).
+* ``assignment_id`` corresponds to the unique name of an assignment.
+
+* ``notebook_id`` corresponds to the name of a notebook within an assignment
+  (excluding the .ipynb extension).
 
 Database of assignments
 -----------------------
-Additionally, nbgrader needs access to a database to store information about the assignments.
-This database is, by default, a sqlite database that lives at ``{course_directory}/gradebook.db``, but you can also configure this to be any location of your choosing.
-You do not need to manually create this database yourself, as nbgrader will create it for you, but you probably want to prepopulate it with some information about assignment due dates and students (see :doc:`03_generating_assignments` and :doc:`04_autograding`).
-Additionally, nbgrader uses SQLAlchemy, so you should be able to also use MySQL or PostgreSQL backends as well (though in these cases, you *will* need to create the database ahead of time, as this is just how MySQL and PostgreSQL work).
-
+Additionally, nbgrader needs access to a database to store information about
+the assignments. This database is, by default, a sqlite database that lives at
+``{course_directory}/gradebook.db``, but you can also configure this to be any
+location of your choosing. You do not need to manually create this database
+yourself, as nbgrader will create it for you, but you probably want to
+prepopulate it with some information about assignment due dates and students
+(see :doc:`03_generating_assignments` and :doc:`04_autograding`).
+Additionally, nbgrader uses SQLAlchemy, so you should be able to also use
+MySQL or PostgreSQL backends as well (though in these cases, you *will* need
+to create the database ahead of time, as this is just how MySQL and PostgreSQL
+work).
 
 Example
 -------

--- a/docs/source/user_guide/01a_installation.rst
+++ b/docs/source/user_guide/01a_installation.rst
@@ -1,0 +1,34 @@
+
+Installation
+============
+
+The nbgrader system and command line tools
+------------------------------------------
+You may install the current version of nbgrader which includes the grading
+system and command line tools::
+
+    pip install nbgrader
+
+nbgrader extensions
+-------------------
+You may then install the nbgrader extensions for Jupyter notebook. This will
+install both the *create assignment* toolbar extension and *assignment list*
+notebook server extension::
+
+    nbgrader extension install
+
+To use the toolbar extension as either an instructor or a student, activate the
+extension with::
+
+    nbgrader extension activate
+
+If you want to install the extension for only your user environment and not
+systemwide, use ``nbgrader extension install --user``.
+If you don't want to have to reinstall the extension when nbgrader is updated,
+use ``nbgrader extension install --symlink``.
+
+To get help and see all the options you can pass while installing or activating
+the nbgrader notebook extension, use::
+
+    nbgrader extension install --help-all
+    nbgrader extension activate --help-all

--- a/docs/source/user_guide/01a_interface.rst
+++ b/docs/source/user_guide/01a_interface.rst
@@ -6,21 +6,23 @@ Instructor toolbar extension for Jupyter notebooks
 --------------------------------------------------
 The nbgrader toolbar extension for Jupyter notebooks guides the instructor through
 assignment and grading tasks using the familiar Jupyter notebook interface.
+For example, creating an assignment has the following workflow:
 
-![Creating assignment](docs/source/user_guide/images/creating_assignment.gif "Creating assignment")
+.. image:: images/creating_assignment.gif
+   :alt: Creating assignment
 
 Student assignment list extension for Jupyter notebooks
 -------------------------------------------------------
 Using the assignment list extension, students may conveniently view, fetch,
-submit, and validate their assignments.
+submit, and validate their assignments:
 
-![nbgrader assignment list](docs/source/user_guide/images/student_assignment.gif "nbgrader assignment list")
+.. image:: images/student_assignment.gif
+   :alt: nbgrader assignment list
 
 The command line tools of nbgrader
 ----------------------------------
-[Command line tools](https://nbgrader.readthedocs.org/en/stable/command_line_tools/index.html)
-offer an efficient way for the instructor to generate, assign, release, collect,
-and grade notebooks.
+Command line tools offer an efficient way for the instructor to generate,
+assign, release, collect, and grade notebooks. Here are some of the commands:
 
 * `nbgrader assign`: create a student version of a notebook
 * `nbgrader release`: release a notebook to students

--- a/docs/source/user_guide/01a_interface.rst
+++ b/docs/source/user_guide/01a_interface.rst
@@ -1,0 +1,29 @@
+
+nbgrader interface highlights
+=============================
+
+Instructor toolbar extension for Jupyter notebooks
+--------------------------------------------------
+The nbgrader toolbar extension for Jupyter notebooks guides the instructor through
+assignment and grading tasks using the familiar Jupyter notebook interface.
+
+![Creating assignment](docs/source/user_guide/images/creating_assignment.gif "Creating assignment")
+
+Student assignment list extension for Jupyter notebooks
+-------------------------------------------------------
+Using the assignment list extension, students may conveniently view, fetch,
+submit, and validate their assignments.
+
+![nbgrader assignment list](docs/source/user_guide/images/student_assignment.gif "nbgrader assignment list")
+
+The command line tools of nbgrader
+----------------------------------
+[Command line tools](https://nbgrader.readthedocs.org/en/stable/command_line_tools/index.html)
+offer an efficient way for the instructor to generate, assign, release, collect,
+and grade notebooks.
+
+* `nbgrader assign`: create a student version of a notebook
+* `nbgrader release`: release a notebook to students
+* `nbgrader collect`: collect students' submissions
+* `nbgrader autograde`: autograde students' submissions
+* `nbgrader formgrade`: launch the formgrader

--- a/docs/source/user_guide/02_developing_assignments.rst
+++ b/docs/source/user_guide/02_developing_assignments.rst
@@ -6,7 +6,7 @@ Developing assignments with the assignment toolbar
 
 .. seealso::
 
-    :doc:`01_philosophy`
+    :doc:`01a_filestructure`
         More details on how the nbgrader hierarchy is structured.
 
 Before you can begin developing assignments, you will need to actually install the nbgrader toolbar. If you do not have it installed, please first follow the instructions `here <https://github.com/jupyter/nbgrader>`__.
@@ -114,7 +114,7 @@ Most problems can be autograded. Problems that involve writing fruitful function
 Tips for writing good test cases
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Test each function/feature in isolation. If a problem contains many functions or parts, write cases that test each of these functions individually. Testing one function at a time makes it easier for you to track an error. 
+Test each function/feature in isolation. If a problem contains many functions or parts, write cases that test each of these functions individually. Testing one function at a time makes it easier for you to track an error.
 
 Organize test cases consistently. It can be helpful to arrange and group your test cases with comments.
 

--- a/docs/source/user_guide/03_generating_assignments.ipynb
+++ b/docs/source/user_guide/03_generating_assignments.ipynb
@@ -139,18 +139,27 @@
     "* [release/Problem Set 1/Problem 1.ipynb](release/Problem Set 1/Problem 1.ipynb)\n",
     "* [release/Problem Set 1/Problem 2.ipynb](release/Problem Set 1/Problem 2.ipynb)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
- "metadata": {},
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/docs/source/user_guide/03_generating_assignments.ipynb
+++ b/docs/source/user_guide/03_generating_assignments.ipynb
@@ -141,25 +141,7 @@
    ]
   }
  ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.5.1"
-  }
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/docs/source/user_guide/03_generating_assignments.ipynb
+++ b/docs/source/user_guide/03_generating_assignments.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Releasing an assignment"
+    "# Assign and release an assignment"
    ]
   },
   {
@@ -16,7 +16,7 @@
     "    :doc:`/command_line_tools/nbgrader-assign`\n",
     "        Command line options for ``nbgrader assign``\n",
     "        \n",
-    "    :doc:`01_philosophy`\n",
+    "    :doc:`01a_filestructure`\n",
     "        Details about how the directory hierarchy is structured\n",
     "\n",
     "    :doc:`/config_options`\n",
@@ -29,7 +29,7 @@
    "source": [
     "After an assignment has been created with the assignment toolbar, you will want to create a release version of the assignment for the students.\n",
     "\n",
-    "As described in :doc:`01_philosophy`, you need to organize your files in a particular way. For releasing assignments, you should have the master copy of your files saved (by default) in the following source directory structure:"
+    "As described in :doc:`01a_filestructure`, you need to organize your files in a particular way. For releasing assignments, you should have the master copy of your files saved (by default) in the following source directory structure:"
    ]
   },
   {
@@ -55,7 +55,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Example: Instructor workflow for generating an assignment release"
+    "## Workflow example: Instructor generating an assignment release"
    ]
   },
   {
@@ -139,6 +139,15 @@
     "* [release/Problem Set 1/Problem 1.ipynb](release/Problem Set 1/Problem 1.ipynb)\n",
     "* [release/Problem Set 1/Problem 2.ipynb](release/Problem Set 1/Problem 2.ipynb)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {},

--- a/docs/source/user_guide/04_autograding.ipynb
+++ b/docs/source/user_guide/04_autograding.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Autograde a students' solution"
+    "# Autograde assignments"
    ]
   },
   {
@@ -16,7 +16,7 @@
     "    :doc:`/command_line_tools/nbgrader-autograde`\n",
     "        Command line options for ``nbgrader autograde``\n",
     "        \n",
-    "    :doc:`01_philosophy`\n",
+    "    :doc:`01a_filestructure`\n",
     "        Details about how the directory hierarchy is structured\n",
     "\n",
     "    :doc:`/config_options`\n",
@@ -27,7 +27,7 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "After assignments have been submitted by students, you will want to save them into a ``submitted`` directory. As described in :doc:`01_philosophy`, you need to organize your files in a particular way. For autograding assignments, you should have the submitted versions of students' assignments organized as follows:"
+    "After assignments have been submitted by students, you will want to save them into a ``submitted`` directory. As described in :doc:`01a_filestructure`, you need to organize your files in a particular way. For autograding assignments, you should have the submitted versions of students' assignments organized as follows:"
    ]
   },
   {
@@ -49,7 +49,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Example"
+    "## Workflow example: Instructor autograding assignments"
    ]
   },
   {

--- a/docs/source/user_guide/05_manual_grading.rst
+++ b/docs/source/user_guide/05_manual_grading.rst
@@ -1,20 +1,20 @@
 
-Manually grading a student's solution
-=====================================
+Manually grading and formgrade
+==============================
 
 .. seealso::
 
     :doc:`/command_line_tools/nbgrader-formgrade`
         Command line options for ``nbgrader formgrade``
 
-    :doc:`01_philosophy`
+    :doc:`01a_filestructure`
         More details on how the nbgrader hierarchy is structured.
 
     :doc:`/config_options`
         Details on ``nbgrader_config.py``
 
 After assignments have been autograded, they will saved into an
-``autograded`` directory (see :doc:`01_philosophy` for details):
+``autograded`` directory (see :doc:`01a_filestructure` for details):
 
 After running ``nbgrader autograde``, the autograded version of the
 notebooks will be:

--- a/docs/source/user_guide/06_returning_feedback.ipynb
+++ b/docs/source/user_guide/06_returning_feedback.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Returning feedback to students"
+    "# Feedback on assignments"
    ]
   },
   {
@@ -16,7 +16,7 @@
     "    :doc:`/command_line_tools/nbgrader-feedback`\n",
     "        Command line options for ``nbgrader feedback``\n",
     "        \n",
-    "    :doc:`01_philosophy`\n",
+    "    :doc:`01a_filestructure`\n",
     "        Details about how the directory hierarchy is structured\n",
     "\n",
     "    :doc:`/config_options`\n",
@@ -27,7 +27,7 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "After assignments have been autograded and/or manually graded, they will located in the `autograded` directory (see :doc:`01_philosophy` for details):"
+    "After assignments have been autograded and/or manually graded, they will located in the `autograded` directory (see :doc:`01a_filestructure` for details):"
    ]
   },
   {
@@ -49,7 +49,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Example"
+    "## Workflow example: Instructor returning feedback to students"
    ]
   },
   {

--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -1,24 +1,55 @@
 User Guide
 ==========
 
+Overview
+--------
+
 .. toctree::
     :maxdepth: 1
 
     01_philosophy
-    02_developing_assignments
-    03_generating_assignments
-    04_autograding
-    05_manual_grading
-    06_returning_feedback
+    01a_interface
+
+
+Getting Started
+---------------
+
+.. toctree::
+    :maxdepth: 1
+
+    01a_installation
+    01a_filestructure
+
+
+Managing course assignments
+---------------------------
+
+.. toctree::
+   :maxdepth: 1
+
+   02_developing_assignments
+   03_generating_assignments
+
+
+Grading
+-------
+
+.. toctree::
+   :maxdepth: 1
+
+   04_autograding
+   05_manual_grading
+   06_returning_feedback
+
 
 Integration with JupyterHub
 ---------------------------
 
-If you are running a class with JupyterHub, nbgrader offers several tools that 
-exploit the fact that students and instructors are all sharing the same system.
-In particular, nbgrader streamlines the process of releasing and collecting
-assignments on the instructor side, and fetching and submitting assignments on
-the student side.
+For instructors running a class with JupyterHub, nbgrader offers several tools that
+optimize and enrich the instructors' and students' experience of sharing the same system.
+By integrating with JupyterHub, nbgrader streamlines the process of releasing and collecting
+assignments for the instructor and of fetching and submitting assignments for
+the student.
 
 .. toctree::
     :maxdepth: 1

--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -19,6 +19,7 @@ Getting Started
 
     01a_installation
     01a_filestructure
+    01a_interface
 
 
 Managing course assignments


### PR DESCRIPTION
This PR addresses issue #392. The user guide will frequently be the first documentation read by those interested in trying out nbgrader. The user guide must explain the project and its use, empower the user to try installing nbgrader, and to guide an instructor toward using nbgrader in a course.

The User Guide table of contents is now broken up into logical subsections of 3-4 items per subsection to improve learning and comprehension for those new to nbgrader. Examples are now titled with the format "Workflow example: Instructor..." or "Workflow example: Student..."

"Philosophy" is modified to be a high level project and benefits overview.
A new section for "Interface highlights" is added to share the user interface gifs that were recently added to the README.
There is a new section "Recommended File Structure" which contains the directory layout previously outlined in "Philosophy". 
There is a new section for "Installation" using the information in the existing README.

New major heading of "Managing assigments" and "Grading" are added to the TOC.

There are still some markdown that needs to be converted to rst. Also the use of markdown on subsection titles such as for the Example in "03_generating_assignments.ipynb" is not elegant with Sphinx as configured and is not properly suppressing subtitles in Sphinx TOC for the docs. I will look into why.

@jhamrick Thoughts? Not anchored to anything. Just want more useable docs for those new to using nbgrader. It also will be helpful to new developers for nbgrader, such as undergrad students, to have a solid overview and the info to get the project up and working.