### PR TITLE
Skip failures and log to file

### DIFF
--- a/nbgrader/apps/baseapp.py
+++ b/nbgrader/apps/baseapp.py
@@ -73,6 +73,16 @@ class NbGrader(JupyterApp):
     def _log_format_default(self):
         return "%(color)s[%(name)s | %(levelname)s]%(end_color)s %(message)s"
 
+    logfile = Unicode(
+        ".nbgrader.log",
+        config=True,
+        help=dedent(
+            """
+            Name of the logfile to log to.
+            """
+        )
+    )
+
     db_url = Unicode(
         "",
         config=True,
@@ -355,9 +365,23 @@ class NbGrader(JupyterApp):
     def excepthook(self, etype, evalue, tb):
         format_excepthook(etype, evalue, tb)
 
+    def init_logging(self):
+        if self.logfile:
+            handler = logging.FileHandler(self.logfile)
+
+            log_format = self.log_format.replace("%(color)s", "").replace("%(end_color)s", "")
+            _formatter = self._log_formatter_cls(
+                fmt=log_format,
+                datefmt=self.log_datefmt,
+            )
+
+            handler.setFormatter(_formatter)
+            self.log.addHandler(handler)
+
     @catch_config_error
     def initialize(self, argv=None):
         self.update_config(self.build_extra_config())
+        self.init_logging()
         super(NbGrader, self).initialize(argv)
 
     def _format_path(self, nbgrader_step, student_id, assignment_id, escape=False):
@@ -738,5 +762,11 @@ class BaseNbConvertApp(NbGrader, NbConvertApp):
 
         if len(errors) > 0:
             for assignment_id, student_id in errors:
-                self.log.error("There was an error processing assignment '{}' for student '{}'".format(assignment_id, student_id))
-            self.fail("Please see the error log for details on the specific errors on the above failures.")
+                self.log.error(
+                    "There was an error processing assignment '{}' for student '{}'".format(
+                        assignment_id, student_id))
+
+            if self.logfile:
+                self.fail(
+                    "Please see the error log ({}) for details on the specific "
+                    "errors on the above failures.".format(self.logfile))

--- a/nbgrader/tests/apps/base.py
+++ b/nbgrader/tests/apps/base.py
@@ -11,8 +11,15 @@ from ...utils import remove
 @pytest.mark.usefixtures("temp_cwd")
 class BaseTestApp(object):
 
-    def _empty_notebook(self, path):
+    def _empty_notebook(self, path, kernel=None):
         nb = new_notebook()
+        if kernel is not None:
+            nb.metadata.kernelspec = {
+                "display_name": "kernel",
+                "language": kernel,
+                "name": kernel
+            }
+
         full_dest = os.path.abspath(path)
         if not os.path.exists(os.path.dirname(full_dest)):
             os.makedirs(os.path.dirname(full_dest))


### PR DESCRIPTION
This PR accomplishes two things:

1. It skips failed assignments and only raises an error at the end
2. It logs to file so that errors are more easily recoverable

Fixes #416