### PR TITLE
Run notebook/formgrader/jupyterhub on random ports during tests

### DIFF
--- a/nbgrader/tests/__init__.py
+++ b/nbgrader/tests/__init__.py
@@ -5,6 +5,7 @@ import subprocess as sp
 import sys
 import logging
 import warnings
+import socket
 
 from six import StringIO
 from nbformat.v4 import new_code_cell, new_markdown_cell
@@ -178,3 +179,18 @@ def run_nbgrader(args, retcode=0, env=None, stdout=False):
             "process returned an unexpected return code: {}".format(true_retcode))
 
     return out
+
+
+def get_free_ports(n):
+    """Based on https://gist.github.com/dbrgn/3979133"""
+    ports = []
+    sockets = []
+    for i in range(n):
+        s = socket.socket()
+        s.bind(('', 0))
+        port = s.getsockname()[1]
+        ports.append(port)
+        sockets.append(s)
+    for s in sockets:
+        s.close()
+    return ports

--- a/nbgrader/tests/nbextensions/conftest.py
+++ b/nbgrader/tests/nbextensions/conftest.py
@@ -15,7 +15,7 @@ from textwrap import dedent
 from nbformat import write as write_nb
 from nbformat.v4 import new_notebook
 
-from .. import run_nbgrader, copy_coverage_files
+from .. import run_nbgrader, copy_coverage_files, get_free_ports
 from ...api import Gradebook
 from ...utils import rmtree
 
@@ -109,7 +109,13 @@ def class_files(coursedir):
 
 
 @pytest.fixture(scope="module")
-def nbserver(request, tempdir, coursedir, jupyter_config_dir, jupyter_data_dir, exchange, cache):
+def port():
+    nbserver_port, = get_free_ports(1)
+    return nbserver_port
+
+
+@pytest.fixture(scope="module")
+def nbserver(request, port, tempdir, coursedir, jupyter_config_dir, jupyter_data_dir, exchange, cache):
     env = os.environ.copy()
     env['JUPYTER_CONFIG_DIR'] = jupyter_config_dir
     env['JUPYTER_DATA_DIR'] = jupyter_data_dir
@@ -143,7 +149,7 @@ def nbserver(request, tempdir, coursedir, jupyter_config_dir, jupyter_data_dir, 
     nbserver = sp.Popen([
         sys.executable, "-m", "jupyter", "notebook",
         "--no-browser",
-        "--port", "9000"], **kwargs)
+        "--port", str(port)], **kwargs)
 
     def fin():
         if sys.platform == 'win32':

--- a/nbgrader/tests/nbextensions/test_assignment_list.py
+++ b/nbgrader/tests/nbextensions/test_assignment_list.py
@@ -14,9 +14,9 @@ def _wait(browser):
     return WebDriverWait(browser, 30)
 
 
-def _load_assignments_list(browser, retries=5):
+def _load_assignments_list(browser, port, retries=5):
     # go to the correct page
-    browser.get("http://localhost:9000/tree")
+    browser.get("http://localhost:{}/tree".format(port))
 
     def page_loaded(browser):
         return browser.execute_script(
@@ -29,7 +29,7 @@ def _load_assignments_list(browser, retries=5):
         if retries > 0:
             print("Retrying page load...")
             # page timeout, but sometimes this happens, so try refreshing?
-            _load_assignments_list(browser, retries=retries - 1)
+            _load_assignments_list(browser, port, retries=retries - 1)
         else:
             print("Failed to load the page too many times")
             raise
@@ -89,8 +89,8 @@ def _sort_rows(x):
 
 @pytest.mark.nbextensions
 @notwindows
-def test_show_assignments_list(browser, class_files, tempdir):
-    _load_assignments_list(browser)
+def test_show_assignments_list(browser, port, class_files, tempdir):
+    _load_assignments_list(browser, port)
 
     # make sure all the placeholders ar initially showing
     _wait(browser).until(EC.visibility_of_element_located((By.CSS_SELECTOR, "#released_assignments_list_placeholder")))
@@ -114,8 +114,8 @@ def test_show_assignments_list(browser, class_files, tempdir):
 
 @pytest.mark.nbextensions
 @notwindows
-def test_multiple_released_assignments(browser, class_files, tempdir):
-    _load_assignments_list(browser)
+def test_multiple_released_assignments(browser, port, class_files, tempdir):
+    _load_assignments_list(browser, port)
 
     # release another assignment
     run_nbgrader(["assign", "ps.01"])
@@ -136,8 +136,8 @@ def test_multiple_released_assignments(browser, class_files, tempdir):
 
 @pytest.mark.nbextensions
 @notwindows
-def test_fetch_assignment(browser, class_files, tempdir):
-    _load_assignments_list(browser)
+def test_fetch_assignment(browser, port, class_files, tempdir):
+    _load_assignments_list(browser, port)
 
     # click the "fetch" button
     _wait(browser).until(EC.invisibility_of_element_located((By.CSS_SELECTOR, "#released_assignments_list_placeholder")))
@@ -163,8 +163,8 @@ def test_fetch_assignment(browser, class_files, tempdir):
 
 @pytest.mark.nbextensions
 @notwindows
-def test_submit_assignment(browser, class_files, tempdir):
-    _load_assignments_list(browser)
+def test_submit_assignment(browser, port, class_files, tempdir):
+    _load_assignments_list(browser, port)
 
     # submit it
     _wait(browser).until(EC.invisibility_of_element_located((By.CSS_SELECTOR, "#fetched_assignments_list_placeholder")))
@@ -195,8 +195,8 @@ def test_submit_assignment(browser, class_files, tempdir):
 
 @pytest.mark.nbextensions
 @notwindows
-def test_fetch_second_assignment(browser, class_files, tempdir):
-    _load_assignments_list(browser)
+def test_fetch_second_assignment(browser, port, class_files, tempdir):
+    _load_assignments_list(browser, port)
 
     # click the "fetch" button
     _wait(browser).until(EC.invisibility_of_element_located((By.CSS_SELECTOR, "#released_assignments_list_placeholder")))
@@ -227,8 +227,8 @@ def test_fetch_second_assignment(browser, class_files, tempdir):
 
 @pytest.mark.nbextensions
 @notwindows
-def test_submit_other_assignment(browser, class_files, tempdir):
-    _load_assignments_list(browser)
+def test_submit_other_assignment(browser, port, class_files, tempdir):
+    _load_assignments_list(browser, port)
 
     # submit it
     _wait(browser).until(EC.invisibility_of_element_located((By.CSS_SELECTOR, "#fetched_assignments_list_placeholder")))
@@ -251,8 +251,8 @@ def test_submit_other_assignment(browser, class_files, tempdir):
 
 @pytest.mark.nbextensions
 @notwindows
-def test_validate_ok(browser, class_files, tempdir):
-    _load_assignments_list(browser)
+def test_validate_ok(browser, port, class_files, tempdir):
+    _load_assignments_list(browser, port)
 
     # expand the assignment to show the notebooks
     _wait(browser).until(EC.invisibility_of_element_located((By.CSS_SELECTOR, "#fetched_assignments_list_placeholder")))
@@ -276,8 +276,8 @@ def test_validate_ok(browser, class_files, tempdir):
 
 @pytest.mark.nbextensions
 @notwindows
-def test_validate_failure(browser, class_files, tempdir):
-    _load_assignments_list(browser)
+def test_validate_failure(browser, port, class_files, tempdir):
+    _load_assignments_list(browser, port)
 
     # expand the assignment to show the notebooks
     _wait(browser).until(EC.invisibility_of_element_located((By.CSS_SELECTOR, "#fetched_assignments_list_placeholder")))

--- a/nbgrader/tests/nbextensions/test_create_assignment.py
+++ b/nbgrader/tests/nbextensions/test_create_assignment.py
@@ -12,9 +12,9 @@ def _wait(browser):
     return WebDriverWait(browser, 30)
 
 
-def _load_notebook(browser, retries=5):
+def _load_notebook(browser, port, retries=5):
     # go to the correct page
-    browser.get("http://localhost:9000/notebooks/blank.ipynb")
+    browser.get("http://localhost:{}/notebooks/blank.ipynb".format(port))
 
     def page_loaded(browser):
         return browser.execute_script(
@@ -27,7 +27,7 @@ def _load_notebook(browser, retries=5):
         if retries > 0:
             print("Retrying page load...")
             # page timeout, but sometimes this happens, so try refreshing?
-            _load_notebook(browser, retries=retries - 1)
+            _load_notebook(browser, port, retries=retries - 1)
         else:
             print("Failed to load the page too many times")
             raise
@@ -131,8 +131,8 @@ def _dismiss_modal(browser):
 
 
 @pytest.mark.nbextensions
-def test_manual_cell(browser):
-    _load_notebook(browser)
+def test_manual_cell(browser, port):
+    _load_notebook(browser, port)
     _activate_toolbar(browser)
 
     # does the nbgrader metadata exist?
@@ -166,8 +166,8 @@ def test_manual_cell(browser):
 
 
 @pytest.mark.nbextensions
-def test_solution_cell(browser):
-    _load_notebook(browser)
+def test_solution_cell(browser, port):
+    _load_notebook(browser, port)
     _activate_toolbar(browser)
 
     # does the nbgrader metadata exist?
@@ -195,8 +195,8 @@ def test_solution_cell(browser):
 
 
 @pytest.mark.nbextensions
-def test_tests_cell(browser):
-    _load_notebook(browser)
+def test_tests_cell(browser, port):
+    _load_notebook(browser, port)
     _activate_toolbar(browser)
 
     # does the nbgrader metadata exist?
@@ -232,8 +232,8 @@ def test_tests_cell(browser):
 
 
 @pytest.mark.nbextensions
-def test_locked_cell(browser):
-    _load_notebook(browser)
+def test_locked_cell(browser, port):
+    _load_notebook(browser, port)
     _activate_toolbar(browser)
 
     # does the nbgrader metadata exist?
@@ -263,8 +263,8 @@ def test_locked_cell(browser):
 
 
 @pytest.mark.nbextensions
-def test_grade_cell_css(browser):
-    _load_notebook(browser)
+def test_grade_cell_css(browser, port):
+    _load_notebook(browser, port)
     _activate_toolbar(browser)
 
     # make it manually graded
@@ -319,8 +319,8 @@ def test_grade_cell_css(browser):
 
 
 @pytest.mark.nbextensions
-def test_tabbing(browser):
-    _load_notebook(browser)
+def test_tabbing(browser, port):
+    _load_notebook(browser, port)
     _activate_toolbar(browser)
 
     # make it manually graded
@@ -357,8 +357,8 @@ def test_tabbing(browser):
 
 
 @pytest.mark.nbextensions
-def test_total_points(browser):
-    _load_notebook(browser)
+def test_total_points(browser, port):
+    _load_notebook(browser, port)
     _activate_toolbar(browser)
 
     # make sure the total points is zero
@@ -418,8 +418,8 @@ def test_total_points(browser):
 
 
 @pytest.mark.nbextensions
-def test_cell_ids(browser):
-    _load_notebook(browser)
+def test_cell_ids(browser, port):
+    _load_notebook(browser, port)
     _activate_toolbar(browser)
 
     # turn it into a cell with an id


### PR DESCRIPTION
Sometimes the subprocesses don't exit cleanly if the test fail, which then makes subsequent tests fail (because the ports aren't available). Also, if there is something else already running on the ports that are expected to be free, the tests will fail. So, this makes the subprocesses run on random ports instead.

Ideally, the subprocesses should always exit cleanly, but that's a separate issue.