### PR TITLE
More helpful default comment box message

### DIFF
--- a/nbgrader/formgrader/static/js/models.js
+++ b/nbgrader/formgrader/static/js/models.js
@@ -120,7 +120,8 @@ var CommentUI = Backbone.View.extend({
         this.listenTo(this.model, "request", this.animateSaving);
         this.listenTo(this.model, "sync", this.animateSaved);
 
-        this.$comment.attr("placeholder", this.model.get("auto_comment") || "Comments");
+        var default_msg = "Type any comments here (supports Markdown and MathJax)";
+        this.$comment.attr("placeholder", this.model.get("auto_comment") || default_msg);
 
         this.render();
         autosize(this.$comment);


### PR DESCRIPTION
Fixes #462 by changing the default message to:

![image](https://cloud.githubusercontent.com/assets/83444/14084775/4e003ff6-f4d1-11e5-9bdc-81ac11b871e4.png)

@willingc @dsblank do you think this is clear enough that it will render in the feedback (given that it doesn't actually render in the formgrader interface)? Or do you think I should also add something indicating specifically that markdown added here will render properly in the feedback? 