### PR TITLE
Allow code stubs to be language specific

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: nbgrader
-  version: "0.3.0"
+  version: "0.4.0.dev0"
 
 source:
   path: ..

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -12,6 +12,18 @@ requirements:
   build:
     - python
     - setuptools
+    - sqlalchemy
+    - python-dateutil
+    - jupyter
+    - notebook >=4.2
+    - nbconvert >=4.2
+    - nbformat
+    - traitlets
+    - jupyter_core
+    - jupyter_client
+    - tornado
+    - six
+    - requests
   run:
     - python
     - sqlalchemy

--- a/nbgrader/_version.py
+++ b/nbgrader/_version.py
@@ -1,2 +1,2 @@
-version_info = (0, 3, 0)
+version_info = (0, 4, 0, 'dev')
 __version__ = '.'.join(map(str, version_info))

--- a/nbgrader/preprocessors/clearsolutions.py
+++ b/nbgrader/preprocessors/clearsolutions.py
@@ -41,6 +41,32 @@ class ClearSolutions(NbGraderPreprocessor):
         )
     )
 
+    def _config_changed(self, name, old, new):
+        def check(x):
+            if x in new.ClearSolutions:
+                if not isinstance(new.ClearSolutions[x], dict):
+                    return True
+            return False
+
+        def fix(new, x):
+            self.log.warn(
+                "The ClearSolutions.{var} option must now be given as a "
+                "dictionary with keys for the language of the notebook. I will "
+                "automatically convert ClearSolutions.{var} to a dictionary "
+                "with a key for 'python', but note that this functionality may "
+                "be removed in future releases.".format(var=x))
+            new.ClearSolutions[x] = dict(python=new.ClearSolutions[x])
+            return new
+
+        if check('code_stub'):
+            fix(new, 'code_stub')
+        if check('begin_solution_delimeter'):
+            fix(new, 'begin_solution_delimeter')
+        if check('end_solution_delimeter'):
+            fix(new, 'end_solution_delimeter')
+
+        super(ClearSolutions, self)._config_changed(name, old, new)
+
     def _replace_solution_region(self, cell, language):
         """Find a region in the cell that is delimeted by
         `self.begin_solution_delimeter` and `self.end_solution_delimeter` (e.g.

--- a/nbgrader/preprocessors/clearsolutions.py
+++ b/nbgrader/preprocessors/clearsolutions.py
@@ -65,6 +65,13 @@ class ClearSolutions(NbGraderPreprocessor):
         if check('end_solution_delimeter'):
             fix(new, 'end_solution_delimeter')
 
+        if 'comment_mark' in new.ClearSolutions:
+            self.log.warn(
+                "The ClearSolutions.comment_mark config option is deprecated. "
+                "Please include the comment mark in ClearSolutions.begin_solution_delimeter "
+                "and ClearSolutions.end_solution_delimeter instead.")
+            del new.ClearSolutions.comment_mark
+
         super(ClearSolutions, self)._config_changed(name, old, new)
 
     def _replace_solution_region(self, cell, language):

--- a/nbgrader/preprocessors/clearsolutions.py
+++ b/nbgrader/preprocessors/clearsolutions.py
@@ -1,4 +1,4 @@
-from traitlets import Unicode, Bool
+from traitlets import Dict, Unicode, Bool
 from textwrap import dedent
 
 from .. import utils
@@ -7,8 +7,8 @@ from . import NbGraderPreprocessor
 
 class ClearSolutions(NbGraderPreprocessor):
 
-    code_stub = Unicode(
-        "# YOUR CODE HERE\nraise NotImplementedError()",
+    code_stub = Dict(
+        dict(python="# YOUR CODE HERE\nraise NotImplementedError()"),
         config=True,
         help="The code snippet that will replace code solutions")
 
@@ -17,20 +17,15 @@ class ClearSolutions(NbGraderPreprocessor):
         config=True,
         help="The text snippet that will replace written solutions")
 
-    comment_mark = Unicode(
-        "#",
+    begin_solution_delimeter = Dict(
+        dict(python="### BEGIN SOLUTION"),
         config=True,
-        help="The comment mark to prefix solution delimiters")
+        help="The delimiter marking the beginning of a solution")
 
-    begin_solution_delimeter = Unicode(
-        "## BEGIN SOLUTION",
+    end_solution_delimeter = Dict(
+        dict(python="### END SOLUTION"),
         config=True,
-        help="The delimiter marking the beginning of a solution (excluding comment mark)")
-
-    end_solution_delimeter = Unicode(
-        "## END SOLUTION",
-        config=True,
-        help="The delimiter marking the end of a solution (excluding comment mark)")
+        help="The delimiter marking the end of a solution")
 
     enforce_metadata = Bool(
         True,
@@ -46,18 +41,10 @@ class ClearSolutions(NbGraderPreprocessor):
         )
     )
 
-    @property
-    def begin_solution(self):
-        return "{}{}".format(self.comment_mark, self.begin_solution_delimeter)
-
-    @property
-    def end_solution(self):
-        return "{}{}".format(self.comment_mark, self.end_solution_delimeter)
-
-    def _replace_solution_region(self, cell):
+    def _replace_solution_region(self, cell, language):
         """Find a region in the cell that is delimeted by
-        `self.begin_solution` and `self.end_solution` (e.g. ### BEGIN
-        SOLUTION and ### END SOLUTION). Replace that region either
+        `self.begin_solution_delimeter` and `self.end_solution_delimeter` (e.g.
+        ### BEGIN SOLUTION and ### END SOLUTION). Replace that region either
         with the code stub or text stub, depending the cell type.
 
         This modifies the cell in place, and then returns True if a
@@ -67,17 +54,19 @@ class ClearSolutions(NbGraderPreprocessor):
         # pull out the cell input/source
         lines = cell.source.split("\n")
         if cell.cell_type == "code":
-            stub_lines = self.code_stub.split("\n")
+            stub_lines = self.code_stub[language].split("\n")
         else:
             stub_lines = self.text_stub.split("\n")
 
         new_lines = []
         in_solution = False
         replaced_solution = False
+        begin = self.begin_solution_delimeter[language]
+        end = self.end_solution_delimeter[language]
 
         for line in lines:
             # begin the solution area
-            if line.strip() == self.begin_solution:
+            if line.strip() == begin:
 
                 # check to make sure this isn't a nested BEGIN
                 # SOLUTION region
@@ -89,12 +78,12 @@ class ClearSolutions(NbGraderPreprocessor):
                 replaced_solution = True
 
                 # replace it with the stub, indented as necessary
-                indent = line[:line.find(self.begin_solution)]
+                indent = line[:line.find(begin)]
                 for stub_line in stub_lines:
                     new_lines.append(indent + stub_line)
 
             # end the solution area
-            elif line.strip() == self.end_solution:
+            elif line.strip() == end:
                 in_solution = False
 
             # add lines as long as it's not in the solution area
@@ -112,6 +101,21 @@ class ClearSolutions(NbGraderPreprocessor):
         return replaced_solution
 
     def preprocess(self, nb, resources):
+        language = nb.metadata.get("kernelspec", {}).get("language", "python")
+        if language not in self.code_stub:
+            raise ValueError(
+                "language '{}' has not been specified in "
+                "ClearSolutions.code_stub".format(language))
+        if language not in self.begin_solution_delimeter:
+            raise ValueError(
+                "language '{}' has not been specified in "
+                "ClearSolutions.begin_solution_delimeter".format(language))
+        if language not in self.end_solution_delimeter:
+            raise ValueError(
+                "language '{}' has not been specified in "
+                "ClearSolutions.end_solution_delimeter".format(language))
+
+        resources["language"] = language
         nb, resources = super(ClearSolutions, self).preprocess(nb, resources)
         if 'celltoolbar' in nb.metadata:
             del nb.metadata['celltoolbar']
@@ -119,7 +123,8 @@ class ClearSolutions(NbGraderPreprocessor):
 
     def preprocess_cell(self, cell, resources, cell_index):
         # replace solution regions with the relevant stubs
-        replaced_solution = self._replace_solution_region(cell)
+        language = resources["language"]
+        replaced_solution = self._replace_solution_region(cell, language)
 
         # determine whether the cell is a solution/grade cell
         is_solution = utils.is_solution(cell)
@@ -139,7 +144,7 @@ class ClearSolutions(NbGraderPreprocessor):
         # there are parts of the cells that should be preserved
         if is_solution and not replaced_solution:
             if cell.cell_type == 'code':
-                cell.source = self.code_stub
+                cell.source = self.code_stub[language]
             else:
                 cell.source = self.text_stub
 

--- a/nbgrader/tests/preprocessors/test_clearsolutions.py
+++ b/nbgrader/tests/preprocessors/test_clearsolutions.py
@@ -211,3 +211,22 @@ class TestClearSolutions(BaseTestPreprocessor):
         assert pp.code_stub == dict(python="foo")
         assert pp.begin_solution_delimeter == dict(python="bar")
         assert pp.end_solution_delimeter == dict(python="baz")
+
+    def test_language_missing(self, preprocessor):
+        nb = self._read_nb(os.path.join("files", "test.ipynb"))
+        nb.metadata['kernelspec'] = {}
+        nb.metadata['kernelspec']['language'] = "javascript"
+
+        with pytest.raises(ValueError):
+            preprocessor.preprocess(nb, {})
+
+        preprocessor.code_stub = dict(javascript="foo")
+        with pytest.raises(ValueError):
+            preprocessor.preprocess(nb, {})
+
+        preprocessor.begin_solution_delimeter = dict(javascript="bar")
+        with pytest.raises(ValueError):
+            preprocessor.preprocess(nb, {})
+
+        preprocessor.end_solution_delimeter = dict(javascript="baz")
+        preprocessor.preprocess(nb, {})

--- a/nbgrader/tests/preprocessors/test_clearsolutions.py
+++ b/nbgrader/tests/preprocessors/test_clearsolutions.py
@@ -2,6 +2,7 @@ import pytest
 import os
 
 from textwrap import dedent
+from traitlets.config import Config
 from ...preprocessors import ClearSolutions
 from .base import BaseTestPreprocessor
 from .. import create_code_cell, create_text_cell
@@ -199,3 +200,14 @@ class TestClearSolutions(BaseTestPreprocessor):
         nb.metadata['celltoolbar'] = 'Create Assignment'
         nb = preprocessor.preprocess(nb, {})[0]
         assert 'celltoolbar' not in nb.metadata
+
+    def test_old_config(self):
+        """Are deprecations handled cleanly?"""
+        c = Config()
+        c.ClearSolutions.code_stub = "foo"
+        c.ClearSolutions.begin_solution_delimeter = "bar"
+        c.ClearSolutions.end_solution_delimeter = "baz"
+        pp = ClearSolutions(config=c)
+        assert pp.code_stub == dict(python="foo")
+        assert pp.begin_solution_delimeter == dict(python="bar")
+        assert pp.end_solution_delimeter == dict(python="baz")


### PR DESCRIPTION
Fixes #517

The idea here is that you can specify the code stubs and solution region delimeters for the `ClearSolutions` preprocessor as a dictionary keyed by language, where the language should be the same as the language of the kernelspec in the notebook metadata. This way, nbgrader can flexibly handle assignments with notebooks that have different kernels. For example, the config file might look like:

```python
c = get_config()
c.ClearSolutions.code_stub = {
    "python": "# YOUR CODE HERE\nraise NotImplementedError()",
    "javascript": "// YOUR CODE HERE\nthrow new Error();"
}
c.ClearSolutions.begin_solution_delimeter = {
    "python": "### BEGIN SOLUTION",
    "javascript": "// BEGIN SOLUTION"
}
c.ClearSolutions.end_solution_delimeter = {
    "python": "### END SOLUTION",
    "javascript": "// END SOLUTION"
}
```

@randy3k does this seem like it would satisfy what you were looking for?