### PR TITLE
Specify assignments and students in the config file

### DIFF
--- a/docs/source/user_guide/03_generating_assignments.ipynb
+++ b/docs/source/user_guide/03_generating_assignments.ipynb
@@ -86,12 +86,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 2. Set up connection to the database and add the assignment\n",
-    "Setting up the database is the first workflow step to create a release version of an assignment.\n",
+    "### 2. Configure assignments in the config file\n",
     "\n",
-    "A connection to the database is set by passing `Gradebook` the default database url, `sqlite:///gradebook.db` which links to the sqlite database `gradebook.db`. If this database does not already exist, nbgrader will automatically create it. By default, the nbgrader commands (like `nbgrader assign`) will assume that this database is called `gradebook.db` and that it lives in the root of your course directory, though its name and path can be configured in `nbgrader_config.py`.\n",
-    "\n",
-    "Next, the assignment is added to the database and the assignment's due date is set using `add_assignment`:"
+    "Creating a `nbgrader_config.py` file and configuring the list of your assignments is the first workflow step to create a release version of an assignment. These assignments will be automatically added to the sqlite database `gradebook.db`. If this database does not already exist, nbgrader will automatically create it. By default, the nbgrader commands (like `nbgrader assign`) will assume that this database is called `gradebook.db` and that it lives in the root of your course directory, though its name and path can be configured in `nbgrader_config.py`."
    ]
   },
   {
@@ -103,18 +100,10 @@
    },
    "outputs": [],
    "source": [
-    "import os\n",
+    "%%file nbgrader_config.py\n",
     "\n",
-    "# remove an existing database\n",
-    "if os.path.exists(\"gradebook.db\"):\n",
-    "    os.remove(\"gradebook.db\")\n",
-    "\n",
-    "# create a connection to the db using the nbgrader API\n",
-    "from nbgrader.api import Gradebook\n",
-    "gb = Gradebook(\"sqlite:///gradebook.db\")\n",
-    "\n",
-    "# add the assignment to the database and specify a due date\n",
-    "gb.add_assignment(\"Problem Set 1\", duedate=\"2015-02-01 15:00:00.000000 PST\")"
+    "c = get_config()\n",
+    "c.NbGrader.db_assignments = [dict(name=\"Problem Set 1\")]"
    ]
   },
   {

--- a/docs/source/user_guide/04_autograding.ipynb
+++ b/docs/source/user_guide/04_autograding.ipynb
@@ -73,39 +73,33 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Before we can actually start grading, we need to actually record who the students are. We can do this using the API provided by nbgrader, which provides access to a database to store information about students and their grades:"
+    "Before we can actually start grading, we need to actually specify who the students are. We can do this through the `nbgrader_config.py` file, where we also specify the list of assignments:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
-    "# create a connection to the db using the nbgrader API\n",
-    "from nbgrader.api import Gradebook\n",
-    "gb = Gradebook(\"sqlite:///gradebook.db\")\n",
+    "%%file nbgrader_config.py\n",
     "\n",
-    "# add some students to the database\n",
-    "gb.add_student(\"Bitdiddle\", first_name=\"Ben\", last_name=\"Bitdiddle\")\n",
-    "gb.add_student(\"Hacker\", first_name=\"Alyssa\", last_name=\"Hacker\")\n",
-    "gb.add_student(\"Reasoner\", first_name=\"Louis\", last_name=\"Reasoner\")"
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "Note: the assignment should also already be in the database. An example of how to add it is given in :doc:`03_generating_assignments`."
+    "c = get_config()\n",
+    "c.NbGrader.db_assignments = [dict(name=\"Problem Set 1\")]\n",
+    "c.NbGrader.db_students = [\n",
+    "    dict(id=\"Bitdiddle\", first_name=\"Ben\", last_name=\"Bitdiddle\"),\n",
+    "    dict(id=\"Hacker\", first_name=\"Alyssa\", last_name=\"Hacker\"),\n",
+    "    dict(id=\"Reasoner\", first_name=\"Louis\", last_name=\"Reasoner\")\n",
+    "]"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Once the database has been set up with the students, we can run the autograder (and as with the other nbgrader commands for instructors, this must be run from the root of the course directory):"
+    "Once the config file has been set up with the students, we can run the autograder (and as with the other nbgrader commands for instructors, this must be run from the root of the course directory):"
    ]
   },
   {

--- a/nbgrader/apps/assignapp.py
+++ b/nbgrader/apps/assignapp.py
@@ -206,7 +206,6 @@ class AssignApp(BaseNbConvertApp):
         if not self.no_database:
             gb = Gradebook(self.db_url)
             assignment = None
-            print(self.db_assignments)
             for a in self.db_assignments:
                 if a['name'] == assignment_id:
                     assignment = a.copy()

--- a/nbgrader/apps/assignapp.py
+++ b/nbgrader/apps/assignapp.py
@@ -151,6 +151,18 @@ class AssignApp(BaseNbConvertApp):
         extra_config.NbGrader.notebook_id = '*'
         return extra_config
 
+    def _config_changed(self, name, old, new):
+        if 'create_assignment' in new.AssignApp:
+            self.log.warn(
+                "The AssignApp.create_assignment (or the --create flag) option is "
+                "deprecated. Please specify your assignments through the "
+                "`NbGrader.db_assignments` variable in your nbgrader config file."
+            )
+            del new.AssignApp.create_assignment
+
+        super(AssignApp, self)._config_changed(name, old, new)
+
+
     def _clean_old_notebooks(self, assignment_id, student_id):
         gb = Gradebook(self.db_url)
         assignment = gb.find_assignment(assignment_id)
@@ -193,16 +205,21 @@ class AssignApp(BaseNbConvertApp):
         # doesn't exist
         if not self.no_database:
             gb = Gradebook(self.db_url)
-            try:
-                gb.find_assignment(assignment_id)
-            except MissingEntry:
-                if self.create_assignment:
-                    self.log.warning("Creating assignment '%s'", assignment_id)
-                    gb.add_assignment(assignment_id)
-                else:
-                    self.fail("No assignment called '%s' exists in the database", assignment_id)
-            else:
+            assignment = None
+            print(self.db_assignments)
+            for a in self.db_assignments:
+                if a['name'] == assignment_id:
+                    assignment = a.copy()
+                    break
+
+            if assignment is not None:
+                del assignment['name']
+                self.log.info("Updating/creating assignment '%s': %s", assignment_id, assignment)
+                gb.update_or_create_assignment(assignment_id, **assignment)
+
                 # check if there are any extra notebooks in the db that are no longer
                 # part of the assignment, and if so, remove them
                 if self.notebook_id == "*":
                     self._clean_old_notebooks(assignment_id, student_id)
+            else:
+                self.fail("No assignment called '%s' exists in the config", assignment_id)

--- a/nbgrader/apps/baseapp.py
+++ b/nbgrader/apps/baseapp.py
@@ -223,6 +223,42 @@ class NbGrader(JupyterApp):
         )
     )
 
+    db_assignments = List(
+        config=True,
+        help=dedent(
+            """
+            A list of assignments that will be created in the database. Each
+            item in the list should be a dictionary with the following keys:
+
+                - name
+                - duedate (optional)
+
+            The values will be stored in the database. Please see the API
+            documentation on the `Assignment` database model for details on
+            these fields.
+            """
+        )
+    )
+
+    db_students = List(
+        config=True,
+        help=dedent(
+            """
+            A list of student that will be created in the database. Each
+            item in the list should be a dictionary with the following keys:
+
+                - id
+                - first_name (optional)
+                - last_name (optional)
+                - email (optional)
+
+            The values will be stored in the database. Please see the API
+            documentation on the `Student` database model for details on
+            these fields.
+            """
+        )
+    )
+
     def _course_directory_default(self):
         return os.getcwd()
 

--- a/nbgrader/tests/apps/conftest.py
+++ b/nbgrader/tests/apps/conftest.py
@@ -23,20 +23,6 @@ def db(request):
 
 
 @pytest.fixture
-def gradebook(request, db):
-    gb = Gradebook(db)
-    gb.add_assignment("ps1", duedate="2015-02-02 14:58:23.948203 PST")
-    gb.add_student("foo")
-    gb.add_student("bar")
-
-    def fin():
-        gb.db.close()
-    request.addfinalizer(fin)
-
-    return db
-
-
-@pytest.fixture
 def course_dir(request):
     path = tempfile.mkdtemp()
 

--- a/nbgrader/tests/apps/test_nbgrader_autograde.py
+++ b/nbgrader/tests/apps/test_nbgrader_autograde.py
@@ -15,47 +15,52 @@ class TestNbGraderAutograde(BaseTestApp):
         """Does the help display without error?"""
         run_python_module(["nbgrader", "autograde", "--help-all"])
 
-    def test_missing_student(self, gradebook, course_dir):
+    def test_missing_student(self, db, course_dir):
         """Is an error thrown when the student is missing?"""
+        with open("nbgrader_config.py", "a") as fh:
+            fh.write("""c.NbGrader.db_assignments = [dict(name='ps1', duedate='2015-02-02 14:58:23.948203 PST')]\n""")
+            fh.write("""c.NbGrader.db_students = [dict(id="foo"), dict(id="bar")]""")
+
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1", "--db", gradebook])
+        run_python_module(["nbgrader", "assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "baz", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook], retcode=1)
+        run_python_module(["nbgrader", "autograde", "ps1", "--db", db], retcode=1)
 
-    def test_add_missing_student(self, gradebook, course_dir):
-        """Can a missing student be added?"""
-        self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1", "--db", gradebook])
+        # check that --create is properly deprecated
+        run_python_module(["nbgrader", "autograde", "ps1", "--db", db, "--create"], retcode=1)
 
-        self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "baz", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook, "--create"])
-
-        assert os.path.isfile(join(course_dir, "autograded", "baz", "ps1", "p1.ipynb"))
-
-    def test_missing_assignment(self, gradebook, course_dir):
+    def test_missing_assignment(self, db, course_dir):
         """Is an error thrown when the assignment is missing?"""
+        with open("nbgrader_config.py", "a") as fh:
+            fh.write("""c.NbGrader.db_assignments = [dict(name='ps1', duedate='2015-02-02 14:58:23.948203 PST')]\n""")
+            fh.write("""c.NbGrader.db_students = [dict(id="foo"), dict(id="bar")]""")
+
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1", "--db", gradebook])
+        run_python_module(["nbgrader", "assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "ps2", "foo", "p1.ipynb"))
-        run_python_module(["nbgrader", "autograde", "ps2", "--db", gradebook], retcode=1)
+        run_python_module(["nbgrader", "autograde", "ps2", "--db", db], retcode=1)
 
-    def test_grade(self, gradebook, course_dir):
+    def test_grade(self, db, course_dir):
         """Can files be graded?"""
+        with open("nbgrader_config.py", "a") as fh:
+            fh.write("""c.NbGrader.db_assignments = [dict(name='ps1', duedate='2015-02-02 14:58:23.948203 PST')]\n""")
+            fh.write("""c.NbGrader.db_students = [dict(id="foo"), dict(id="bar")]""")
+
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1", "--db", gradebook])
+        run_python_module(["nbgrader", "assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "bar", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook])
+        run_python_module(["nbgrader", "autograde", "ps1", "--db", db])
 
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "timestamp.txt"))
         assert os.path.isfile(join(course_dir, "autograded", "bar", "ps1", "p1.ipynb"))
         assert not os.path.isfile(join(course_dir, "autograded", "bar", "ps1", "timestamp.txt"))
 
-        gb = Gradebook(gradebook)
+        gb = Gradebook(db)
         notebook = gb.find_submission_notebook("p1", "ps1", "foo")
         assert notebook.score == 1
         assert notebook.max_score == 7
@@ -81,10 +86,14 @@ class TestNbGraderAutograde(BaseTestApp):
 
         gb.db.close()
 
-    def test_grade_timestamp(self, gradebook, course_dir):
+    def test_grade_timestamp(self, db, course_dir):
         """Is a timestamp correctly read in?"""
+        with open("nbgrader_config.py", "a") as fh:
+            fh.write("""c.NbGrader.db_assignments = [dict(name='ps1', duedate='2015-02-02 14:58:23.948203 PST')]\n""")
+            fh.write("""c.NbGrader.db_students = [dict(id="foo"), dict(id="bar")]""")
+
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1", "--db", gradebook])
+        run_python_module(["nbgrader", "assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "timestamp.txt"), "2015-02-02 15:58:23.948203 PST")
@@ -92,36 +101,40 @@ class TestNbGraderAutograde(BaseTestApp):
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "bar", "ps1", "p1.ipynb"))
         self._make_file(join(course_dir, "submitted", "bar", "ps1", "timestamp.txt"), "2015-02-01 14:58:23.948203 PST")
 
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook])
+        run_python_module(["nbgrader", "autograde", "ps1", "--db", db])
 
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "timestamp.txt"))
         assert os.path.isfile(join(course_dir, "autograded", "bar", "ps1", "p1.ipynb"))
         assert os.path.isfile(join(course_dir, "autograded", "bar", "ps1", "timestamp.txt"))
 
-        gb = Gradebook(gradebook)
+        gb = Gradebook(db)
         submission = gb.find_submission("ps1", "foo")
         assert submission.total_seconds_late > 0
         submission = gb.find_submission("ps1", "bar")
         assert submission.total_seconds_late == 0
 
         # make sure it still works to run it a second time
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook])
+        run_python_module(["nbgrader", "autograde", "ps1", "--db", db])
 
         gb.db.close()
 
-    def test_force(self, gradebook, course_dir):
+    def test_force(self, db, course_dir):
         """Ensure the force option works properly"""
+        with open("nbgrader_config.py", "a") as fh:
+            fh.write("""c.NbGrader.db_assignments = [dict(name='ps1', duedate='2015-02-02 14:58:23.948203 PST')]\n""")
+            fh.write("""c.NbGrader.db_students = [dict(id="foo"), dict(id="bar")]""")
+
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         self._make_file(join(course_dir, "source", "ps1", "foo.txt"), "foo")
         self._make_file(join(course_dir, "source", "ps1", "data", "bar.txt"), "bar")
-        run_python_module(["nbgrader", "assign", "ps1", "--db", gradebook])
+        run_python_module(["nbgrader", "assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "foo.txt"), "foo")
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "data", "bar.txt"), "bar")
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "blah.pyc"), "asdf")
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook])
+        run_python_module(["nbgrader", "autograde", "ps1", "--db", db])
 
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
@@ -130,34 +143,38 @@ class TestNbGraderAutograde(BaseTestApp):
 
         # check that it skips the existing directory
         remove(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook])
+        run_python_module(["nbgrader", "autograde", "ps1", "--db", db])
         assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
 
         # force overwrite the supplemental files
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook, "--force"])
+        run_python_module(["nbgrader", "autograde", "ps1", "--db", db, "--force"])
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
 
         # force overwrite
         remove(join(course_dir, "source", "ps1", "foo.txt"))
         remove(join(course_dir, "submitted", "foo", "ps1", "foo.txt"))
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook, "--force"])
+        run_python_module(["nbgrader", "autograde", "ps1", "--db", db, "--force"])
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "data", "bar.txt"))
         assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "blah.pyc"))
 
-    def test_filter_notebook(self, gradebook, course_dir):
+    def test_filter_notebook(self, db, course_dir):
         """Does autograding filter by notebook properly?"""
+        with open("nbgrader_config.py", "a") as fh:
+            fh.write("""c.NbGrader.db_assignments = [dict(name='ps1', duedate='2015-02-02 14:58:23.948203 PST')]\n""")
+            fh.write("""c.NbGrader.db_students = [dict(id="foo"), dict(id="bar")]""")
+
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         self._make_file(join(course_dir, "source", "ps1", "foo.txt"), "foo")
         self._make_file(join(course_dir, "source", "ps1", "data", "bar.txt"), "bar")
-        run_python_module(["nbgrader", "assign", "ps1", "--db", gradebook])
+        run_python_module(["nbgrader", "assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "foo.txt"), "foo")
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "data", "bar.txt"), "bar")
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "blah.pyc"), "asdf")
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook, "--notebook", "p1"])
+        run_python_module(["nbgrader", "autograde", "ps1", "--db", db, "--notebook", "p1"])
 
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
@@ -167,7 +184,7 @@ class TestNbGraderAutograde(BaseTestApp):
         # check that removing the notebook still causes the autograder to run
         remove(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         remove(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook, "--notebook", "p1"])
+        run_python_module(["nbgrader", "autograde", "ps1", "--db", db, "--notebook", "p1"])
 
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
@@ -176,7 +193,7 @@ class TestNbGraderAutograde(BaseTestApp):
 
         # check that running it again doesn"t do anything
         remove(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook, "--notebook", "p1"])
+        run_python_module(["nbgrader", "autograde", "ps1", "--db", db, "--notebook", "p1"])
 
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
@@ -185,23 +202,27 @@ class TestNbGraderAutograde(BaseTestApp):
 
         # check that removing the notebook doesn"t caus the autograder to run
         remove(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook])
+        run_python_module(["nbgrader", "autograde", "ps1", "--db", db])
 
         assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "data", "bar.txt"))
         assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "blah.pyc"))
 
-    def test_grade_overwrite_files(self, gradebook, course_dir):
+    def test_grade_overwrite_files(self, db, course_dir):
         """Are dependent files properly linked and overwritten?"""
+        with open("nbgrader_config.py", "a") as fh:
+            fh.write("""c.NbGrader.db_assignments = [dict(name='ps1', duedate='2015-02-02 14:58:23.948203 PST')]\n""")
+            fh.write("""c.NbGrader.db_students = [dict(id="foo"), dict(id="bar")]""")
+
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         self._make_file(join(course_dir, "source", "ps1", "data.csv"), "some,data\n")
-        run_python_module(["nbgrader", "assign", "ps1", "--db", gradebook])
+        run_python_module(["nbgrader", "assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "timestamp.txt"), "2015-02-02 15:58:23.948203 PST")
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "data.csv"), "some,other,data\n")
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook])
+        run_python_module(["nbgrader", "autograde", "ps1", "--db", db])
 
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "timestamp.txt"))
@@ -215,36 +236,48 @@ class TestNbGraderAutograde(BaseTestApp):
             contents = fh.read()
         assert contents == "some,data\n"
 
-    def test_side_effects(self, gradebook, course_dir):
+    def test_side_effects(self, db, course_dir):
+        with open("nbgrader_config.py", "a") as fh:
+            fh.write("""c.NbGrader.db_assignments = [dict(name='ps1', duedate='2015-02-02 14:58:23.948203 PST')]\n""")
+            fh.write("""c.NbGrader.db_students = [dict(id="foo"), dict(id="bar")]""")
+
         self._copy_file(join("files", "side-effects.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1", "--db", gradebook])
+        run_python_module(["nbgrader", "assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "side-effects.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook])
+        run_python_module(["nbgrader", "autograde", "ps1", "--db", db])
 
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "side-effect.txt"))
         assert not os.path.isfile(join(course_dir, "submitted", "foo", "ps1", "side-effect.txt"))
 
-    def test_skip_extra_notebooks(self, gradebook, course_dir):
+    def test_skip_extra_notebooks(self, db, course_dir):
+        with open("nbgrader_config.py", "a") as fh:
+            fh.write("""c.NbGrader.db_assignments = [dict(name='ps1', duedate='2015-02-02 14:58:23.948203 PST')]\n""")
+            fh.write("""c.NbGrader.db_students = [dict(id="foo"), dict(id="bar")]""")
+
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1", "--db", gradebook])
+        run_python_module(["nbgrader", "assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1 copy.ipynb"))
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook])
+        run_python_module(["nbgrader", "autograde", "ps1", "--db", db])
 
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1 copy.ipynb"))
 
     def test_permissions(self, course_dir):
         """Are permissions properly set?"""
+        with open("nbgrader_config.py", "a") as fh:
+            fh.write("""c.NbGrader.db_assignments = [dict(name='ps1', duedate='2015-02-02 14:58:23.948203 PST')]\n""")
+            fh.write("""c.NbGrader.db_students = [dict(id="foo"), dict(id="bar")]""")
+
         self._empty_notebook(join(course_dir, "source", "ps1", "foo.ipynb"))
         self._make_file(join(course_dir, "source", "ps1", "foo.txt"), "foo")
-        run_python_module(["nbgrader", "assign", "ps1", "--create"])
+        run_python_module(["nbgrader", "assign", "ps1"])
 
         self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "foo.ipynb"))
         self._make_file(join(course_dir, "source", "foo", "ps1", "foo.txt"), "foo")
-        run_python_module(["nbgrader", "autograde", "ps1", "--create"])
+        run_python_module(["nbgrader", "autograde", "ps1"])
 
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "foo.ipynb"))
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
@@ -253,13 +286,17 @@ class TestNbGraderAutograde(BaseTestApp):
 
     def test_custom_permissions(self, course_dir):
         """Are custom permissions properly set?"""
+        with open("nbgrader_config.py", "a") as fh:
+            fh.write("""c.NbGrader.db_assignments = [dict(name='ps1', duedate='2015-02-02 14:58:23.948203 PST')]\n""")
+            fh.write("""c.NbGrader.db_students = [dict(id="foo"), dict(id="bar")]""")
+
         self._empty_notebook(join(course_dir, "source", "ps1", "foo.ipynb"))
         self._make_file(join(course_dir, "source", "ps1", "foo.txt"), "foo")
-        run_python_module(["nbgrader", "assign", "ps1", "--create"])
+        run_python_module(["nbgrader", "assign", "ps1"])
 
         self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "foo.ipynb"))
         self._make_file(join(course_dir, "source", "foo", "ps1", "foo.txt"), "foo")
-        run_python_module(["nbgrader", "autograde", "ps1", "--create", "--AutogradeApp.permissions=644"])
+        run_python_module(["nbgrader", "autograde", "ps1", "--AutogradeApp.permissions=644"])
 
         if sys.platform == 'win32':
             perms = '666'
@@ -272,13 +309,17 @@ class TestNbGraderAutograde(BaseTestApp):
         assert self._get_permissions(join(course_dir, "autograded", "foo", "ps1", "foo.txt")) == perms
 
     def test_force_single_notebook(self, course_dir):
+        with open("nbgrader_config.py", "a") as fh:
+            fh.write("""c.NbGrader.db_assignments = [dict(name='ps1', duedate='2015-02-02 14:58:23.948203 PST')]\n""")
+            fh.write("""c.NbGrader.db_students = [dict(id="foo"), dict(id="bar")]""")
+
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p2.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1", "--create"])
+        run_python_module(["nbgrader", "assign", "ps1"])
 
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p2.ipynb"))
-        run_python_module(["nbgrader", "autograde", "ps1", "--create"])
+        run_python_module(["nbgrader", "autograde", "ps1"])
 
         assert os.path.exists(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         assert os.path.exists(join(course_dir, "autograded", "foo", "ps1", "p2.ipynb"))
@@ -296,12 +337,16 @@ class TestNbGraderAutograde(BaseTestApp):
         assert p2 == self._file_contents(join(course_dir, "autograded", "foo", "ps1", "p2.ipynb"))
 
     def test_update_newer(self, course_dir):
+        with open("nbgrader_config.py", "a") as fh:
+            fh.write("""c.NbGrader.db_assignments = [dict(name='ps1', duedate='2015-02-02 14:58:23.948203 PST')]\n""")
+            fh.write("""c.NbGrader.db_students = [dict(id="foo"), dict(id="bar")]""")
+
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1", "--create"])
+        run_python_module(["nbgrader", "assign", "ps1"])
 
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "timestamp.txt"), "2015-02-02 15:58:23.948203 PST")
-        run_python_module(["nbgrader", "autograde", "ps1", "--create"])
+        run_python_module(["nbgrader", "autograde", "ps1"])
 
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "timestamp.txt"))
@@ -310,7 +355,7 @@ class TestNbGraderAutograde(BaseTestApp):
 
         self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "timestamp.txt"), "2015-02-02 16:58:23.948203 PST")
-        run_python_module(["nbgrader", "autograde", "ps1", "--create"])
+        run_python_module(["nbgrader", "autograde", "ps1"])
 
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "timestamp.txt"))
@@ -318,14 +363,18 @@ class TestNbGraderAutograde(BaseTestApp):
         assert p != self._file_contents(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
 
     def test_update_newer_single_notebook(self, course_dir):
+        with open("nbgrader_config.py", "a") as fh:
+            fh.write("""c.NbGrader.db_assignments = [dict(name='ps1', duedate='2015-02-02 14:58:23.948203 PST')]\n""")
+            fh.write("""c.NbGrader.db_students = [dict(id="foo"), dict(id="bar")]""")
+
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p2.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1", "--create"])
+        run_python_module(["nbgrader", "assign", "ps1"])
 
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p2.ipynb"))
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "timestamp.txt"), "2015-02-02 15:58:23.948203 PST")
-        run_python_module(["nbgrader", "autograde", "ps1", "--create"])
+        run_python_module(["nbgrader", "autograde", "ps1"])
 
         assert os.path.exists(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         assert os.path.exists(join(course_dir, "autograded", "foo", "ps1", "p2.ipynb"))
@@ -348,24 +397,32 @@ class TestNbGraderAutograde(BaseTestApp):
         assert p2 == self._file_contents(join(course_dir, "autograded", "foo", "ps1", "p2.ipynb"))
 
     def test_handle_failure(self, course_dir):
+        with open("nbgrader_config.py", "a") as fh:
+            fh.write("""c.NbGrader.db_assignments = [dict(name='ps1', duedate='2015-02-02 14:58:23.948203 PST')]\n""")
+            fh.write("""c.NbGrader.db_students = [dict(id="foo"), dict(id="bar")]""")
+
         self._empty_notebook(join(course_dir, "source", "ps1", "p1.ipynb"))
         self._empty_notebook(join(course_dir, "source", "ps1", "p2.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1", "--create"])
+        run_python_module(["nbgrader", "assign", "ps1"])
 
         self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p2.ipynb"))
-        run_python_module(["nbgrader", "autograde", "ps1", "--create"], retcode=1)
+        run_python_module(["nbgrader", "autograde", "ps1"], retcode=1)
 
         assert not os.path.exists(join(course_dir, "autograded", "foo", "ps1"))
 
     def test_handle_failure_single_notebook(self, course_dir):
+        with open("nbgrader_config.py", "a") as fh:
+            fh.write("""c.NbGrader.db_assignments = [dict(name='ps1', duedate='2015-02-02 14:58:23.948203 PST')]\n""")
+            fh.write("""c.NbGrader.db_students = [dict(id="foo"), dict(id="bar")]""")
+
         self._empty_notebook(join(course_dir, "source", "ps1", "p1.ipynb"))
         self._empty_notebook(join(course_dir, "source", "ps1", "p2.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1", "--create"])
+        run_python_module(["nbgrader", "assign", "ps1"])
 
         self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p2.ipynb"))
-        run_python_module(["nbgrader", "autograde", "ps1", "--create", "--notebook", "p*"], retcode=1)
+        run_python_module(["nbgrader", "autograde", "ps1", "--notebook", "p*"], retcode=1)
 
         assert os.path.exists(join(course_dir, "autograded", "foo", "ps1"))
         assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))

--- a/nbgrader/tests/apps/test_nbgrader_feedback.py
+++ b/nbgrader/tests/apps/test_nbgrader_feedback.py
@@ -13,31 +13,37 @@ class TestNbGraderFeedback(BaseTestApp):
         """Does the help display without error?"""
         run_python_module(["nbgrader", "feedback", "--help-all"])
 
-    def test_single_file(self, gradebook, course_dir):
+    def test_single_file(self, db, course_dir):
         """Can feedback be generated for an unchanged assignment?"""
+        with open("nbgrader_config.py", "a") as fh:
+            fh.write("""c.NbGrader.db_assignments = [dict(name="ps1")]\n""")
+            fh.write("""c.NbGrader.db_students = [dict(id="foo")]\n""")
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1", "--db", gradebook])
+        run_python_module(["nbgrader", "assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook])
-        run_python_module(["nbgrader", "feedback", "ps1", "--db", gradebook])
+        run_python_module(["nbgrader", "autograde", "ps1", "--db", db])
+        run_python_module(["nbgrader", "feedback", "ps1", "--db", db])
 
         assert exists(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
 
-    def test_force(self, gradebook, course_dir):
+    def test_force(self, db, course_dir):
         """Ensure the force option works properly"""
+        with open("nbgrader_config.py", "a") as fh:
+            fh.write("""c.NbGrader.db_assignments = [dict(name="ps1")]\n""")
+            fh.write("""c.NbGrader.db_students = [dict(id="foo")]\n""")
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         self._make_file(join(course_dir, "source", "ps1", "foo.txt"), "foo")
         self._make_file(join(course_dir, "source", "ps1", "data", "bar.txt"), "bar")
-        run_python_module(["nbgrader", "assign", "ps1", "--db", gradebook])
+        run_python_module(["nbgrader", "assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "foo.txt"), "foo")
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "data", "bar.txt"), "bar")
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook])
+        run_python_module(["nbgrader", "autograde", "ps1", "--db", db])
 
         self._make_file(join(course_dir, "autograded", "foo", "ps1", "blah.pyc"), "asdf")
-        run_python_module(["nbgrader", "feedback", "ps1", "--db", gradebook])
+        run_python_module(["nbgrader", "feedback", "ps1", "--db", db])
 
         assert isfile(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
         assert isfile(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))
@@ -46,34 +52,37 @@ class TestNbGraderFeedback(BaseTestApp):
 
         # check that it skips the existing directory
         remove(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))
-        run_python_module(["nbgrader", "feedback", "ps1", "--db", gradebook])
+        run_python_module(["nbgrader", "feedback", "ps1", "--db", db])
         assert not isfile(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))
 
         # force overwrite the supplemental files
-        run_python_module(["nbgrader", "feedback", "ps1", "--db", gradebook, "--force"])
+        run_python_module(["nbgrader", "feedback", "ps1", "--db", db, "--force"])
         assert isfile(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))
 
         # force overwrite
         remove(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
-        run_python_module(["nbgrader", "feedback", "ps1", "--db", gradebook, "--force"])
+        run_python_module(["nbgrader", "feedback", "ps1", "--db", db, "--force"])
         assert isfile(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
         assert not isfile(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))
         assert isfile(join(course_dir, "feedback", "foo", "ps1", "data", "bar.txt"))
         assert not isfile(join(course_dir, "feedback", "foo", "ps1", "blah.pyc"))
 
-    def test_filter_notebook(self, gradebook, course_dir):
+    def test_filter_notebook(self, db, course_dir):
         """Does feedback filter by notebook properly?"""
+        with open("nbgrader_config.py", "a") as fh:
+            fh.write("""c.NbGrader.db_assignments = [dict(name="ps1")]\n""")
+            fh.write("""c.NbGrader.db_students = [dict(id="foo")]\n""")
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         self._make_file(join(course_dir, "source", "ps1", "foo.txt"), "foo")
         self._make_file(join(course_dir, "source", "ps1", "data", "bar.txt"), "bar")
-        run_python_module(["nbgrader", "assign", "ps1", "--db", gradebook])
+        run_python_module(["nbgrader", "assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "foo.txt"), "foo")
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "data", "bar.txt"), "bar")
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "blah.pyc"), "asdf")
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", gradebook])
-        run_python_module(["nbgrader", "feedback", "ps1", "--db", gradebook, "--notebook", "p1"])
+        run_python_module(["nbgrader", "autograde", "ps1", "--db", db])
+        run_python_module(["nbgrader", "feedback", "ps1", "--db", db, "--notebook", "p1"])
 
         assert isfile(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
         assert isfile(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))
@@ -83,7 +92,7 @@ class TestNbGraderFeedback(BaseTestApp):
         # check that removing the notebook still causes it to run
         remove(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
         remove(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))
-        run_python_module(["nbgrader", "feedback", "ps1", "--db", gradebook, "--notebook", "p1"])
+        run_python_module(["nbgrader", "feedback", "ps1", "--db", db, "--notebook", "p1"])
 
         assert isfile(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
         assert isfile(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))
@@ -92,7 +101,7 @@ class TestNbGraderFeedback(BaseTestApp):
 
         # check that running it again doesn"t do anything
         remove(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))
-        run_python_module(["nbgrader", "feedback", "ps1", "--db", gradebook, "--notebook", "p1"])
+        run_python_module(["nbgrader", "feedback", "ps1", "--db", db, "--notebook", "p1"])
 
         assert isfile(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
         assert not isfile(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))
@@ -101,7 +110,7 @@ class TestNbGraderFeedback(BaseTestApp):
 
         # check that removing the notebook doesn"t cause it to run
         remove(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
-        run_python_module(["nbgrader", "feedback", "ps1", "--db", gradebook])
+        run_python_module(["nbgrader", "feedback", "ps1", "--db", db])
 
         assert not isfile(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
         assert not isfile(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))

--- a/nbgrader/tests/apps/test_nbgrader_feedback.py
+++ b/nbgrader/tests/apps/test_nbgrader_feedback.py
@@ -110,11 +110,14 @@ class TestNbGraderFeedback(BaseTestApp):
 
     def test_permissions(self, course_dir):
         """Are permissions properly set?"""
+        with open("nbgrader_config.py", "a") as fh:
+            fh.write("""c.NbGrader.db_assignments = [dict(name="ps1")]\n""")
+            fh.write("""c.NbGrader.db_students = [dict(id="foo")]\n""")
         self._empty_notebook(join(course_dir, "source", "ps1", "foo.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1", "--create"])
+        run_python_module(["nbgrader", "assign", "ps1"])
 
         self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "foo.ipynb"))
-        run_python_module(["nbgrader", "autograde", "ps1", "--create"])
+        run_python_module(["nbgrader", "autograde", "ps1"])
         run_python_module(["nbgrader", "feedback", "ps1"])
 
         assert isfile(join(course_dir, "feedback", "foo", "ps1", "foo.html"))
@@ -122,11 +125,14 @@ class TestNbGraderFeedback(BaseTestApp):
 
     def test_custom_permissions(self, course_dir):
         """Are custom permissions properly set?"""
+        with open("nbgrader_config.py", "a") as fh:
+            fh.write("""c.NbGrader.db_assignments = [dict(name="ps1")]\n""")
+            fh.write("""c.NbGrader.db_students = [dict(id="foo")]\n""")
         self._empty_notebook(join(course_dir, "source", "ps1", "foo.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1", "--create"])
+        run_python_module(["nbgrader", "assign", "ps1"])
 
         self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "foo.ipynb"))
-        run_python_module(["nbgrader", "autograde", "ps1", "--create"])
+        run_python_module(["nbgrader", "autograde", "ps1"])
         run_python_module(["nbgrader", "feedback", "ps1", "--FeedbackApp.permissions=644"])
 
         if sys.platform == 'win32':
@@ -138,13 +144,16 @@ class TestNbGraderFeedback(BaseTestApp):
         assert self._get_permissions(join(course_dir, "feedback", "foo", "ps1", "foo.html")) == perms
 
     def test_force_single_notebook(self, course_dir):
+        with open("nbgrader_config.py", "a") as fh:
+            fh.write("""c.NbGrader.db_assignments = [dict(name="ps1")]\n""")
+            fh.write("""c.NbGrader.db_students = [dict(id="foo")]\n""")
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p2.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1", "--create"])
+        run_python_module(["nbgrader", "assign", "ps1"])
 
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p2.ipynb"))
-        run_python_module(["nbgrader", "autograde", "ps1", "--create"])
+        run_python_module(["nbgrader", "autograde", "ps1"])
         run_python_module(["nbgrader", "feedback", "ps1"])
 
         assert exists(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
@@ -162,12 +171,15 @@ class TestNbGraderFeedback(BaseTestApp):
         assert p2 == self._file_contents(join(course_dir, "feedback", "foo", "ps1", "p2.html"))
 
     def test_update_newer(self, course_dir):
+        with open("nbgrader_config.py", "a") as fh:
+            fh.write("""c.NbGrader.db_assignments = [dict(name="ps1")]\n""")
+            fh.write("""c.NbGrader.db_students = [dict(id="foo")]\n""")
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1", "--create"])
+        run_python_module(["nbgrader", "assign", "ps1"])
 
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "timestamp.txt"), "2015-02-02 15:58:23.948203 PST")
-        run_python_module(["nbgrader", "autograde", "ps1", "--create"])
+        run_python_module(["nbgrader", "autograde", "ps1"])
         run_python_module(["nbgrader", "feedback", "ps1"])
 
         assert isfile(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
@@ -185,14 +197,17 @@ class TestNbGraderFeedback(BaseTestApp):
         assert p != self._file_contents(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
 
     def test_update_newer_single_notebook(self, course_dir):
+        with open("nbgrader_config.py", "a") as fh:
+            fh.write("""c.NbGrader.db_assignments = [dict(name="ps1")]\n""")
+            fh.write("""c.NbGrader.db_students = [dict(id="foo")]\n""")
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p2.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1", "--create"])
+        run_python_module(["nbgrader", "assign", "ps1"])
 
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p2.ipynb"))
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "timestamp.txt"), "2015-02-02 15:58:23.948203 PST")
-        run_python_module(["nbgrader", "autograde", "ps1", "--create"])
+        run_python_module(["nbgrader", "autograde", "ps1"])
         run_python_module(["nbgrader", "feedback", "ps1"])
 
         assert exists(join(course_dir, "feedback", "foo", "ps1", "p1.html"))

--- a/nbgrader/tests/nbextensions/conftest.py
+++ b/nbgrader/tests/nbextensions/conftest.py
@@ -98,14 +98,6 @@ def class_files(coursedir):
     with open(os.path.join(coursedir, "source", "ps.01", "problem 1.ipynb"), "w") as fh:
         write_nb(new_notebook(), fh, 4)
 
-    # create the gradebook
-    gb = Gradebook("sqlite:///" + os.path.join(coursedir, "gradebook.db"))
-    gb.add_assignment("Problem Set 1")
-    gb.add_assignment("ps.01")
-    gb.add_student("Bitdiddle", first_name="Ben", last_name="B")
-    gb.add_student("Hacker", first_name="Alyssa", last_name="H")
-    gb.add_student("Reasoner", first_name="Louis", last_name="R")
-
     return coursedir
 
 
@@ -128,6 +120,12 @@ def nbserver(request, tempdir, coursedir, jupyter_config_dir, jupyter_data_dir, 
                 c.TransferApp.exchange_directory = '{}'
                 c.TransferApp.cache_directory = '{}'
                 c.NbGrader.course_directory = '{}'
+                c.NbGrader.db_assignments = [dict(name="Problem Set 1"), dict(name="ps.01")]
+                c.NbGrader.db_students = [
+                    dict(id="Bitdiddle", first_name="Ben", last_name="B"),
+                    dict(id="Hacker", first_name="Alyssa", last_name="H"),
+                    dict(id="Reasoner", first_name="Louis", last_name="R")
+                ]
                 """.format(exchange, cache, coursedir)
             ))
 


### PR DESCRIPTION
This deprecates the `--create` flags for `nbgrader assign` and `nbgrader autograde` in favor of specifying assignments and students in the `nbgrader_config.py` file. I am leaving in the `--config` option for the time being so that it can print a warning -- it won't work, but it will tell people what they need to do. Fixes #415