### PR TITLE
Confirm no SSL when running jupyterhub

### DIFF
--- a/flit.ini
+++ b/flit.ini
@@ -10,6 +10,7 @@ requires = sqlalchemy
     nbformat
     traitlets
     jupyter_core
+    jupyter_client<4.2
     tornado
     six
     requests

--- a/nbgrader/tests/formgrader/manager.py
+++ b/nbgrader/tests/formgrader/manager.py
@@ -109,6 +109,7 @@ class HubAuthManager(DefaultManager):
         c.Authenticator.admin_users = set(['admin'])
         c.Authenticator.whitelist = set(['foobar', 'baz'])
         c.JupyterHub.log_level = "WARN"
+        c.JupyterHub.confirm_no_ssl = True
         """
     )
 
@@ -197,6 +198,7 @@ class HubAuthNotebookServerUserManager(HubAuthManager):
         c.JupyterHub.spawner_class = 'nbgrader.tests.formgrader.fakeuser.FakeUserSpawner'
         c.JupyterHub.admin_access = True
         c.JupyterHub.log_level = "WARN"
+        c.JupyterHub.confirm_no_ssl = True
         c.Authenticator.admin_users = set(['admin'])
         c.Authenticator.whitelist = set(['foobar', 'baz', 'quux'])
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ nbconvert
 nbformat
 traitlets
 jupyter_core
+jupyter_client<4.2
 tornado
 six
 requests


### PR DESCRIPTION
Fixes failing tests. Also pins `jupyter_client` to less than 4.2.