### PR TITLE
Fix build errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ python:
 env:
   matrix:
     - GROUP=docs
-    - GROUP=js
+    - GROUP=formgrader
+    - GROUP=nbextensions
     - GROUP=python
 addons:
   apt:

--- a/flit.ini
+++ b/flit.ini
@@ -5,7 +5,7 @@ author-email = jupyter@googlegroups.com
 requires = sqlalchemy
     python-dateutil
     jupyter
-    notebook
+    notebook>=4.1
     nbconvert
     nbformat
     traitlets

--- a/nbgrader/tests/formgrader/fakeuser.py
+++ b/nbgrader/tests/formgrader/fakeuser.py
@@ -34,8 +34,6 @@ class FakeUserSpawner(LocalProcessSpawner):
     def make_preexec_fn(self, name):
         home = os.getcwd()
         def preexec():
-            # don't forward signals
-            os.setpgrp()
             # start in the cwd
             os.chdir(home)
         return preexec

--- a/nbgrader/tests/formgrader/test_auth_failures.py
+++ b/nbgrader/tests/formgrader/test_auth_failures.py
@@ -2,7 +2,7 @@ import pytest
 
 from .base import BaseTestFormgrade
 
-@pytest.mark.js
+@pytest.mark.formgrader
 @pytest.mark.usefixtures("bad_formgrader")
 class TestAuthFailures(BaseTestFormgrade):
 
@@ -27,7 +27,7 @@ class TestAuthFailures(BaseTestFormgrade):
         self._wait_for_element("error-500")
 
 
-@pytest.mark.js
+@pytest.mark.formgrader
 @pytest.mark.usefixtures("all_formgraders")
 class TestInvalidGrader(BaseTestFormgrade):
 

--- a/nbgrader/tests/formgrader/test_configproxy_auth_failure.py
+++ b/nbgrader/tests/formgrader/test_configproxy_auth_failure.py
@@ -6,7 +6,7 @@ from .conftest import jupyterhub, minversion
 
 @jupyterhub
 @minversion
-@pytest.mark.js
+@pytest.mark.formgrader
 def test_configproxy_auth_success(gradebook, tempdir):
     """Can the formgrader be started with the correct auth token?"""
 
@@ -28,7 +28,7 @@ def test_configproxy_auth_success(gradebook, tempdir):
 
 @jupyterhub
 @minversion
-@pytest.mark.js
+@pytest.mark.formgrader
 def test_configproxy_auth_failure(gradebook, tempdir):
     """Can the formgrader not be started when the auth token is incorrect?"""
 

--- a/nbgrader/tests/formgrader/test_formgrader_js.py
+++ b/nbgrader/tests/formgrader/test_formgrader_js.py
@@ -8,7 +8,7 @@ from selenium.webdriver.common.by import By
 from .base import BaseTestFormgrade
 
 
-@pytest.mark.js
+@pytest.mark.formgrader
 @pytest.mark.usefixtures("formgrader")
 class TestFormgraderJS(BaseTestFormgrade):
 

--- a/nbgrader/tests/formgrader/test_gradebook_navigation.py
+++ b/nbgrader/tests/formgrader/test_gradebook_navigation.py
@@ -7,7 +7,7 @@ from .base import BaseTestFormgrade
 from .manager import HubAuthNotebookServerUserManager
 
 
-@pytest.mark.js
+@pytest.mark.formgrader
 @pytest.mark.usefixtures("all_formgraders")
 class TestGradebook(BaseTestFormgrade):
 

--- a/nbgrader/tests/formgrader/test_gradebook_navigation.py
+++ b/nbgrader/tests/formgrader/test_gradebook_navigation.py
@@ -231,17 +231,11 @@ class TestGradebook(BaseTestFormgrade):
         next_url = self.formgrade_url().replace(self.manager.base_url, "")
         self._check_url("{}/hub/login?next={}".format(self.manager.base_url, next_url))
 
-        # this will fail if we have a cookie for another user and try to access
-        # a live notebook for that user
-        if isinstance(self.manager, HubAuthNotebookServerUserManager):
-            pytest.xfail("https://github.com/jupyter/jupyterhub/pull/290")
-
         # try going to a live notebook page
         problem = self.gradebook.find_assignment("Problem Set 1").notebooks[0]
         submission = sorted(problem.submissions, key=lambda x: x.id)[0]
         url = self.notebook_url("autograded/{}/Problem Set 1/{}.ipynb".format(submission.student.id, problem.name))
         self._get(url)
         self._wait_for_element("username_input")
-        next_url = quote(url.replace(self.manager.base_url, ""))
-        self._check_url("{}/hub/?next={}".format(self.manager.base_url, next_url))
+        self._check_url("{}/hub/login".format(self.manager.base_url))
 

--- a/nbgrader/tests/nbextensions/test_assignment_list.py
+++ b/nbgrader/tests/nbextensions/test_assignment_list.py
@@ -86,7 +86,7 @@ def _sort_rows(x):
     return item_name
 
 
-@pytest.mark.js
+@pytest.mark.nbextensions
 def test_show_assignments_list(browser, class_files, tempdir):
     _load_assignments_list(browser)
 
@@ -110,7 +110,7 @@ def test_show_assignments_list(browser, class_files, tempdir):
     assert rows[0].find_element_by_class_name("item_course").text == "abc101"
 
 
-@pytest.mark.js
+@pytest.mark.nbextensions
 def test_multiple_released_assignments(browser, class_files, tempdir):
     _load_assignments_list(browser)
 
@@ -131,7 +131,7 @@ def test_multiple_released_assignments(browser, class_files, tempdir):
     assert rows[1].find_element_by_class_name("item_course").text == "xyz 200"
 
 
-@pytest.mark.js
+@pytest.mark.nbextensions
 def test_fetch_assignment(browser, class_files, tempdir):
     _load_assignments_list(browser)
 
@@ -157,7 +157,7 @@ def test_fetch_assignment(browser, class_files, tempdir):
     _unexpand(browser, "#nbgrader-xyz_200-ps01", "ps.01")
 
 
-@pytest.mark.js
+@pytest.mark.nbextensions
 def test_submit_assignment(browser, class_files, tempdir):
     _load_assignments_list(browser)
 
@@ -188,7 +188,7 @@ def test_submit_assignment(browser, class_files, tempdir):
     assert rows[0].find_element_by_class_name("item_status").text != rows[1].find_element_by_class_name("item_status").text
 
 
-@pytest.mark.js
+@pytest.mark.nbextensions
 def test_fetch_second_assignment(browser, class_files, tempdir):
     _load_assignments_list(browser)
 
@@ -219,7 +219,7 @@ def test_fetch_second_assignment(browser, class_files, tempdir):
     _unexpand(browser, "abc101-Problem_Set_1", "Problem Set 1")
 
 
-@pytest.mark.js
+@pytest.mark.nbextensions
 def test_submit_other_assignment(browser, class_files, tempdir):
     _load_assignments_list(browser)
 
@@ -242,7 +242,7 @@ def test_submit_other_assignment(browser, class_files, tempdir):
     assert rows[0].find_element_by_class_name("item_status").text != rows[2].find_element_by_class_name("item_status").text
 
 
-@pytest.mark.js
+@pytest.mark.nbextensions
 def test_validate_ok(browser, class_files, tempdir):
     _load_assignments_list(browser)
 
@@ -266,7 +266,7 @@ def test_validate_ok(browser, class_files, tempdir):
     _dismiss_modal(browser)
 
 
-@pytest.mark.js
+@pytest.mark.nbextensions
 def test_validate_failure(browser, class_files, tempdir):
     _load_assignments_list(browser)
 

--- a/nbgrader/tests/nbextensions/test_create_assignment.py
+++ b/nbgrader/tests/nbextensions/test_create_assignment.py
@@ -32,9 +32,12 @@ def _load_notebook(browser, retries=5):
             print("Failed to load the page too many times")
             raise
 
+    def celltoolbar_exists(browser):
+        return browser.execute_script(
+            'return $("#view_menu #menu-cell-toolbar").find("[data-name=\'None\']").length == 1;')
+
     # wait for the view menu to appear
-    _wait(browser).until(
-        EC.presence_of_element_located((By.CSS_SELECTOR, '#menus')))
+    _wait(browser).until(celltoolbar_exists)
 
 
 def _activate_toolbar(browser, name="Create%20Assignment"):

--- a/nbgrader/tests/nbextensions/test_create_assignment.py
+++ b/nbgrader/tests/nbextensions/test_create_assignment.py
@@ -32,16 +32,16 @@ def _load_notebook(browser, retries=5):
             print("Failed to load the page too many times")
             raise
 
-    # wait for the celltoolbar menu to appear
+    # wait for the view menu to appear
     _wait(browser).until(
-        EC.element_to_be_clickable((By.CSS_SELECTOR, '#ctb_select')))
+        EC.presence_of_element_located((By.CSS_SELECTOR, '#menus')))
 
 
-def _activate_toolbar(browser, name="Create Assignment"):
+def _activate_toolbar(browser, name="Create%20Assignment"):
     # activate the Create Assignment toolbar
-    element = browser.find_element_by_css_selector("#ctb_select")
-    select = Select(element)
-    select.select_by_visible_text(name)
+    browser.execute_script(
+        "$('#view_menu #menu-cell-toolbar').find('[data-name=\"{}\"]').find('a').click()".format(name)
+    )
 
 
 def _select_none(browser, index=0):
@@ -318,7 +318,7 @@ def test_grade_cell_css(browser):
     assert len(elements) == 1
 
     # deactivate the toolbar
-    _activate_toolbar(browser, "Edit Metadata")
+    _activate_toolbar(browser, "Edit%20Metadata")
     elements = browser.find_elements_by_css_selector(".nbgrader-cell")
     assert len(elements) == 0
 

--- a/nbgrader/tests/nbextensions/test_create_assignment.py
+++ b/nbgrader/tests/nbextensions/test_create_assignment.py
@@ -130,7 +130,7 @@ def _dismiss_modal(browser):
     _wait(browser).until(modal_gone)
 
 
-@pytest.mark.js
+@pytest.mark.nbextensions
 def test_manual_cell(browser):
     _load_notebook(browser)
     _activate_toolbar(browser)
@@ -165,7 +165,7 @@ def test_manual_cell(browser):
     assert not _get_metadata(browser)['locked']
 
 
-@pytest.mark.js
+@pytest.mark.nbextensions
 def test_solution_cell(browser):
     _load_notebook(browser)
     _activate_toolbar(browser)
@@ -194,7 +194,7 @@ def test_solution_cell(browser):
     assert not _get_metadata(browser)['locked']
 
 
-@pytest.mark.js
+@pytest.mark.nbextensions
 def test_tests_cell(browser):
     _load_notebook(browser)
     _activate_toolbar(browser)
@@ -231,7 +231,7 @@ def test_tests_cell(browser):
     assert not _get_metadata(browser)['locked']
 
 
-@pytest.mark.js
+@pytest.mark.nbextensions
 def test_locked_cell(browser):
     _load_notebook(browser)
     _activate_toolbar(browser)
@@ -262,7 +262,7 @@ def test_locked_cell(browser):
     assert not _get_metadata(browser)['locked']
 
 
-@pytest.mark.js
+@pytest.mark.nbextensions
 def test_grade_cell_css(browser):
     _load_notebook(browser)
     _activate_toolbar(browser)
@@ -318,7 +318,7 @@ def test_grade_cell_css(browser):
     assert len(elements) == 0
 
 
-@pytest.mark.js
+@pytest.mark.nbextensions
 def test_tabbing(browser):
     _load_notebook(browser)
     _activate_toolbar(browser)
@@ -356,7 +356,7 @@ def test_tabbing(browser):
     assert "nbgrader-id-input" == element.get_attribute("class")
 
 
-@pytest.mark.js
+@pytest.mark.nbextensions
 def test_total_points(browser):
     _load_notebook(browser)
     _activate_toolbar(browser)
@@ -417,7 +417,7 @@ def test_total_points(browser):
     assert _get_total_points(browser) == 0
 
 
-@pytest.mark.js
+@pytest.mark.nbextensions
 def test_cell_ids(browser):
     _load_notebook(browser)
     _activate_toolbar(browser)

--- a/nbgrader/tests/nbextensions/test_create_assignment.py
+++ b/nbgrader/tests/nbextensions/test_create_assignment.py
@@ -32,19 +32,27 @@ def _load_notebook(browser, retries=5):
             print("Failed to load the page too many times")
             raise
 
+
+def _activate_toolbar(browser, name="Create%20Assignment"):
     def celltoolbar_exists(browser):
         return browser.execute_script(
-            'return $("#view_menu #menu-cell-toolbar").find("[data-name=\'None\']").length == 1;')
+            'return $("#view_menu #menu-cell-toolbar").find("[data-name=\'{}\']").length == 1;'.format(name))
 
     # wait for the view menu to appear
     _wait(browser).until(celltoolbar_exists)
 
-
-def _activate_toolbar(browser, name="Create%20Assignment"):
     # activate the Create Assignment toolbar
     browser.execute_script(
-        "$('#view_menu #menu-cell-toolbar').find('[data-name=\"{}\"]').find('a').click()".format(name)
+        "$('#view_menu #menu-cell-toolbar').find('[data-name=\"{}\"]').find('a').click();".format(name)
     )
+
+    # make sure the toolbar appeared
+    if name == "Create%20Assignment":
+        _wait(browser).until(
+            EC.presence_of_all_elements_located((By.CSS_SELECTOR, ".celltoolbar select")))
+    elif name == "Edit%20Metadata":
+        _wait(browser).until(
+            EC.presence_of_all_elements_located((By.CSS_SELECTOR, ".celltoolbar button")))
 
 
 def _select_none(browser, index=0):
@@ -127,10 +135,6 @@ def test_manual_cell(browser):
     _load_notebook(browser)
     _activate_toolbar(browser)
 
-    # make sure the toolbar appeared
-    _wait(browser).until(
-        EC.presence_of_all_elements_located((By.CSS_SELECTOR, ".celltoolbar select")))
-
     # does the nbgrader metadata exist?
     assert _get_metadata(browser) is None
 
@@ -166,10 +170,6 @@ def test_solution_cell(browser):
     _load_notebook(browser)
     _activate_toolbar(browser)
 
-    # make sure the toolbar appeared
-    _wait(browser).until(
-        EC.presence_of_all_elements_located((By.CSS_SELECTOR, ".celltoolbar select")))
-
     # does the nbgrader metadata exist?
     assert _get_metadata(browser) is None
 
@@ -198,10 +198,6 @@ def test_solution_cell(browser):
 def test_tests_cell(browser):
     _load_notebook(browser)
     _activate_toolbar(browser)
-
-    # make sure the toolbar appeared
-    _wait(browser).until(
-        EC.presence_of_all_elements_located((By.CSS_SELECTOR, ".celltoolbar select")))
 
     # does the nbgrader metadata exist?
     assert _get_metadata(browser) is None
@@ -239,10 +235,6 @@ def test_tests_cell(browser):
 def test_locked_cell(browser):
     _load_notebook(browser)
     _activate_toolbar(browser)
-
-    # make sure the toolbar appeared
-    WebDriverWait(browser, 30).until(
-        EC.presence_of_all_elements_located((By.CSS_SELECTOR, ".celltoolbar select")))
 
     # does the nbgrader metadata exist?
     assert _get_metadata(browser) is None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 sqlalchemy
 python-dateutil
 jupyter
-notebook
+notebook>=4.1
 nbconvert
 nbformat
 traitlets

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,8 @@ setup_args = dict(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ],
     packages=[
         'nbgrader',

--- a/tasks.py
+++ b/tasks.py
@@ -133,10 +133,13 @@ def _run_tests(mark=None, skip=None):
 @task
 def tests(group='all', skip=None):
     if group == 'python':
-        _run_tests(mark="not js", skip=skip)
+        _run_tests(mark="not formgrader and not nbextensions", skip=skip)
 
-    elif group == 'js':
-        _run_tests(mark="js", skip=skip)
+    elif group == 'formgrader':
+        _run_tests(mark="formgrader", skip=skip)
+
+    elif group == 'nbextensions':
+        _run_tests(mark="nbextensions", skip=skip)
 
     elif group == 'docs':
         docs()
@@ -150,7 +153,7 @@ def tests(group='all', skip=None):
 
 @task
 def after_success(group):
-    if group in ('python', 'js'):
+    if group in ('python', 'formgrader', 'nbextensions'):
         run('codecov')
     else:
         echo('Nothing to do.')
@@ -170,7 +173,7 @@ def before_install(group, python_version):
     run('git clone --quiet --depth 1 https://github.com/minrk/travis-wheels ~/travis-wheels')
 
     # install jupyterhub
-    if python_version.startswith('3') and group == 'js':
+    if python_version.startswith('3') and group == 'formgrader':
         run('npm install -g configurable-http-proxy')
         run('pip install jupyterhub')
 

--- a/tasks.py
+++ b/tasks.py
@@ -114,7 +114,8 @@ def _run_tests(mark=None, skip=None):
         '--cov nbgrader',
         '--no-cov-on-fail',
         '-v',
-        '-x'
+        '-x',
+        '--capture=no'
     ]
 
     marks = []

--- a/tasks.py
+++ b/tasks.py
@@ -170,7 +170,7 @@ def before_install(group, python_version):
     run('git clone --quiet --depth 1 https://github.com/minrk/travis-wheels ~/travis-wheels')
 
     # install jupyterhub
-    if python_version == '3.4' and group == 'js':
+    if python_version.startswith('3') and group == 'js':
         run('npm install -g configurable-http-proxy')
         run('pip install jupyterhub')
 

--- a/tasks.py
+++ b/tasks.py
@@ -114,8 +114,7 @@ def _run_tests(mark=None, skip=None):
         '--cov nbgrader',
         '--no-cov-on-fail',
         '-v',
-        '-x',
-        '--capture=no'
+        '-x'
     ]
 
     marks = []


### PR DESCRIPTION
This should fix the build errors that are occuring on master currently... the issues were:

1. Related to moving the celltoolbar menu into the View menu in the notebook.
2. Fixing the JupyterHub cookie bug (https://github.com/jupyter/jupyterhub/pull/290) in more recent JupyterHub releases.
3. Making sure JupyterHub is installed on Python 3.5.
4. Removing `os.setpgrp()` from the fake spawner, because it doesn't work on Travis.

This also splits the javascript tests into two separate groups, one for the formgrader and one for the nbextensions, which should hopefully make restarting tests a little less cumbersome.