### PR TITLE
Speed up tests

### DIFF
--- a/nbgrader/apps/extensionapp.py
+++ b/nbgrader/apps/extensionapp.py
@@ -164,7 +164,7 @@ class ExtensionDeactivateApp(DisableNBExtensionApp, NbGrader):
         self.log.info("Done. You may need to restart the Jupyter notebook server for changes to take effect.")
 
 
-class ExtensionApp(Application):
+class ExtensionApp(NbGrader):
 
     name = u'nbgrader extension'
     description = u'Utilities for managing the nbgrader extension'
@@ -192,6 +192,8 @@ class ExtensionApp(Application):
         for appname, (app, help) in self.subcommands.items():
             if len(app.class_traits(config=True)) > 0:
                 classes.append(app)
+
+        return classes
 
     @catch_config_error
     def initialize(self, argv=None):

--- a/nbgrader/apps/formgradeapp.py
+++ b/nbgrader/apps/formgradeapp.py
@@ -124,7 +124,10 @@ class FormgradeApp(NbGrader):
         super(FormgradeApp, self).initialize(argv)
         self.init_signal()
 
-    def init_logging(self):
+    def init_logging(self, handler_class=None, handler_args=None, color=True, subapps=False):
+        if handler_class:
+            super(FormgradeApp, self).init_logging(handler_class, handler_args, color=color, subapps=subapps)
+
         # hook up tornado 3's loggers to our app handlers
         self.log.propagate = False
         for log in (app_log, access_log, gen_log):
@@ -177,7 +180,11 @@ class FormgradeApp(NbGrader):
     def start(self):
         super(FormgradeApp, self).start()
 
-        self.init_logging()
+        if self.logfile:
+            self.init_logging(logging.FileHandler, [self.logfile], color=False)
+        else:
+            self.init_logging()
+
         self.init_tornado_settings()
         self.init_handlers()
         self.init_tornado_application()

--- a/nbgrader/apps/nbgraderapp.py
+++ b/nbgrader/apps/nbgraderapp.py
@@ -7,7 +7,7 @@ import os
 from textwrap import dedent
 
 from traitlets.config.application import catch_config_error
-from traitlets import Bool
+from jupyter_core.application import NoStart
 
 import nbgrader
 from .. import preprocessors
@@ -215,7 +215,7 @@ class NbGraderApp(NbGrader):
             with open(filename, 'w') as fh:
                 fh.write(s)
             self.log.info("New config file saved to '{}'".format(filename))
-            sys.exit(0)
+            raise NoStart()
 
         # check: is there a subapp given?
         if self.subapp is None:

--- a/nbgrader/tests/apps/test_nbgrader.py
+++ b/nbgrader/tests/apps/test_nbgrader.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-from .. import run_python_module, run_command
+from .. import run_nbgrader, run_command
 from .base import BaseTestApp
 
 
@@ -9,11 +9,11 @@ class TestNbGrader(BaseTestApp):
 
     def test_help(self):
         """Does the help display without error?"""
-        run_python_module(["nbgrader", "--help-all"])
+        run_nbgrader(["--help-all"])
 
     def test_no_subapp(self):
         """Is the help displayed when no subapp is given?"""
-        run_python_module(["nbgrader"], retcode=1)
+        run_nbgrader([], retcode=1)
 
     def test_generate_config(self):
         """Is the config file properly generated?"""
@@ -22,17 +22,17 @@ class TestNbGrader(BaseTestApp):
         os.remove("nbgrader_config.py")
 
         # try recreating it
-        run_python_module(["nbgrader", "--generate-config"])
+        run_nbgrader(["--generate-config"])
         assert os.path.isfile("nbgrader_config.py")
 
         # does it fail if it already exists?
-        run_python_module(["nbgrader", "--generate-config"], retcode=1)
+        run_nbgrader(["--generate-config"], retcode=1)
 
-    def test_check_version(self):
+    def test_check_version(self, capfd):
         """Is the version the same regardless of how we run nbgrader?"""
         if sys.platform == 'win32':
             out1 = "\r\n".join(run_command(["nbgrader.cmd", "--version"]).split("\r\n")[2:])
         else:
             out1 = run_command(["nbgrader", "--version"])
-        out2 = run_python_module(["nbgrader", "--version"])
+        out2 = run_nbgrader(["--version"], stdout=True)
         assert out1 == out2

--- a/nbgrader/tests/apps/test_nbgrader_assign.py
+++ b/nbgrader/tests/apps/test_nbgrader_assign.py
@@ -7,7 +7,7 @@ from sqlalchemy.exc import InvalidRequestError
 from textwrap import dedent
 
 from ...api import Gradebook
-from .. import run_python_module
+from .. import run_nbgrader
 from .base import BaseTestApp
 
 
@@ -15,33 +15,33 @@ class TestNbGraderAssign(BaseTestApp):
 
     def test_help(self):
         """Does the help display without error?"""
-        run_python_module(["nbgrader", "assign", "--help-all"])
+        run_nbgrader(["assign", "--help-all"])
 
     def test_no_args(self):
         """Is there an error if no arguments are given?"""
-        run_python_module(["nbgrader", "assign"], retcode=1)
+        run_nbgrader(["assign"], retcode=1)
 
     def test_conflicting_args(self):
         """Is there an error if assignment is specified both in config and as an argument?"""
-        run_python_module(["nbgrader", "assign", "--assignment", "foo", "foo"], retcode=1)
+        run_nbgrader(["assign", "--assignment", "foo", "foo"], retcode=1)
 
     def test_multiple_args(self):
         """Is there an error if multiple arguments are given?"""
-        run_python_module(["nbgrader", "assign", "foo", "bar"], retcode=1)
+        run_nbgrader(["assign", "foo", "bar"], retcode=1)
 
     def test_no_assignment(self, course_dir):
         """Is an error thrown if the assignment doesn't exist?"""
         self._empty_notebook(join(course_dir, 'source', 'ps1', 'foo.ipynb'))
-        run_python_module(["nbgrader", "assign", "ps1"], retcode=1)
+        run_nbgrader(["assign", "ps1"], retcode=1)
         # check that the --create flag is properly deprecated
-        run_python_module(["nbgrader", "assign", "ps1", "--create"], retcode=1)
+        run_nbgrader(["assign", "ps1", "--create"], retcode=1)
 
     def test_single_file(self, course_dir, temp_cwd):
         """Can a single file be assigned?"""
         self._empty_notebook(join(course_dir, 'source', 'ps1', 'foo.ipynb'))
         with open("nbgrader_config.py", "a") as fh:
             fh.write("""c.NbGrader.db_assignments = [dict(name="ps1")]\n""")
-        run_python_module(["nbgrader", "assign", "ps1"])
+        run_nbgrader(["assign", "ps1"])
         assert os.path.isfile(join(course_dir, "release", "ps1", "foo.ipynb"))
 
     def test_multiple_files(self, course_dir):
@@ -50,7 +50,7 @@ class TestNbGraderAssign(BaseTestApp):
         self._empty_notebook(join(course_dir, 'source', 'ps1', 'bar.ipynb'))
         with open("nbgrader_config.py", "a") as fh:
             fh.write("""c.NbGrader.db_assignments = [dict(name="ps1")]\n""")
-        run_python_module(["nbgrader", "assign", "ps1"])
+        run_nbgrader(["assign", "ps1"])
         assert os.path.isfile(join(course_dir, 'release', 'ps1', 'foo.ipynb'))
         assert os.path.isfile(join(course_dir, 'release', 'ps1', 'bar.ipynb'))
 
@@ -62,7 +62,7 @@ class TestNbGraderAssign(BaseTestApp):
         self._empty_notebook(join(course_dir, 'source', 'ps1', 'bar.ipynb'))
         with open("nbgrader_config.py", "a") as fh:
             fh.write("""c.NbGrader.db_assignments = [dict(name="ps1")]\n""")
-        run_python_module(["nbgrader", "assign", "ps1"])
+        run_nbgrader(["assign", "ps1"])
 
         assert os.path.isfile(join(course_dir, 'release', 'ps1', 'foo.ipynb'))
         assert os.path.isfile(join(course_dir, 'release', 'ps1', 'bar.ipynb'))
@@ -80,7 +80,7 @@ class TestNbGraderAssign(BaseTestApp):
         with open("nbgrader_config.py", "a") as fh:
             fh.write("""c.NbGrader.db_assignments = [dict(name="ps1")]\n""")
 
-        run_python_module(["nbgrader", "assign", "ps1", "--db", db])
+        run_nbgrader(["assign", "ps1", "--db", db])
 
         gb = Gradebook(db)
         notebook = gb.find_notebook("test", "ps1")
@@ -97,7 +97,7 @@ class TestNbGraderAssign(BaseTestApp):
         with open("nbgrader_config.py", "a") as fh:
             fh.write("""c.NbGrader.db_assignments = [dict(name="ps1")]\n""")
 
-        run_python_module(["nbgrader", "assign", "ps1"])
+        run_nbgrader(["assign", "ps1"])
         assert os.path.isfile(join(course_dir, 'release', 'ps1', 'test.ipynb'))
         assert os.path.isfile(join(course_dir, 'release', 'ps1', 'foo.txt'))
         assert os.path.isfile(join(course_dir, 'release', 'ps1', 'data', 'bar.txt'))
@@ -105,16 +105,16 @@ class TestNbGraderAssign(BaseTestApp):
 
         # check that it skips the existing directory
         os.remove(join(course_dir, 'release', 'ps1', 'foo.txt'))
-        run_python_module(["nbgrader", "assign", "ps1"])
+        run_nbgrader(["assign", "ps1"])
         assert not os.path.isfile(join(course_dir, 'release', 'ps1', 'foo.txt'))
 
         # force overwrite the supplemental files
-        run_python_module(["nbgrader", "assign", "ps1", "--force"])
+        run_nbgrader(["assign", "ps1", "--force"])
         assert os.path.isfile(join(course_dir, 'release', 'ps1', 'foo.txt'))
 
         # force overwrite
         os.remove(join(course_dir, 'source', 'ps1', 'foo.txt'))
-        run_python_module(["nbgrader", "assign", "ps1", "--force"])
+        run_nbgrader(["assign", "ps1", "--force"])
         assert os.path.isfile(join(course_dir, "release", "ps1", "test.ipynb"))
         assert os.path.isfile(join(course_dir, "release", "ps1", "data", "bar.txt"))
         assert not os.path.isfile(join(course_dir, "release", "ps1", "foo.txt"))
@@ -126,7 +126,7 @@ class TestNbGraderAssign(BaseTestApp):
         self._make_file(join(course_dir, 'source', 'ps1', 'foo.txt'), 'foo')
         with open("nbgrader_config.py", "a") as fh:
             fh.write("""c.NbGrader.db_assignments = [dict(name="ps1")]\n""")
-        run_python_module(["nbgrader", "assign", "ps1"])
+        run_nbgrader(["assign", "ps1"])
 
         if sys.platform == 'win32':
             perms = '666'
@@ -144,7 +144,7 @@ class TestNbGraderAssign(BaseTestApp):
         self._make_file(join(course_dir, 'source', 'ps1', 'foo.txt'), 'foo')
         with open("nbgrader_config.py", "a") as fh:
             fh.write("""c.NbGrader.db_assignments = [dict(name="ps1")]\n""")
-        run_python_module(["nbgrader", "assign", "ps1", "--AssignApp.permissions=444"])
+        run_nbgrader(["assign", "ps1", "--AssignApp.permissions=444"])
 
         assert os.path.isfile(join(course_dir, "release", "ps1", "foo.ipynb"))
         assert os.path.isfile(join(course_dir, "release", "ps1", "foo.txt"))
@@ -156,7 +156,7 @@ class TestNbGraderAssign(BaseTestApp):
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "test.ipynb"))
         with open("nbgrader_config.py", "a") as fh:
             fh.write("""c.NbGrader.db_assignments = [dict(name="ps1")]\n""")
-        run_python_module(["nbgrader", "assign", "ps1", "--db", db])
+        run_nbgrader(["assign", "ps1", "--db", db])
 
         gb = Gradebook(db)
         assignment = gb.find_assignment("ps1")
@@ -164,7 +164,7 @@ class TestNbGraderAssign(BaseTestApp):
         notebook1 = gb.find_notebook("test", "ps1")
 
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "test2.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1", "--db", db, "--force"])
+        run_nbgrader(["assign", "ps1", "--db", db, "--force"])
 
         gb.db.refresh(assignment)
         assert len(assignment.notebooks) == 2
@@ -172,7 +172,7 @@ class TestNbGraderAssign(BaseTestApp):
         notebook2 = gb.find_notebook("test2", "ps1")
 
         os.remove(join(course_dir, "source", "ps1", "test2.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1", "--db", db, "--force"])
+        run_nbgrader(["assign", "ps1", "--db", db, "--force"])
 
         gb.db.refresh(assignment)
         assert len(assignment.notebooks) == 1
@@ -188,7 +188,7 @@ class TestNbGraderAssign(BaseTestApp):
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "test.ipynb"))
         with open("nbgrader_config.py", "a") as fh:
             fh.write("""c.NbGrader.db_assignments = [dict(name="ps1")]\n""")
-        run_python_module(["nbgrader", "assign", "ps1", "--db", db])
+        run_nbgrader(["assign", "ps1", "--db", db])
 
         gb = Gradebook(db)
         assignment = gb.find_assignment("ps1")
@@ -198,7 +198,7 @@ class TestNbGraderAssign(BaseTestApp):
         gb.add_submission("ps1", "hacker123")
 
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "test2.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1", "--db", db, "--force"], retcode=1)
+        run_nbgrader(["assign", "ps1", "--db", db, "--force"], retcode=1)
 
         gb.db.close()
 
@@ -209,7 +209,7 @@ class TestNbGraderAssign(BaseTestApp):
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "test2.ipynb"))
         with open("nbgrader_config.py", "a") as fh:
             fh.write("""c.NbGrader.db_assignments = [dict(name="ps1")]\n""")
-        run_python_module(["nbgrader", "assign", "ps1", "--db", db])
+        run_nbgrader(["assign", "ps1", "--db", db])
 
         gb = Gradebook(db)
         assignment = gb.find_assignment("ps1")
@@ -219,7 +219,7 @@ class TestNbGraderAssign(BaseTestApp):
         gb.add_submission("ps1", "hacker123")
 
         os.remove(join(course_dir, "source", "ps1", "test2.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1", "--db", db, "--force"], retcode=1)
+        run_nbgrader(["assign", "ps1", "--db", db, "--force"], retcode=1)
 
         gb.db.close()
 
@@ -229,7 +229,7 @@ class TestNbGraderAssign(BaseTestApp):
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "test.ipynb"))
         with open("nbgrader_config.py", "a") as fh:
             fh.write("""c.NbGrader.db_assignments = [dict(name="ps1")]\n""")
-        run_python_module(["nbgrader", "assign", "ps1", "--db", db])
+        run_nbgrader(["assign", "ps1", "--db", db])
 
         gb = Gradebook(db)
         assignment = gb.find_assignment("ps1")
@@ -240,7 +240,7 @@ class TestNbGraderAssign(BaseTestApp):
         submission = gb.add_submission("ps1", "hacker123")
         submission_notebook = submission.notebooks[0]
 
-        run_python_module(["nbgrader", "assign", "ps1", "--db", db, "--force"])
+        run_nbgrader(["assign", "ps1", "--db", db, "--force"])
 
         gb.db.refresh(assignment)
         assert len(assignment.notebooks) == 1
@@ -255,7 +255,7 @@ class TestNbGraderAssign(BaseTestApp):
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p2.ipynb"))
         with open("nbgrader_config.py", "a") as fh:
             fh.write("""c.NbGrader.db_assignments = [dict(name="ps1")]\n""")
-        run_python_module(["nbgrader", "assign", "ps1"])
+        run_nbgrader(["assign", "ps1"])
 
         assert os.path.exists(join(course_dir, "release", "ps1", "p1.ipynb"))
         assert os.path.exists(join(course_dir, "release", "ps1", "p2.ipynb"))
@@ -265,7 +265,7 @@ class TestNbGraderAssign(BaseTestApp):
 
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "source", "ps1", "p2.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1", "--notebook", "p1", "--force"])
+        run_nbgrader(["assign", "ps1", "--notebook", "p1", "--force"])
 
         assert os.path.exists(join(course_dir, "release", "ps1", "p1.ipynb"))
         assert os.path.exists(join(course_dir, "release", "ps1", "p2.ipynb"))
@@ -275,15 +275,15 @@ class TestNbGraderAssign(BaseTestApp):
     def test_fail_no_notebooks(self):
         with open("nbgrader_config.py", "a") as fh:
             fh.write("""c.NbGrader.db_assignments = [dict(name="ps1")]\n""")
-        run_python_module(["nbgrader", "assign", "ps1"], retcode=1)
+        run_nbgrader(["assign", "ps1"], retcode=1)
 
     def test_no_metadata(self, course_dir):
         self._copy_file(join("files", "test-no-metadata.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
 
         # it should fail because of the solution regions
-        run_python_module(["nbgrader", "assign", "ps1", "--no-db"], retcode=1)
+        run_nbgrader(["assign", "ps1", "--no-db"], retcode=1)
 
         # it should pass now that we're not enforcing metadata
-        run_python_module(["nbgrader", "assign", "ps1", "--no-db", "--no-metadata"])
+        run_nbgrader(["assign", "ps1", "--no-db", "--no-metadata"])
         assert os.path.exists(join(course_dir, "release", "ps1", "p1.ipynb"))
 

--- a/nbgrader/tests/apps/test_nbgrader_autograde.py
+++ b/nbgrader/tests/apps/test_nbgrader_autograde.py
@@ -6,7 +6,7 @@ from nbformat.v4 import reads
 
 from ...api import Gradebook
 from ...utils import remove
-from .. import run_python_module
+from .. import run_nbgrader
 from .base import BaseTestApp
 
 
@@ -14,7 +14,7 @@ class TestNbGraderAutograde(BaseTestApp):
 
     def test_help(self):
         """Does the help display without error?"""
-        run_python_module(["nbgrader", "autograde", "--help-all"])
+        run_nbgrader(["autograde", "--help-all"])
 
     def test_missing_student(self, db, course_dir):
         """Is an error thrown when the student is missing?"""
@@ -23,13 +23,13 @@ class TestNbGraderAutograde(BaseTestApp):
             fh.write("""c.NbGrader.db_students = [dict(id="foo"), dict(id="bar")]""")
 
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1", "--db", db])
+        run_nbgrader(["assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "baz", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", db], retcode=1)
+        run_nbgrader(["autograde", "ps1", "--db", db], retcode=1)
 
         # check that --create is properly deprecated
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", db, "--create"], retcode=1)
+        run_nbgrader(["autograde", "ps1", "--db", db, "--create"], retcode=1)
 
     def test_missing_assignment(self, db, course_dir):
         """Is an error thrown when the assignment is missing?"""
@@ -38,10 +38,10 @@ class TestNbGraderAutograde(BaseTestApp):
             fh.write("""c.NbGrader.db_students = [dict(id="foo"), dict(id="bar")]""")
 
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1", "--db", db])
+        run_nbgrader(["assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "ps2", "foo", "p1.ipynb"))
-        run_python_module(["nbgrader", "autograde", "ps2", "--db", db], retcode=1)
+        run_nbgrader(["autograde", "ps2", "--db", db], retcode=1)
 
     def test_grade(self, db, course_dir):
         """Can files be graded?"""
@@ -50,11 +50,11 @@ class TestNbGraderAutograde(BaseTestApp):
             fh.write("""c.NbGrader.db_students = [dict(id="foo"), dict(id="bar")]""")
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1", "--db", db])
+        run_nbgrader(["assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "bar", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", db])
+        run_nbgrader(["autograde", "ps1", "--db", db])
 
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "timestamp.txt"))
@@ -94,7 +94,7 @@ class TestNbGraderAutograde(BaseTestApp):
             fh.write("""c.NbGrader.db_students = [dict(id="foo"), dict(id="bar")]""")
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1", "--db", db])
+        run_nbgrader(["assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "timestamp.txt"), "2015-02-02 15:58:23.948203 PST")
@@ -102,7 +102,7 @@ class TestNbGraderAutograde(BaseTestApp):
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "bar", "ps1", "p1.ipynb"))
         self._make_file(join(course_dir, "submitted", "bar", "ps1", "timestamp.txt"), "2015-02-01 14:58:23.948203 PST")
 
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", db])
+        run_nbgrader(["autograde", "ps1", "--db", db])
 
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "timestamp.txt"))
@@ -116,7 +116,7 @@ class TestNbGraderAutograde(BaseTestApp):
         assert submission.total_seconds_late == 0
 
         # make sure it still works to run it a second time
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", db])
+        run_nbgrader(["autograde", "ps1", "--db", db])
 
         gb.db.close()
 
@@ -129,13 +129,13 @@ class TestNbGraderAutograde(BaseTestApp):
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         self._make_file(join(course_dir, "source", "ps1", "foo.txt"), "foo")
         self._make_file(join(course_dir, "source", "ps1", "data", "bar.txt"), "bar")
-        run_python_module(["nbgrader", "assign", "ps1", "--db", db])
+        run_nbgrader(["assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "foo.txt"), "foo")
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "data", "bar.txt"), "bar")
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "blah.pyc"), "asdf")
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", db])
+        run_nbgrader(["autograde", "ps1", "--db", db])
 
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
@@ -144,17 +144,17 @@ class TestNbGraderAutograde(BaseTestApp):
 
         # check that it skips the existing directory
         remove(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", db])
+        run_nbgrader(["autograde", "ps1", "--db", db])
         assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
 
         # force overwrite the supplemental files
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", db, "--force"])
+        run_nbgrader(["autograde", "ps1", "--db", db, "--force"])
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
 
         # force overwrite
         remove(join(course_dir, "source", "ps1", "foo.txt"))
         remove(join(course_dir, "submitted", "foo", "ps1", "foo.txt"))
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", db, "--force"])
+        run_nbgrader(["autograde", "ps1", "--db", db, "--force"])
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "data", "bar.txt"))
@@ -169,13 +169,13 @@ class TestNbGraderAutograde(BaseTestApp):
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         self._make_file(join(course_dir, "source", "ps1", "foo.txt"), "foo")
         self._make_file(join(course_dir, "source", "ps1", "data", "bar.txt"), "bar")
-        run_python_module(["nbgrader", "assign", "ps1", "--db", db])
+        run_nbgrader(["assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "foo.txt"), "foo")
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "data", "bar.txt"), "bar")
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "blah.pyc"), "asdf")
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", db, "--notebook", "p1"])
+        run_nbgrader(["autograde", "ps1", "--db", db, "--notebook", "p1"])
 
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
@@ -185,7 +185,7 @@ class TestNbGraderAutograde(BaseTestApp):
         # check that removing the notebook still causes the autograder to run
         remove(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         remove(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", db, "--notebook", "p1"])
+        run_nbgrader(["autograde", "ps1", "--db", db, "--notebook", "p1"])
 
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
@@ -194,7 +194,7 @@ class TestNbGraderAutograde(BaseTestApp):
 
         # check that running it again doesn"t do anything
         remove(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", db, "--notebook", "p1"])
+        run_nbgrader(["autograde", "ps1", "--db", db, "--notebook", "p1"])
 
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
@@ -203,7 +203,7 @@ class TestNbGraderAutograde(BaseTestApp):
 
         # check that removing the notebook doesn"t caus the autograder to run
         remove(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", db])
+        run_nbgrader(["autograde", "ps1", "--db", db])
 
         assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
@@ -218,12 +218,12 @@ class TestNbGraderAutograde(BaseTestApp):
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         self._make_file(join(course_dir, "source", "ps1", "data.csv"), "some,data\n")
-        run_python_module(["nbgrader", "assign", "ps1", "--db", db])
+        run_nbgrader(["assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "timestamp.txt"), "2015-02-02 15:58:23.948203 PST")
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "data.csv"), "some,other,data\n")
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", db])
+        run_nbgrader(["autograde", "ps1", "--db", db])
 
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "timestamp.txt"))
@@ -243,10 +243,10 @@ class TestNbGraderAutograde(BaseTestApp):
             fh.write("""c.NbGrader.db_students = [dict(id="foo"), dict(id="bar")]""")
 
         self._copy_file(join("files", "side-effects.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1", "--db", db])
+        run_nbgrader(["assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "side-effects.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", db])
+        run_nbgrader(["autograde", "ps1", "--db", db])
 
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "side-effect.txt"))
         assert not os.path.isfile(join(course_dir, "submitted", "foo", "ps1", "side-effect.txt"))
@@ -257,11 +257,11 @@ class TestNbGraderAutograde(BaseTestApp):
             fh.write("""c.NbGrader.db_students = [dict(id="foo"), dict(id="bar")]""")
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1", "--db", db])
+        run_nbgrader(["assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1 copy.ipynb"))
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", db])
+        run_nbgrader(["autograde", "ps1", "--db", db])
 
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1 copy.ipynb"))
@@ -274,11 +274,11 @@ class TestNbGraderAutograde(BaseTestApp):
 
         self._empty_notebook(join(course_dir, "source", "ps1", "foo.ipynb"))
         self._make_file(join(course_dir, "source", "ps1", "foo.txt"), "foo")
-        run_python_module(["nbgrader", "assign", "ps1"])
+        run_nbgrader(["assign", "ps1"])
 
         self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "foo.ipynb"))
         self._make_file(join(course_dir, "source", "foo", "ps1", "foo.txt"), "foo")
-        run_python_module(["nbgrader", "autograde", "ps1"])
+        run_nbgrader(["autograde", "ps1"])
 
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "foo.ipynb"))
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
@@ -293,11 +293,11 @@ class TestNbGraderAutograde(BaseTestApp):
 
         self._empty_notebook(join(course_dir, "source", "ps1", "foo.ipynb"))
         self._make_file(join(course_dir, "source", "ps1", "foo.txt"), "foo")
-        run_python_module(["nbgrader", "assign", "ps1"])
+        run_nbgrader(["assign", "ps1"])
 
         self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "foo.ipynb"))
         self._make_file(join(course_dir, "source", "foo", "ps1", "foo.txt"), "foo")
-        run_python_module(["nbgrader", "autograde", "ps1", "--AutogradeApp.permissions=644"])
+        run_nbgrader(["autograde", "ps1", "--AutogradeApp.permissions=644"])
 
         if sys.platform == 'win32':
             perms = '666'
@@ -316,11 +316,11 @@ class TestNbGraderAutograde(BaseTestApp):
 
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p2.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1"])
+        run_nbgrader(["assign", "ps1"])
 
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p2.ipynb"))
-        run_python_module(["nbgrader", "autograde", "ps1"])
+        run_nbgrader(["autograde", "ps1"])
 
         assert os.path.exists(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         assert os.path.exists(join(course_dir, "autograded", "foo", "ps1", "p2.ipynb"))
@@ -330,7 +330,7 @@ class TestNbGraderAutograde(BaseTestApp):
 
         self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "p2.ipynb"))
-        run_python_module(["nbgrader", "autograde", "ps1", "--notebook", "p1", "--force"])
+        run_nbgrader(["autograde", "ps1", "--notebook", "p1", "--force"])
 
         assert os.path.exists(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         assert os.path.exists(join(course_dir, "autograded", "foo", "ps1", "p2.ipynb"))
@@ -343,11 +343,11 @@ class TestNbGraderAutograde(BaseTestApp):
             fh.write("""c.NbGrader.db_students = [dict(id="foo"), dict(id="bar")]""")
 
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1"])
+        run_nbgrader(["assign", "ps1"])
 
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "timestamp.txt"), "2015-02-02 15:58:23.948203 PST")
-        run_python_module(["nbgrader", "autograde", "ps1"])
+        run_nbgrader(["autograde", "ps1"])
 
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "timestamp.txt"))
@@ -356,7 +356,7 @@ class TestNbGraderAutograde(BaseTestApp):
 
         self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "timestamp.txt"), "2015-02-02 16:58:23.948203 PST")
-        run_python_module(["nbgrader", "autograde", "ps1"])
+        run_nbgrader(["autograde", "ps1"])
 
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "timestamp.txt"))
@@ -370,12 +370,12 @@ class TestNbGraderAutograde(BaseTestApp):
 
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p2.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1"])
+        run_nbgrader(["assign", "ps1"])
 
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p2.ipynb"))
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "timestamp.txt"), "2015-02-02 15:58:23.948203 PST")
-        run_python_module(["nbgrader", "autograde", "ps1"])
+        run_nbgrader(["autograde", "ps1"])
 
         assert os.path.exists(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         assert os.path.exists(join(course_dir, "autograded", "foo", "ps1", "p2.ipynb"))
@@ -388,7 +388,7 @@ class TestNbGraderAutograde(BaseTestApp):
         self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "p2.ipynb"))
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "timestamp.txt"), "2015-02-02 16:58:23.948203 PST")
-        run_python_module(["nbgrader", "autograde", "ps1", "--notebook", "p1"])
+        run_nbgrader(["autograde", "ps1", "--notebook", "p1"])
 
         assert os.path.exists(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         assert os.path.exists(join(course_dir, "autograded", "foo", "ps1", "p2.ipynb"))
@@ -404,11 +404,11 @@ class TestNbGraderAutograde(BaseTestApp):
 
         self._empty_notebook(join(course_dir, "source", "ps1", "p1.ipynb"))
         self._empty_notebook(join(course_dir, "source", "ps1", "p2.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1"])
+        run_nbgrader(["assign", "ps1"])
 
         self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p2.ipynb"))
-        run_python_module(["nbgrader", "autograde", "ps1"], retcode=1)
+        run_nbgrader(["autograde", "ps1"], retcode=1)
 
         assert not os.path.exists(join(course_dir, "autograded", "foo", "ps1"))
 
@@ -419,11 +419,11 @@ class TestNbGraderAutograde(BaseTestApp):
 
         self._empty_notebook(join(course_dir, "source", "ps1", "p1.ipynb"))
         self._empty_notebook(join(course_dir, "source", "ps1", "p2.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1"])
+        run_nbgrader(["assign", "ps1"])
 
         self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p2.ipynb"))
-        run_python_module(["nbgrader", "autograde", "ps1", "--notebook", "p*"], retcode=1)
+        run_nbgrader(["autograde", "ps1", "--notebook", "p*"], retcode=1)
 
         assert os.path.exists(join(course_dir, "autograded", "foo", "ps1"))
         assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
@@ -435,11 +435,11 @@ class TestNbGraderAutograde(BaseTestApp):
             fh.write("""c.NbGrader.db_students = [dict(id="foo"), dict(id="bar")]""")
 
         self._empty_notebook(join(course_dir, "source", "ps1", "p1.ipynb"), kernel="python")
-        run_python_module(["nbgrader", "assign", "ps1"])
+        run_nbgrader(["assign", "ps1"])
 
         self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"), kernel="blah")
         self._empty_notebook(join(course_dir, "submitted", "bar", "ps1", "p1.ipynb"), kernel="python")
-        run_python_module(["nbgrader", "autograde", "ps1"], retcode=1)
+        run_nbgrader(["autograde", "ps1"], retcode=1)
 
         assert not os.path.exists(join(course_dir, "autograded", "foo", "ps1"))
         assert os.path.exists(join(course_dir, "autograded", "bar", "ps1"))
@@ -451,13 +451,13 @@ class TestNbGraderAutograde(BaseTestApp):
             fh.write("""c.NbGrader.db_students = [dict(id="foo")]""")
 
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1"])
+        run_nbgrader(["assign", "ps1"])
 
         self._copy_file(join("files", "test-with-output.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         with open(join(os.path.dirname(__file__), "files", "test-with-output.ipynb"), "r") as fh:
             orig_contents = reads(fh.read())
 
-        run_python_module(["nbgrader", "autograde", "ps1"])
+        run_nbgrader(["autograde", "ps1"])
         with open(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"), "r") as fh:
             new_contents = reads(fh.read())
 
@@ -474,7 +474,7 @@ class TestNbGraderAutograde(BaseTestApp):
 
         assert different
 
-        run_python_module(["nbgrader", "autograde", "ps1", "--force", "--no-execute"])
+        run_nbgrader(["autograde", "ps1", "--force", "--no-execute"])
         with open(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"), "r") as fh:
             new_contents = reads(fh.read())
 

--- a/nbgrader/tests/apps/test_nbgrader_extension.py
+++ b/nbgrader/tests/apps/test_nbgrader_extension.py
@@ -4,7 +4,7 @@ import json
 import six
 import sys
 
-from .. import run_python_module
+from .. import run_nbgrader
 from .base import BaseTestApp
 
 
@@ -45,24 +45,24 @@ class TestNbGraderExtension(BaseTestApp):
 
     def test_help(self):
         """Does the help display without error?"""
-        run_python_module(["nbgrader", "extension", "--help-all"])
-        run_python_module(["nbgrader", "extension", "install", "--help-all"])
-        run_python_module(["nbgrader", "extension", "activate", "--help-all"])
-        run_python_module(["nbgrader", "extension", "deactivate", "--help-all"])
+        run_nbgrader(["extension", "--help-all"])
+        run_nbgrader(["extension", "install", "--help-all"])
+        run_nbgrader(["extension", "activate", "--help-all"])
+        run_nbgrader(["extension", "deactivate", "--help-all"])
 
     def test_install_system(self, jupyter_data_dir, env):
-        run_python_module(["nbgrader", "extension", "install", "--prefix", jupyter_data_dir], env=env)
+        run_nbgrader(["extension", "install", "--prefix", jupyter_data_dir], env=env)
         self._assert_is_installed(os.path.join(jupyter_data_dir, "share", "jupyter", "nbextensions"))
 
     def test_install_user(self, jupyter_data_dir, env):
         nbextension_dir = os.path.join(jupyter_data_dir, "nbextensions")
-        run_python_module(["nbgrader", "extension", "install", "--nbextensions", nbextension_dir], env=env)
+        run_nbgrader(["extension", "install", "--nbextensions", nbextension_dir], env=env)
         self._assert_is_installed(nbextension_dir)
 
     def test_activate(self, jupyter_data_dir, jupyter_config_dir, env):
         nbextension_dir = os.path.join(jupyter_data_dir, "nbextensions")
-        run_python_module(["nbgrader", "extension", "install", "--nbextensions", nbextension_dir], env=env)
-        run_python_module(["nbgrader", "extension", "activate"], env=env)
+        run_nbgrader(["extension", "install", "--nbextensions", nbextension_dir], env=env)
+        run_nbgrader(["extension", "activate"], env=env)
 
         # check the extension file were copied
         self._assert_is_installed(nbextension_dir)
@@ -74,8 +74,8 @@ class TestNbGraderExtension(BaseTestApp):
 
     def test_deactivate(self, jupyter_data_dir, jupyter_config_dir, env):
         nbextension_dir = os.path.join(jupyter_data_dir, "nbextensions")
-        run_python_module(["nbgrader", "extension", "install", "--nbextensions", nbextension_dir], env=env)
-        run_python_module(["nbgrader", "extension", "activate"], env=env)
+        run_nbgrader(["extension", "install", "--nbextensions", nbextension_dir], env=env)
+        run_nbgrader(["extension", "activate"], env=env)
 
         # check the extension file were copied
         self._assert_is_installed(nbextension_dir)
@@ -90,7 +90,7 @@ class TestNbGraderExtension(BaseTestApp):
         if sys.platform != 'win32':
             self._activate_fake_extension(os.path.join(jupyter_config_dir, 'nbconfig', 'tree.json'), key='other_extension')
 
-        run_python_module(["nbgrader", "extension", "deactivate"], env=env)
+        run_nbgrader(["extension", "deactivate"], env=env)
 
         # check that it is deactivated
         self._assert_is_deactivated(os.path.join(jupyter_config_dir, 'nbconfig', 'notebook.json'), key='create_assignment/main')
@@ -99,7 +99,7 @@ class TestNbGraderExtension(BaseTestApp):
             self._assert_is_deactivated(os.path.join(jupyter_config_dir, 'nbconfig', 'tree.json'), key='assignment_list/main')
             self._assert_is_activated(os.path.join(jupyter_config_dir, 'nbconfig', 'tree.json'), key='other_extension')
 
-        run_python_module(["nbgrader", "extension", "activate"], env=env)
+        run_nbgrader(["extension", "activate"], env=env)
 
         self._assert_is_activated(os.path.join(jupyter_config_dir, 'nbconfig', 'notebook.json'), key='create_assignment/main')
         self._assert_is_activated(os.path.join(jupyter_config_dir, 'nbconfig', 'notebook.json'), key='other_extension')

--- a/nbgrader/tests/apps/test_nbgrader_feedback.py
+++ b/nbgrader/tests/apps/test_nbgrader_feedback.py
@@ -3,7 +3,7 @@ import sys
 from os.path import join, exists, isfile
 
 from ...utils import remove
-from .. import run_python_module
+from .. import run_nbgrader
 from .base import BaseTestApp
 
 
@@ -11,7 +11,7 @@ class TestNbGraderFeedback(BaseTestApp):
 
     def test_help(self):
         """Does the help display without error?"""
-        run_python_module(["nbgrader", "feedback", "--help-all"])
+        run_nbgrader(["feedback", "--help-all"])
 
     def test_single_file(self, db, course_dir):
         """Can feedback be generated for an unchanged assignment?"""
@@ -19,11 +19,11 @@ class TestNbGraderFeedback(BaseTestApp):
             fh.write("""c.NbGrader.db_assignments = [dict(name="ps1")]\n""")
             fh.write("""c.NbGrader.db_students = [dict(id="foo")]\n""")
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1", "--db", db])
+        run_nbgrader(["assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", db])
-        run_python_module(["nbgrader", "feedback", "ps1", "--db", db])
+        run_nbgrader(["autograde", "ps1", "--db", db])
+        run_nbgrader(["feedback", "ps1", "--db", db])
 
         assert exists(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
 
@@ -35,15 +35,15 @@ class TestNbGraderFeedback(BaseTestApp):
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         self._make_file(join(course_dir, "source", "ps1", "foo.txt"), "foo")
         self._make_file(join(course_dir, "source", "ps1", "data", "bar.txt"), "bar")
-        run_python_module(["nbgrader", "assign", "ps1", "--db", db])
+        run_nbgrader(["assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "foo.txt"), "foo")
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "data", "bar.txt"), "bar")
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", db])
+        run_nbgrader(["autograde", "ps1", "--db", db])
 
         self._make_file(join(course_dir, "autograded", "foo", "ps1", "blah.pyc"), "asdf")
-        run_python_module(["nbgrader", "feedback", "ps1", "--db", db])
+        run_nbgrader(["feedback", "ps1", "--db", db])
 
         assert isfile(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
         assert isfile(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))
@@ -52,16 +52,16 @@ class TestNbGraderFeedback(BaseTestApp):
 
         # check that it skips the existing directory
         remove(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))
-        run_python_module(["nbgrader", "feedback", "ps1", "--db", db])
+        run_nbgrader(["feedback", "ps1", "--db", db])
         assert not isfile(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))
 
         # force overwrite the supplemental files
-        run_python_module(["nbgrader", "feedback", "ps1", "--db", db, "--force"])
+        run_nbgrader(["feedback", "ps1", "--db", db, "--force"])
         assert isfile(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))
 
         # force overwrite
         remove(join(course_dir, "autograded", "foo", "ps1", "foo.txt"))
-        run_python_module(["nbgrader", "feedback", "ps1", "--db", db, "--force"])
+        run_nbgrader(["feedback", "ps1", "--db", db, "--force"])
         assert isfile(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
         assert not isfile(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))
         assert isfile(join(course_dir, "feedback", "foo", "ps1", "data", "bar.txt"))
@@ -75,14 +75,14 @@ class TestNbGraderFeedback(BaseTestApp):
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         self._make_file(join(course_dir, "source", "ps1", "foo.txt"), "foo")
         self._make_file(join(course_dir, "source", "ps1", "data", "bar.txt"), "bar")
-        run_python_module(["nbgrader", "assign", "ps1", "--db", db])
+        run_nbgrader(["assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "foo.txt"), "foo")
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "data", "bar.txt"), "bar")
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "blah.pyc"), "asdf")
-        run_python_module(["nbgrader", "autograde", "ps1", "--db", db])
-        run_python_module(["nbgrader", "feedback", "ps1", "--db", db, "--notebook", "p1"])
+        run_nbgrader(["autograde", "ps1", "--db", db])
+        run_nbgrader(["feedback", "ps1", "--db", db, "--notebook", "p1"])
 
         assert isfile(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
         assert isfile(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))
@@ -92,7 +92,7 @@ class TestNbGraderFeedback(BaseTestApp):
         # check that removing the notebook still causes it to run
         remove(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
         remove(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))
-        run_python_module(["nbgrader", "feedback", "ps1", "--db", db, "--notebook", "p1"])
+        run_nbgrader(["feedback", "ps1", "--db", db, "--notebook", "p1"])
 
         assert isfile(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
         assert isfile(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))
@@ -101,7 +101,7 @@ class TestNbGraderFeedback(BaseTestApp):
 
         # check that running it again doesn"t do anything
         remove(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))
-        run_python_module(["nbgrader", "feedback", "ps1", "--db", db, "--notebook", "p1"])
+        run_nbgrader(["feedback", "ps1", "--db", db, "--notebook", "p1"])
 
         assert isfile(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
         assert not isfile(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))
@@ -110,7 +110,7 @@ class TestNbGraderFeedback(BaseTestApp):
 
         # check that removing the notebook doesn"t cause it to run
         remove(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
-        run_python_module(["nbgrader", "feedback", "ps1", "--db", db])
+        run_nbgrader(["feedback", "ps1", "--db", db])
 
         assert not isfile(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
         assert not isfile(join(course_dir, "feedback", "foo", "ps1", "foo.txt"))
@@ -123,11 +123,11 @@ class TestNbGraderFeedback(BaseTestApp):
             fh.write("""c.NbGrader.db_assignments = [dict(name="ps1")]\n""")
             fh.write("""c.NbGrader.db_students = [dict(id="foo")]\n""")
         self._empty_notebook(join(course_dir, "source", "ps1", "foo.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1"])
+        run_nbgrader(["assign", "ps1"])
 
         self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "foo.ipynb"))
-        run_python_module(["nbgrader", "autograde", "ps1"])
-        run_python_module(["nbgrader", "feedback", "ps1"])
+        run_nbgrader(["autograde", "ps1"])
+        run_nbgrader(["feedback", "ps1"])
 
         assert isfile(join(course_dir, "feedback", "foo", "ps1", "foo.html"))
         assert self._get_permissions(join(course_dir, "feedback", "foo", "ps1", "foo.html")) == "444"
@@ -138,11 +138,11 @@ class TestNbGraderFeedback(BaseTestApp):
             fh.write("""c.NbGrader.db_assignments = [dict(name="ps1")]\n""")
             fh.write("""c.NbGrader.db_students = [dict(id="foo")]\n""")
         self._empty_notebook(join(course_dir, "source", "ps1", "foo.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1"])
+        run_nbgrader(["assign", "ps1"])
 
         self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "foo.ipynb"))
-        run_python_module(["nbgrader", "autograde", "ps1"])
-        run_python_module(["nbgrader", "feedback", "ps1", "--FeedbackApp.permissions=644"])
+        run_nbgrader(["autograde", "ps1"])
+        run_nbgrader(["feedback", "ps1", "--FeedbackApp.permissions=644"])
 
         if sys.platform == 'win32':
             perms = '666'
@@ -158,12 +158,12 @@ class TestNbGraderFeedback(BaseTestApp):
             fh.write("""c.NbGrader.db_students = [dict(id="foo")]\n""")
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p2.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1"])
+        run_nbgrader(["assign", "ps1"])
 
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p2.ipynb"))
-        run_python_module(["nbgrader", "autograde", "ps1"])
-        run_python_module(["nbgrader", "feedback", "ps1"])
+        run_nbgrader(["autograde", "ps1"])
+        run_nbgrader(["feedback", "ps1"])
 
         assert exists(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
         assert exists(join(course_dir, "feedback", "foo", "ps1", "p2.html"))
@@ -172,7 +172,7 @@ class TestNbGraderFeedback(BaseTestApp):
 
         self._empty_notebook(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         self._empty_notebook(join(course_dir, "autograded", "foo", "ps1", "p2.ipynb"))
-        run_python_module(["nbgrader", "feedback", "ps1", "--notebook", "p1", "--force"])
+        run_nbgrader(["feedback", "ps1", "--notebook", "p1", "--force"])
 
         assert exists(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
         assert exists(join(course_dir, "feedback", "foo", "ps1", "p2.html"))
@@ -184,12 +184,12 @@ class TestNbGraderFeedback(BaseTestApp):
             fh.write("""c.NbGrader.db_assignments = [dict(name="ps1")]\n""")
             fh.write("""c.NbGrader.db_students = [dict(id="foo")]\n""")
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1"])
+        run_nbgrader(["assign", "ps1"])
 
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "timestamp.txt"), "2015-02-02 15:58:23.948203 PST")
-        run_python_module(["nbgrader", "autograde", "ps1"])
-        run_python_module(["nbgrader", "feedback", "ps1"])
+        run_nbgrader(["autograde", "ps1"])
+        run_nbgrader(["feedback", "ps1"])
 
         assert isfile(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
         assert isfile(join(course_dir, "feedback", "foo", "ps1", "timestamp.txt"))
@@ -198,7 +198,7 @@ class TestNbGraderFeedback(BaseTestApp):
 
         self._empty_notebook(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         self._make_file(join(course_dir, "autograded", "foo", "ps1", "timestamp.txt"), "2015-02-02 16:58:23.948203 PST")
-        run_python_module(["nbgrader", "feedback", "ps1"])
+        run_nbgrader(["feedback", "ps1"])
 
         assert isfile(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
         assert isfile(join(course_dir, "feedback", "foo", "ps1", "timestamp.txt"))
@@ -211,13 +211,13 @@ class TestNbGraderFeedback(BaseTestApp):
             fh.write("""c.NbGrader.db_students = [dict(id="foo")]\n""")
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p2.ipynb"))
-        run_python_module(["nbgrader", "assign", "ps1"])
+        run_nbgrader(["assign", "ps1"])
 
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p2.ipynb"))
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "timestamp.txt"), "2015-02-02 15:58:23.948203 PST")
-        run_python_module(["nbgrader", "autograde", "ps1"])
-        run_python_module(["nbgrader", "feedback", "ps1"])
+        run_nbgrader(["autograde", "ps1"])
+        run_nbgrader(["feedback", "ps1"])
 
         assert exists(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
         assert exists(join(course_dir, "feedback", "foo", "ps1", "p2.html"))
@@ -229,7 +229,7 @@ class TestNbGraderFeedback(BaseTestApp):
         self._empty_notebook(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         self._empty_notebook(join(course_dir, "autograded", "foo", "ps1", "p2.ipynb"))
         self._make_file(join(course_dir, "autograded", "foo", "ps1", "timestamp.txt"), "2015-02-02 16:58:23.948203 PST")
-        run_python_module(["nbgrader", "feedback", "ps1", "--notebook", "p1"])
+        run_nbgrader(["feedback", "ps1", "--notebook", "p1"])
 
         assert exists(join(course_dir, "feedback", "foo", "ps1", "p1.html"))
         assert exists(join(course_dir, "feedback", "foo", "ps1", "p2.html"))

--- a/nbgrader/tests/apps/test_nbgrader_fetch.py
+++ b/nbgrader/tests/apps/test_nbgrader_fetch.py
@@ -1,7 +1,7 @@
 import os
 from os.path import join
 
-from .. import run_python_module
+from .. import run_nbgrader
 from .base import BaseTestApp
 from .conftest import notwindows
 
@@ -11,15 +11,15 @@ class TestNbGraderFetch(BaseTestApp):
 
     def _release(self, assignment, exchange, course_dir):
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "release", "ps1", "p1.ipynb"))
-        run_python_module([
-            "nbgrader", "release", assignment,
+        run_nbgrader([
+            "release", assignment,
             "--course", "abc101",
             "--TransferApp.exchange_directory={}".format(exchange)
         ])
 
     def _fetch(self, assignment, exchange, flags=None, retcode=0):
         cmd = [
-            "nbgrader", "fetch", assignment,
+            "fetch", assignment,
             "--course", "abc101",
             "--TransferApp.exchange_directory={}".format(exchange)
         ]
@@ -27,20 +27,20 @@ class TestNbGraderFetch(BaseTestApp):
         if flags is not None:
             cmd.extend(flags)
 
-        run_python_module(cmd, retcode=retcode)
+        run_nbgrader(cmd, retcode=retcode)
 
     def test_help(self):
         """Does the help display without error?"""
-        run_python_module(["nbgrader", "fetch", "--help-all"])
+        run_nbgrader(["fetch", "--help-all"])
 
     def test_no_course_id(self, exchange, course_dir):
         """Does releasing without a course id thrown an error?"""
         self._release("ps1", exchange, course_dir)
         cmd = [
-            "nbgrader", "fetch", "ps1",
+            "fetch", "ps1",
             "--TransferApp.exchange_directory={}".format(exchange)
         ]
-        run_python_module(cmd, retcode=1)
+        run_nbgrader(cmd, retcode=1)
 
     def test_fetch(self, exchange, course_dir):
         self._release("ps1", exchange, course_dir)

--- a/nbgrader/tests/apps/test_nbgrader_release.py
+++ b/nbgrader/tests/apps/test_nbgrader_release.py
@@ -1,7 +1,7 @@
 import os
 from os.path import join
 
-from .. import run_python_module
+from .. import run_nbgrader
 from .base import BaseTestApp
 from .conftest import notwindows
 
@@ -11,7 +11,7 @@ class TestNbGraderRelease(BaseTestApp):
 
     def _release(self, assignment, exchange, flags=None, retcode=0):
         cmd = [
-            "nbgrader", "release", assignment,
+            "release", assignment,
             "--course", "abc101",
             "--TransferApp.exchange_directory={}".format(exchange)
         ]
@@ -19,19 +19,19 @@ class TestNbGraderRelease(BaseTestApp):
         if flags is not None:
             cmd.extend(flags)
 
-        run_python_module(cmd, retcode=retcode)
+        run_nbgrader(cmd, retcode=retcode)
 
     def test_help(self):
         """Does the help display without error?"""
-        run_python_module(["nbgrader", "release", "--help-all"])
+        run_nbgrader(["release", "--help-all"])
 
     def test_no_course_id(self, exchange):
         """Does releasing without a course id thrown an error?"""
         cmd = [
-            "nbgrader", "release", "ps1",
+            "release", "ps1",
             "--TransferApp.exchange_directory={}".format(exchange)
         ]
-        run_python_module(cmd, retcode=1)
+        run_nbgrader(cmd, retcode=1)
 
     def test_release(self, exchange, course_dir):
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "release", "ps1", "p1.ipynb"))

--- a/nbgrader/tests/apps/test_nbgrader_submit.py
+++ b/nbgrader/tests/apps/test_nbgrader_submit.py
@@ -6,7 +6,7 @@ import stat
 from os.path import join, isfile
 
 from ...utils import parse_utc
-from .. import run_python_module
+from .. import run_nbgrader
 from .base import BaseTestApp
 from .conftest import notwindows
 
@@ -16,14 +16,14 @@ class TestNbGraderSubmit(BaseTestApp):
 
     def _release_and_fetch(self, assignment, exchange, cache, course_dir):
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "release", "ps1", "p1.ipynb"))
-        run_python_module([
-            "nbgrader", "release", assignment,
+        run_nbgrader([
+            "release", assignment,
             "--course", "abc101",
             "--TransferApp.cache_directory={}".format(cache),
             "--TransferApp.exchange_directory={}".format(exchange)
         ])
-        run_python_module([
-            "nbgrader", "fetch", assignment,
+        run_nbgrader([
+            "fetch", assignment,
             "--course", "abc101",
             "--TransferApp.cache_directory={}".format(cache),
             "--TransferApp.exchange_directory={}".format(exchange)
@@ -31,7 +31,7 @@ class TestNbGraderSubmit(BaseTestApp):
 
     def _submit(self, assignment, exchange, cache, flags=None, retcode=0):
         cmd = [
-            "nbgrader", "submit", assignment,
+            "submit", assignment,
             "--course", "abc101",
             "--TransferApp.cache_directory={}".format(cache),
             "--TransferApp.exchange_directory={}".format(exchange)
@@ -40,21 +40,21 @@ class TestNbGraderSubmit(BaseTestApp):
         if flags is not None:
             cmd.extend(flags)
 
-        run_python_module(cmd, retcode=retcode)
+        run_nbgrader(cmd, retcode=retcode)
 
     def test_help(self):
         """Does the help display without error?"""
-        run_python_module(["nbgrader", "submit", "--help-all"])
+        run_nbgrader(["submit", "--help-all"])
 
     def test_no_course_id(self, exchange, cache, course_dir):
         """Does releasing without a course id thrown an error?"""
         self._release_and_fetch("ps1", exchange, cache, course_dir)
         cmd = [
-            "nbgrader", "submit", "ps1",
+            "submit", "ps1",
             "--TransferApp.cache_directory={}".format(cache),
             "--TransferApp.exchange_directory={}".format(exchange)
         ]
-        run_python_module(cmd, retcode=1)
+        run_nbgrader(cmd, retcode=1)
 
     def test_submit(self, exchange, cache, course_dir):
         self._release_and_fetch("ps1", exchange, cache, course_dir)

--- a/nbgrader/tests/apps/test_nbgrader_validate.py
+++ b/nbgrader/tests/apps/test_nbgrader_validate.py
@@ -3,7 +3,7 @@ import sys
 
 from os.path import join
 
-from .. import run_python_module
+from .. import run_nbgrader
 from .base import BaseTestApp
 
 
@@ -16,112 +16,112 @@ class TestNbGraderValidate(BaseTestApp):
 
     def test_help(self):
         """Does the help display without error?"""
-        run_python_module(["nbgrader", "validate", "--help-all"])
+        run_nbgrader(["validate", "--help-all"])
 
     def test_validate_unchanged(self):
         """Does the validation fail on an unchanged notebook?"""
         self._copy_file(join("files", "submitted-unchanged.ipynb"), "submitted-unchanged.ipynb")
-        output = run_python_module(["nbgrader", "validate", "submitted-unchanged.ipynb"])
+        output = run_nbgrader(["validate", "submitted-unchanged.ipynb"], stdout=True)
         assert output.split(self.newline)[0] == "VALIDATION FAILED ON 3 CELL(S)! If you submit your assignment as it is, you WILL NOT"
 
     def test_validate_changed(self):
         """Does the validation pass on an changed notebook?"""
         self._copy_file(join("files", "submitted-changed.ipynb"), "submitted-changed.ipynb")
-        output = run_python_module(["nbgrader", "validate", "submitted-changed.ipynb"])
+        output = run_nbgrader(["validate", "submitted-changed.ipynb"], stdout=True)
         assert output == "Success! Your notebook passes all the tests.{}".format(self.newline)
 
     def test_invert_validate_unchanged(self):
         """Does the inverted validation pass on an unchanged notebook?"""
         self._copy_file(join("files", "submitted-unchanged.ipynb"), "submitted-unchanged.ipynb")
-        output = run_python_module(["nbgrader", "validate", "submitted-unchanged.ipynb", "--invert"])
+        output = run_nbgrader(["validate", "submitted-unchanged.ipynb", "--invert"], stdout=True)
         assert output.split(self.newline)[0] == "NOTEBOOK PASSED ON 1 CELL(S)!"
 
     def test_invert_validate_changed(self):
         """Does the inverted validation fail on a changed notebook?"""
         self._copy_file(join("files", "submitted-changed.ipynb"), "submitted-changed.ipynb")
-        output = run_python_module(["nbgrader", "validate", "submitted-changed.ipynb", "--invert"])
+        output = run_nbgrader(["validate", "submitted-changed.ipynb", "--invert"], stdout=True)
         assert output.split(self.newline)[0] == "NOTEBOOK PASSED ON 2 CELL(S)!"
 
     def test_grade_cell_changed(self):
         """Does the validate fail if a grade cell has changed?"""
         self._copy_file(join("files", "submitted-grade-cell-changed.ipynb"), "submitted-grade-cell-changed.ipynb")
-        output = run_python_module(["nbgrader", "validate", "submitted-grade-cell-changed.ipynb"])
+        output = run_nbgrader(["validate", "submitted-grade-cell-changed.ipynb"], stdout=True)
         assert output.split(self.newline)[0] == "THE CONTENTS OF 1 TEST CELL(S) HAVE CHANGED! This might mean that even though the tests"
 
     def test_grade_cell_changed_ignore_checksums(self):
         """Does the validate pass if a grade cell has changed but we're ignoring checksums?"""
         self._copy_file(join("files", "submitted-grade-cell-changed.ipynb"), "submitted-grade-cell-changed.ipynb")
-        output = run_python_module([
-            "nbgrader", "validate", "submitted-grade-cell-changed.ipynb",
+        output = run_nbgrader([
+            "validate", "submitted-grade-cell-changed.ipynb",
             "--DisplayAutoGrades.ignore_checksums=True"
-        ])
+        ], stdout=True)
         assert output.split(self.newline)[0] == "Success! Your notebook passes all the tests."
 
     def test_invert_grade_cell_changed(self):
         """Does the validate fail if a grade cell has changed, even with --invert?"""
         self._copy_file(join("files", "submitted-grade-cell-changed.ipynb"), "submitted-grade-cell-changed.ipynb")
-        output = run_python_module(["nbgrader", "validate", "submitted-grade-cell-changed.ipynb", "--invert"])
+        output = run_nbgrader(["validate", "submitted-grade-cell-changed.ipynb", "--invert"], stdout=True)
         assert output.split(self.newline)[0] == "THE CONTENTS OF 1 TEST CELL(S) HAVE CHANGED! This might mean that even though the tests"
 
     def test_invert_grade_cell_changed_ignore_checksums(self):
         """Does the validate fail if a grade cell has changed with --invert and ignoring checksums?"""
         self._copy_file(join("files", "submitted-grade-cell-changed.ipynb"), "submitted-grade-cell-changed.ipynb")
-        output = run_python_module([
-            "nbgrader", "validate", "submitted-grade-cell-changed.ipynb",
+        output = run_nbgrader([
+            "validate", "submitted-grade-cell-changed.ipynb",
             "--invert",
             "--DisplayAutoGrades.ignore_checksums=True"
-        ])
+        ], stdout=True)
         assert output.split(self.newline)[0] == "NOTEBOOK PASSED ON 2 CELL(S)!"
 
     def test_validate_unchanged_ignore_checksums(self):
         """Does the validation fail on an unchanged notebook with ignoring checksums?"""
         self._copy_file(join("files", "submitted-unchanged.ipynb"), "submitted-unchanged.ipynb")
-        output = run_python_module([
-            "nbgrader", "validate", "submitted-unchanged.ipynb",
+        output = run_nbgrader([
+            "validate", "submitted-unchanged.ipynb",
             "--DisplayAutoGrades.ignore_checksums=True"
-        ])
+        ], stdout=True)
         assert output.split(self.newline)[0] == "VALIDATION FAILED ON 1 CELL(S)! If you submit your assignment as it is, you WILL NOT"
 
     def test_locked_cell_changed(self):
         """Does the validate fail if a locked cell has changed?"""
         self._copy_file(join("files", "submitted-locked-cell-changed.ipynb"), "submitted-locked-cell-changed.ipynb")
-        output = run_python_module(["nbgrader", "validate", "submitted-locked-cell-changed.ipynb"])
+        output = run_nbgrader(["validate", "submitted-locked-cell-changed.ipynb"], stdout=True)
         assert output.split(self.newline)[0] == "THE CONTENTS OF 2 TEST CELL(S) HAVE CHANGED! This might mean that even though the tests"
 
     def test_locked_cell_changed_ignore_checksums(self):
         """Does the validate pass if a locked cell has changed but we're ignoring checksums?"""
         self._copy_file(join("files", "submitted-locked-cell-changed.ipynb"), "submitted-locked-cell-changed.ipynb")
-        output = run_python_module([
-            "nbgrader", "validate", "submitted-locked-cell-changed.ipynb",
+        output = run_nbgrader([
+            "validate", "submitted-locked-cell-changed.ipynb",
             "--DisplayAutoGrades.ignore_checksums=True"
-        ])
+        ], stdout=True)
         assert output.split(self.newline)[0] == "VALIDATION FAILED ON 1 CELL(S)! If you submit your assignment as it is, you WILL NOT"
 
     def test_invert_locked_cell_changed(self):
         """Does the validate fail if a locked cell has changed, even with --invert?"""
         self._copy_file(join("files", "submitted-locked-cell-changed.ipynb"), "submitted-locked-cell-changed.ipynb")
-        output = run_python_module(["nbgrader", "validate", "submitted-locked-cell-changed.ipynb", "--invert"])
+        output = run_nbgrader(["validate", "submitted-locked-cell-changed.ipynb", "--invert"], stdout=True)
         assert output.split(self.newline)[0] == "THE CONTENTS OF 2 TEST CELL(S) HAVE CHANGED! This might mean that even though the tests"
 
     def test_invert_locked_cell_changed_ignore_checksums(self):
         """Does the validate fail if a locked cell has changed with --invert and ignoring checksums?"""
         self._copy_file(join("files", "submitted-locked-cell-changed.ipynb"), "submitted-locked-cell-changed.ipynb")
-        output = run_python_module([
-            "nbgrader", "validate", "submitted-locked-cell-changed.ipynb",
+        output = run_nbgrader([
+            "validate", "submitted-locked-cell-changed.ipynb",
             "--invert",
             "--DisplayAutoGrades.ignore_checksums=True"
-        ])
+        ], stdout=True)
         assert output.split(self.newline)[0] == "NOTEBOOK PASSED ON 1 CELL(S)!"
 
     def test_invert_locked_cell_changed_ignore_checksums_json(self):
         """Does the validate fail if a locked cell has changed with --invert and ignoring checksums?"""
         self._copy_file(join("files", "submitted-locked-cell-changed.ipynb"), "submitted-locked-cell-changed.ipynb")
-        output = run_python_module([
-            "nbgrader", "validate", "submitted-locked-cell-changed.ipynb",
+        output = run_nbgrader([
+            "validate", "submitted-locked-cell-changed.ipynb",
             "--invert",
             "--json",
             "--DisplayAutoGrades.ignore_checksums=True"
-        ])
+        ], stdout=True)
         assert json.loads(output) == {
             "passed": [
                 {

--- a/nbgrader/tests/formgrader/conftest.py
+++ b/nbgrader/tests/formgrader/conftest.py
@@ -11,7 +11,7 @@ from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 
 from ...api import Gradebook
 from ...utils import rmtree
-from .. import run_python_module
+from .. import run_nbgrader
 from . import manager, bad_manager
 
 
@@ -72,13 +72,13 @@ def gradebook(request, tempdir):
         ))
 
     # run nbgrader assign
-    run_python_module([
-        "nbgrader", "assign", "Problem Set 1",
+    run_nbgrader([
+        "assign", "Problem Set 1",
         "--IncludeHeaderFooter.header=source/header.ipynb"
     ])
 
     # run the autograder
-    run_python_module(["nbgrader", "autograde", "Problem Set 1"])
+    run_nbgrader(["autograde", "Problem Set 1"])
 
     gb = Gradebook("sqlite:///gradebook.db")
 

--- a/nbgrader/tests/formgrader/test_nbgrader_formgrade.py
+++ b/nbgrader/tests/formgrader/test_nbgrader_formgrade.py
@@ -1,5 +1,5 @@
-from .. import run_python_module
+from .. import run_nbgrader
 
 
 def test_help():
-    run_python_module(["nbgrader", "formgrade", "--help-all"])
+    run_nbgrader(["formgrade", "--help-all"])

--- a/nbgrader/tests/nbextensions/conftest.py
+++ b/nbgrader/tests/nbextensions/conftest.py
@@ -15,9 +15,10 @@ from textwrap import dedent
 from nbformat import write as write_nb
 from nbformat.v4 import new_notebook
 
-from .. import run_python_module, copy_coverage_files
+from .. import run_nbgrader, copy_coverage_files
 from ...api import Gradebook
 from ...utils import rmtree
+
 
 @pytest.fixture(scope="module")
 def tempdir(request):
@@ -114,8 +115,8 @@ def nbserver(request, tempdir, coursedir, jupyter_config_dir, jupyter_data_dir, 
     env['JUPYTER_DATA_DIR'] = jupyter_data_dir
 
     nbextension_dir = os.path.join(jupyter_data_dir, "nbextensions")
-    run_python_module(["nbgrader", "extension", "install", "--nbextensions", nbextension_dir], env=env)
-    run_python_module(["nbgrader", "extension", "activate"], env=env)
+    run_nbgrader(["extension", "install", "--nbextensions", nbextension_dir], env=env)
+    run_nbgrader(["extension", "activate"], env=env)
 
     # create nbgrader_config.py file
     if sys.platform != 'win32':

--- a/nbgrader/tests/nbextensions/test_assignment_list.py
+++ b/nbgrader/tests/nbextensions/test_assignment_list.py
@@ -6,7 +6,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException, NoSuchElementException
 
-from .. import run_python_module
+from .. import run_nbgrader
 from .conftest import notwindows
 
 
@@ -98,8 +98,8 @@ def test_show_assignments_list(browser, class_files, tempdir):
     _wait(browser).until(EC.visibility_of_element_located((By.CSS_SELECTOR, "#submitted_assignments_list_placeholder")))
 
     # release an assignment
-    run_python_module(["nbgrader", "assign", "Problem Set 1"])
-    run_python_module(["nbgrader", "release", "Problem Set 1", "--course", "abc101"])
+    run_nbgrader(["assign", "Problem Set 1"])
+    run_nbgrader(["release", "Problem Set 1", "--course", "abc101"])
 
     # click the refresh button
     browser.find_element_by_css_selector("#refresh_assignments_list").click()
@@ -118,8 +118,8 @@ def test_multiple_released_assignments(browser, class_files, tempdir):
     _load_assignments_list(browser)
 
     # release another assignment
-    run_python_module(["nbgrader", "assign", "ps.01"])
-    run_python_module(["nbgrader", "release", "ps.01", "--course", "xyz 200"])
+    run_nbgrader(["assign", "ps.01"])
+    run_nbgrader(["release", "ps.01", "--course", "xyz 200"])
 
     # click the refresh button
     browser.find_element_by_css_selector("#refresh_assignments_list").click()


### PR DESCRIPTION
Fixes #463 by having tests create nbgrader apps in the same python session rather than calling out to subprocess. This was a little tricky to do because it involved a lot of monkeypatching of things like sys.stdout, but ultimately I think I have gotten it to work correctly!