### PR TITLE
Update formgrader options to not conflict with the notebook

### DIFF
--- a/nbgrader/apps/formgradeapp.py
+++ b/nbgrader/apps/formgradeapp.py
@@ -148,15 +148,15 @@ class FormgradeApp(NbGrader):
 
         # Configure the formgrader settings
         self.tornado_settings = dict(
-            auth=self.authenticator_instance,
-            notebook_dir=self.course_directory,
-            notebook_dir_format=self.directory_structure,
+            nbgrader_auth=self.authenticator_instance,
+            nbgrader_notebook_dir=self.course_directory,
+            nbgrader_notebook_dir_format=self.directory_structure,
             nbgrader_step=self.autograded_directory,
-            exporter=HTMLExporter(config=self.config),
-            mathjax_url=self.mathjax_url,
-            gradebook=Gradebook(self.db_url),
-            jinja2_env=jinja_env,
-            log=self.log
+            nbgrader_exporter=HTMLExporter(config=self.config),
+            nbgrader_mathjax_url=self.mathjax_url,
+            nbgrader_gradebook=Gradebook(self.db_url),
+            nbgrader_jinja2_env=jinja_env,
+            nbgrader_log=self.log
         )
 
     def init_handlers(self):

--- a/nbgrader/formgrader/base.py
+++ b/nbgrader/formgrader/base.py
@@ -20,23 +20,23 @@ class BaseHandler(web.RequestHandler):
 
     @property
     def gradebook(self):
-        return self.settings['gradebook']
+        return self.settings['nbgrader_gradebook']
 
     @property
     def auth(self):
-        return self.settings['auth']
+        return self.settings['nbgrader_auth']
 
     @property
     def mathjax_url(self):
-        return self.settings['mathjax_url']
+        return self.settings['nbgrader_mathjax_url']
 
     @property
     def notebook_dir(self):
-        return self.settings['notebook_dir']
+        return self.settings['nbgrader_notebook_dir']
 
     @property
     def notebook_dir_format(self):
-        return self.settings['notebook_dir_format']
+        return self.settings['nbgrader_notebook_dir_format']
 
     @property
     def nbgrader_step(self):
@@ -44,14 +44,14 @@ class BaseHandler(web.RequestHandler):
 
     @property
     def exporter(self):
-        return self.settings['exporter']
+        return self.settings['nbgrader_exporter']
 
     @property
     def log(self):
-        return self.settings['log']
+        return self.settings['nbgrader_log']
 
     def render(self, name, **ns):
-        template = self.settings['jinja2_env'].get_template(name)
+        template = self.settings['nbgrader_jinja2_env'].get_template(name)
         return template.render(**ns)
 
     def write_error(self, status_code, **kwargs):


### PR DESCRIPTION
Prefix all the options in the `settings` dictionary so that they do not conflict with preexisting settings. This is necessary to hook up the formgrader's routes to another application, such as the notebook server.