### PR TITLE
Fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,15 @@ import os
 from distutils.core import setup
 from os.path import join
 
+# get paths to all the extension files
+extension_files = []
+for (dirname, dirnames, filenames) in os.walk("nbgrader/nbextensions"):
+    root = os.path.relpath(dirname, "nbgrader")
+    for filename in filenames:
+        if filename.endswith(".pyc"):
+            continue
+        extension_files.append(os.path.join(root, filename))
+
 # get paths to all the static files and templates
 static_files = []
 for (dirname, dirnames, filenames) in os.walk("nbgrader/formgrader/static"):
@@ -53,13 +62,12 @@ setup_args = dict(
         'nbgrader.tests'
     ],
     package_data={
-        'nbgrader': [
-            'nbextensions/nbgrader/*.js',
-            'nbextensions/nbgrader/*.css'
-        ],
+        'nbgrader': extension_files,
         'nbgrader.formgrader': static_files,
         'nbgrader.tests': [
-            'files/*',
+            'apps/files/*',
+            'nbextensions/files/*',
+            'preprocessors/files/*'
         ]
     },
     scripts = ['scripts/nbgrader']


### PR DESCRIPTION
`setup.py` currently doesn't install the files for the nbextensions, which makes it impossible to install from github (or via `python setup.py install`, for that matter).