### PR TITLE
Close db engine

### DIFF
--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1018,11 +1018,16 @@ class Gradebook(object):
 
         """
         # create the connection to the database
-        engine = create_engine(db_url)
-        self.db = scoped_session(sessionmaker(autoflush=True, bind=engine))
+        self.engine = create_engine(db_url)
+        self.db = scoped_session(sessionmaker(autoflush=True, bind=self.engine))
 
         # this creates all the tables in the database if they don't already exist
-        Base.metadata.create_all(bind=engine)
+        Base.metadata.create_all(bind=self.engine)
+
+    def close(self):
+        """Close the connection to the database."""
+        self.db.remove()
+        self.engine.dispose()
 
     #### Students
 

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1025,7 +1025,14 @@ class Gradebook(object):
         Base.metadata.create_all(bind=self.engine)
 
     def close(self):
-        """Close the connection to the database."""
+        """Close the connection to the database.
+
+        It is important to call this method after you are done using the
+        gradebook. In particular, if you create multiple instances of the
+        gradebook without closing them, you may run into errors where there
+        are too many open connections to the database.
+
+        """
         self.db.remove()
         self.engine.dispose()
 

--- a/nbgrader/apps/assignapp.py
+++ b/nbgrader/apps/assignapp.py
@@ -186,13 +186,13 @@ class AssignApp(BaseNbConvertApp):
 
         # no added or removed notebooks, so nothing to do
         if old_notebook_ids == new_notebook_ids:
-            gb.db.close()
+            gb.close()
             return
 
         # some notebooks have been removed, but there are submissions associated
         # with the assignment, so we don't want to overwrite stuff
         if len(assignment.submissions) > 0:
-            gb.db.close()
+            gb.close()
             self.fail("Cannot modify existing assignment '%s' because there are submissions associated with it", assignment)
 
         # remove the old notebooks
@@ -200,7 +200,7 @@ class AssignApp(BaseNbConvertApp):
             self.log.warning("Removing notebook '%s' from the gradebook", notebook_id)
             gb.remove_notebook(notebook_id, assignment_id)
 
-        gb.db.close()
+        gb.close()
 
     def init_assignment(self, assignment_id, student_id):
         super(AssignApp, self).init_assignment(assignment_id, student_id)
@@ -219,7 +219,7 @@ class AssignApp(BaseNbConvertApp):
                 self.log.info("Updating/creating assignment '%s': %s", assignment_id, assignment)
                 gb = Gradebook(self.db_url)
                 gb.update_or_create_assignment(assignment_id, **assignment)
-                gb.db.close()
+                gb.close()
 
                 # check if there are any extra notebooks in the db that are no longer
                 # part of the assignment, and if so, remove them

--- a/nbgrader/apps/autogradeapp.py
+++ b/nbgrader/apps/autogradeapp.py
@@ -152,7 +152,7 @@ class AutogradeApp(BaseNbConvertApp):
             self.log.info("Creating/updating student with ID '%s': %s", student_id, student)
             gb = Gradebook(self.db_url)
             gb.update_or_create_student(student_id, **student)
-            gb.db.close()
+            gb.close()
         else:
             self.fail("No student with ID '%s' exists in the config", student_id)
 
@@ -170,7 +170,7 @@ class AutogradeApp(BaseNbConvertApp):
                 self.log.warning("%s is %s seconds late", submission, submission.total_seconds_late)
         else:
             submission = gb.update_or_create_submission(assignment_id, student_id)
-        gb.db.close()
+        gb.close()
 
         # copy files over from the source directory
         self.log.info("Overwriting files with master versions from the source directory")
@@ -200,7 +200,7 @@ class AutogradeApp(BaseNbConvertApp):
                 continue
             else:
                 notebooks.append(notebook)
-        gb.db.close()
+        gb.close()
         self.notebooks = notebooks
 
     def _init_preprocessors(self):

--- a/nbgrader/apps/exportapp.py
+++ b/nbgrader/apps/exportapp.py
@@ -63,4 +63,4 @@ class ExportApp(NbGrader):
         try:
             self.plugin_inst.export(gradebook)
         finally:
-            gradebook.db.close()
+            gradebook.close()

--- a/nbgrader/apps/formgradeapp.py
+++ b/nbgrader/apps/formgradeapp.py
@@ -114,7 +114,7 @@ class FormgradeApp(NbGrader):
         ioloop.IOLoop.current().stop()
 
         # close the gradebook
-        self.tornado_settings['nbgrader_gradebook'].db.close()
+        self.tornado_settings['nbgrader_gradebook'].close()
 
     def build_extra_config(self):
         extra_config = super(FormgradeApp, self).build_extra_config()

--- a/nbgrader/docs/source/api/gradebook.rst
+++ b/nbgrader/docs/source/api/gradebook.rst
@@ -7,6 +7,8 @@ Gradebook
 
     .. automethod:: __init__
 
+    .. automethod:: close
+
     .. autoattribute:: students
 
     .. automethod:: add_student

--- a/nbgrader/docs/source/user_guide/extract_grades.py
+++ b/nbgrader/docs/source/user_guide/extract_grades.py
@@ -38,3 +38,7 @@ grades.to_csv('grades.csv')
 # Print out what the grades look like
 with open('grades.csv', 'r') as fh:
     print(fh.read())
+
+# Close the connection to the database
+gb.close()
+

--- a/nbgrader/preprocessors/getgrades.py
+++ b/nbgrader/preprocessors/getgrades.py
@@ -32,7 +32,7 @@ class GetGrades(NbGraderPreprocessor):
             resources['nbgrader']['late_penalty'] = late_penalty
 
         finally:
-            self.gradebook.db.close()
+            self.gradebook.close()
 
         return nb, resources
 

--- a/nbgrader/preprocessors/latesubmissions.py
+++ b/nbgrader/preprocessors/latesubmissions.py
@@ -70,7 +70,7 @@ class AssignLatePenalties(NbGraderPreprocessor):
                     self.gradebook.db.commit()
 
         finally:
-            self.gradebook.db.close()
+            self.gradebook.close()
 
         return nb, resources
 

--- a/nbgrader/preprocessors/overwritecells.py
+++ b/nbgrader/preprocessors/overwritecells.py
@@ -19,7 +19,7 @@ class OverwriteCells(NbGraderPreprocessor):
         try:
             nb, resources = super(OverwriteCells, self).preprocess(nb, resources)
         finally:
-            self.gradebook.db.close()
+            self.gradebook.close()
 
         return nb, resources
 

--- a/nbgrader/preprocessors/saveautogrades.py
+++ b/nbgrader/preprocessors/saveautogrades.py
@@ -20,7 +20,7 @@ class SaveAutoGrades(NbGraderPreprocessor):
             # process the cells
             nb, resources = super(SaveAutoGrades, self).preprocess(nb, resources)
         finally:
-            self.gradebook.db.close()
+            self.gradebook.close()
 
         return nb, resources
 

--- a/nbgrader/preprocessors/savecells.py
+++ b/nbgrader/preprocessors/savecells.py
@@ -82,7 +82,7 @@ class SaveCells(NbGraderPreprocessor):
             self._create_notebook()
 
         finally:
-            self.gradebook.db.close()
+            self.gradebook.close()
 
         return nb, resources
 

--- a/nbgrader/tests/api/test_gradebook.py
+++ b/nbgrader/tests/api/test_gradebook.py
@@ -9,7 +9,7 @@ from ...api import InvalidEntry, MissingEntry
 def gradebook(request):
     gb = api.Gradebook("sqlite:///:memory:")
     def fin():
-        gb.db.close()
+        gb.close()
     request.addfinalizer(fin)
     return gb
 

--- a/nbgrader/tests/api/test_models.py
+++ b/nbgrader/tests/api/test_models.py
@@ -17,7 +17,8 @@ def db(request):
     api.Base.metadata.create_all(bind=engine)
 
     def fin():
-        db.close()
+        db.remove()
+        engine.dispose()
     request.addfinalizer(fin)
 
     return db

--- a/nbgrader/tests/apps/test_nbgrader_assign.py
+++ b/nbgrader/tests/apps/test_nbgrader_assign.py
@@ -86,7 +86,7 @@ class TestNbGraderAssign(BaseTestApp):
         notebook = gb.find_notebook("test", "ps1")
         assert len(notebook.grade_cells) == 6
 
-        gb.db.close()
+        gb.close()
 
     def test_force(self, course_dir):
         """Ensure the force option works properly"""
@@ -180,7 +180,7 @@ class TestNbGraderAssign(BaseTestApp):
         with pytest.raises(InvalidRequestError):
             gb.db.refresh(notebook2)
 
-        gb.db.close()
+        gb.close()
 
     def test_add_extra_notebooks_with_submissions(self, db, course_dir):
         """Is an error thrown when new notebooks are added and there are existing submissions?"""
@@ -200,7 +200,7 @@ class TestNbGraderAssign(BaseTestApp):
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "test2.ipynb"))
         run_nbgrader(["assign", "ps1", "--db", db, "--force"], retcode=1)
 
-        gb.db.close()
+        gb.close()
 
     def test_remove_extra_notebooks_with_submissions(self, db, course_dir):
         """Is an error thrown when notebooks are removed and there are existing submissions?"""
@@ -221,7 +221,7 @@ class TestNbGraderAssign(BaseTestApp):
         os.remove(join(course_dir, "source", "ps1", "test2.ipynb"))
         run_nbgrader(["assign", "ps1", "--db", db, "--force"], retcode=1)
 
-        gb.db.close()
+        gb.close()
 
     def test_same_notebooks_with_submissions(self, db, course_dir):
         """Is it ok to run nbgrader assign with the same notebooks and existing submissions?"""
@@ -248,7 +248,7 @@ class TestNbGraderAssign(BaseTestApp):
         gb.db.refresh(submission)
         gb.db.refresh(submission_notebook)
 
-        gb.db.close()
+        gb.close()
 
     def test_force_single_notebook(self, course_dir):
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))

--- a/nbgrader/tests/apps/test_nbgrader_autograde.py
+++ b/nbgrader/tests/apps/test_nbgrader_autograde.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import json
+import pytest
 
 from os.path import join
 from textwrap import dedent
@@ -628,12 +629,17 @@ class TestNbGraderAutograde(BaseTestApp):
             else:
                 assert 'outputs' not in new_cell
 
+    @pytest.mark.skip(reason="this test takes too long to run and requires manual configuration")
     def test_many_students(self, course_dir):
+        # NOTE: to test this, you will manually have to configure the postgres
+        # database. In the postgresql.conf file in the postgres data directory,
+        # set max_connections to something low (like 5). Then, create the gradebook
+        # database and run this test.
         db = "postgresql://localhost:5432/gradebook"
 
         students = []
         student_fmt = "student{:03d}"
-        num_students = 300
+        num_students = 50
         for i in range(num_students):
             students.append(dict(id=student_fmt.format(i)))
 

--- a/nbgrader/tests/apps/test_nbgrader_autograde.py
+++ b/nbgrader/tests/apps/test_nbgrader_autograde.py
@@ -629,8 +629,9 @@ class TestNbGraderAutograde(BaseTestApp):
             else:
                 assert 'outputs' not in new_cell
 
-    @pytest.mark.skip(reason="this test takes too long to run and requires manual configuration")
     def test_many_students(self, course_dir):
+        pytest.skip("this test takes too long to run and requires manual configuration")
+
         # NOTE: to test this, you will manually have to configure the postgres
         # database. In the postgresql.conf file in the postgres data directory,
         # set max_connections to something low (like 5). Then, create the gradebook

--- a/nbgrader/tests/apps/test_nbgrader_autograde.py
+++ b/nbgrader/tests/apps/test_nbgrader_autograde.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import json
 
 from os.path import join
 from textwrap import dedent
@@ -86,7 +87,7 @@ class TestNbGraderAutograde(BaseTestApp):
         assert comment1.comment == None
         assert comment2.comment == None
 
-        gb.db.close()
+        gb.close()
 
     def test_grade_timestamp(self, db, course_dir):
         """Is a timestamp correctly read in?"""
@@ -119,7 +120,7 @@ class TestNbGraderAutograde(BaseTestApp):
         # make sure it still works to run it a second time
         run_nbgrader(["autograde", "ps1", "--db", db])
 
-        gb.db.close()
+        gb.close()
 
     def test_late_submission_penalty_none(self, db, course_dir):
         """Does 'none' method do nothing?"""
@@ -160,7 +161,7 @@ class TestNbGraderAutograde(BaseTestApp):
         assert submission.total_seconds_late > 0
         assert nb.late_submission_penalty == None
 
-        gb.db.close()
+        gb.close()
 
     def test_late_submission_penalty_zero(self, db, course_dir):
         """Does 'zero' method assign notebook.score as penalty if late?"""
@@ -202,7 +203,7 @@ class TestNbGraderAutograde(BaseTestApp):
         assert submission.total_seconds_late > 0
         assert nb.late_submission_penalty == nb.score
 
-        gb.db.close()
+        gb.close()
 
     def test_late_submission_penalty_plugin(self, db, course_dir):
         """Does plugin set 1 point per hour late penalty?"""
@@ -259,7 +260,7 @@ class TestNbGraderAutograde(BaseTestApp):
         assert submission.total_seconds_late > 0
         assert nb.late_submission_penalty == 1
 
-        gb.db.close()
+        gb.close()
 
     def test_force(self, db, course_dir):
         """Ensure the force option works properly"""
@@ -626,3 +627,24 @@ class TestNbGraderAutograde(BaseTestApp):
                 assert orig_cell.outputs == new_cell.outputs
             else:
                 assert 'outputs' not in new_cell
+
+    def test_many_students(self, course_dir):
+        db = "postgresql://localhost:5432/gradebook"
+
+        students = []
+        student_fmt = "student{:03d}"
+        num_students = 300
+        for i in range(num_students):
+            students.append(dict(id=student_fmt.format(i)))
+
+        with open("nbgrader_config.py", "a") as fh:
+            fh.write("""c.NbGrader.db_assignments = [dict(name='ps1', duedate='2015-02-02 14:58:23.948203 PST')]\n""")
+            fh.write("""c.NbGrader.db_students = {}""".format(json.dumps(students)))
+
+        self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
+        run_nbgrader(["assign", "ps1", "--db", db])
+
+        for i in range(num_students):
+            self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", student_fmt.format(i), "ps1", "p1.ipynb"))
+
+        run_nbgrader(["autograde", "ps1", "--db", db])

--- a/nbgrader/tests/formgrader/conftest.py
+++ b/nbgrader/tests/formgrader/conftest.py
@@ -83,7 +83,7 @@ def gradebook(request, tempdir):
     gb = Gradebook("sqlite:///gradebook.db")
 
     def fin():
-        gb.db.close()
+        gb.close()
     request.addfinalizer(fin)
 
     return gb

--- a/nbgrader/tests/preprocessors/test_getgrades.py
+++ b/nbgrader/tests/preprocessors/test_getgrades.py
@@ -22,7 +22,7 @@ def gradebook(request, db):
     gb.add_student("bar")
 
     def fin():
-        gb.db.close()
+        gb.close()
     request.addfinalizer(fin)
 
     return gb

--- a/nbgrader/tests/preprocessors/test_overwritecells.py
+++ b/nbgrader/tests/preprocessors/test_overwritecells.py
@@ -22,7 +22,7 @@ def gradebook(request, db):
     gb.add_assignment("ps0")
 
     def fin():
-        gb.db.close()
+        gb.close()
     request.addfinalizer(fin)
 
     return gb

--- a/nbgrader/tests/preprocessors/test_saveautogrades.py
+++ b/nbgrader/tests/preprocessors/test_saveautogrades.py
@@ -22,7 +22,7 @@ def gradebook(request, db):
     gb.add_student("bar")
 
     def fin():
-        gb.db.close()
+        gb.close()
     request.addfinalizer(fin)
 
     return gb

--- a/nbgrader/tests/preprocessors/test_savecells.py
+++ b/nbgrader/tests/preprocessors/test_savecells.py
@@ -22,7 +22,7 @@ def gradebook(request, db):
     gb.add_assignment("ps0")
 
     def fin():
-        gb.db.close()
+        gb.close()
     request.addfinalizer(fin)
 
     return gb


### PR DESCRIPTION
Fixes #560 

This adds a `close()` method to the `Gradebook` object and modifies everything to use that rather than `Gradebook.db.close()`. This ensures that the engine is also shutdown properly.