### PR TITLE
Add better support to transfer apps for multiple courses

### DIFF
--- a/nbgrader/apps/baseapp.py
+++ b/nbgrader/apps/baseapp.py
@@ -465,6 +465,18 @@ class TransferApp(NbGrader):
         config=True,
         help="Local cache directory for nbgrader submit and nbgrader list. Defaults to $JUPYTER_DATA_DIR/nbgrader_cache")
 
+    path_includes_course = Bool(
+        False, config=True,
+        help=dedent(
+            """
+            Whether the path for fetching/submitting  assignments should be
+            prefixed with the course name. If this is `False`, then the path
+            will be something like `./ps1`. If this is `True`, then the path
+            will be something like `./course123/ps1`.
+            """
+        )
+    )
+
     def _cache_directory_default(self):
         return os.path.join(jupyter_data_dir(), 'nbgrader_cache')
 

--- a/nbgrader/apps/fetchapp.py
+++ b/nbgrader/apps/fetchapp.py
@@ -1,5 +1,8 @@
 import os
 
+from textwrap import dedent
+from traitlets import Bool
+
 from .baseapp import TransferApp, transfer_aliases, transfer_flags
 from ..utils import check_mode
 
@@ -56,9 +59,13 @@ class FetchApp(TransferApp):
             self.fail("You don't have read permissions for the directory: {}".format(self.src_path))
 
     def init_dest(self):
-        self.dest_path = os.path.abspath(os.path.join('.', self.assignment_id))
+        if self.path_includes_course:
+            root = os.path.join(self.course_id, self.assignment_id)
+        else:
+            root = self.assignment_id
+        self.dest_path = os.path.abspath(os.path.join('.', root))
         if os.path.isdir(self.dest_path):
-            self.fail("You already have a copy of the assignment in this directory: {}".format(self.assignment_id))
+            self.fail("You already have a copy of the assignment in this directory: {}".format(root))
 
     def copy_files(self):
         self.log.info("Source: {}".format(self.src_path))

--- a/nbgrader/apps/listapp.py
+++ b/nbgrader/apps/listapp.py
@@ -140,13 +140,17 @@ class ListApp(TransferApp):
         assignments = []
         for path in self.assignments:
             info = self.parse_assignment(path)
+            if self.path_includes_course:
+                root = os.path.join(info['course_id'], info['assignment_id'])
+            else:
+                root = info['assignment_id']
 
             if self.inbound or self.cached:
                 info['status'] = 'submitted'
                 info['path'] = path
-            elif os.path.exists(info['assignment_id']):
+            elif os.path.exists(root):
                 info['status'] = 'fetched'
-                info['path'] = os.path.abspath(info['assignment_id'])
+                info['path'] = os.path.abspath(root)
             else:
                 info['status'] = 'released'
                 info['path'] = path

--- a/nbgrader/apps/submitapp.py
+++ b/nbgrader/apps/submitapp.py
@@ -50,7 +50,11 @@ class SubmitApp(TransferApp):
         """
 
     def init_src(self):
-        self.src_path = os.path.abspath(self.assignment_id)
+        if self.path_includes_course:
+            root = os.path.join(self.course_id, self.assignment_id)
+        else:
+            root = self.assignment_id
+        self.src_path = os.path.abspath(root)
         self.assignment_id = os.path.split(self.src_path)[-1]
         if not os.path.isdir(self.src_path):
             self.fail("Assignment not found: {}".format(self.src_path))

--- a/nbgrader/nbextensions/assignment_list/handlers.py
+++ b/nbgrader/nbextensions/assignment_list/handlers.py
@@ -73,11 +73,10 @@ class AssignmentList(LoggingConfigurable):
             self.log.error(output)
             raise RuntimeError('nbgrader submit exited with code {}'.format(retcode))
 
-    def validate_notebook(self, assignment_id, notebook_id):
-        p = sp.Popen([
-            sys.executable, "-m", "nbgrader", "validate", "--json",
-            os.path.join(assignment_id, "{}.ipynb".format(notebook_id))
-        ], stdout=sp.PIPE, stderr=sp.PIPE, cwd=self.assignment_dir)
+    def validate_notebook(self, path):
+        p = sp.Popen(
+            [sys.executable, "-m", "nbgrader", "validate", "--json", path],
+            stdout=sp.PIPE, stderr=sp.PIPE, cwd=self.assignment_dir)
         output, _ = p.communicate()
         retcode = p.poll()
         if retcode != 0:
@@ -103,17 +102,18 @@ class AssignmentActionHandler(BaseAssignmentHandler):
 
     @web.authenticated
     def post(self, action):
-        assignment_id = self.get_argument('assignment_id')
-        course_id = self.get_argument('course_id')
-
         if action == 'fetch':
+            assignment_id = self.get_argument('assignment_id')
+            course_id = self.get_argument('course_id')
             self.manager.fetch_assignment(course_id, assignment_id)
             self.finish(json.dumps(self.manager.list_assignments()))
         elif action == 'submit':
+            assignment_id = self.get_argument('assignment_id')
+            course_id = self.get_argument('course_id')
             self.manager.submit_assignment(course_id, assignment_id)
             self.finish(json.dumps(self.manager.list_assignments()))
         elif action == 'validate':
-            output = self.manager.validate_notebook(assignment_id, self.get_argument('notebook_id'))
+            output = self.manager.validate_notebook(self.get_argument('path'))
             self.finish(json.dumps(output))
 
 

--- a/nbgrader/nbextensions/static/assignment_list/assignment_list.js
+++ b/nbgrader/nbextensions/static/assignment_list/assignment_list.js
@@ -275,7 +275,7 @@ define([
 
     Notebook.prototype.make_row = function () {
         var container = $('<div/>').addClass('col-md-12');
-        var url = utils.url_join_encode(this.base_url, 'tree', this.data.assignment_id, this.data.notebook_id) + ".ipynb";
+        var url = utils.url_join_encode(this.base_url, 'tree', this.data.path);
         var link = $('<span/>').addClass('item_name col-sm-6').append(
             $('<a/>')
                 .attr("href", url)
@@ -297,11 +297,7 @@ define([
         button.click(function (e) {
             var settings = {
                 cache : false,
-                data : {
-                    course_id: that.data.course_id,
-                    assignment_id: that.data.assignment_id,
-                    notebook_id: that.data.notebook_id
-                },
+                data : { path: that.data.path },
                 type : "POST",
                 dataType : "json",
                 success : function (data, status, xhr) {

--- a/nbgrader/tests/apps/test_nbgrader_fetch.py
+++ b/nbgrader/tests/apps/test_nbgrader_fetch.py
@@ -9,18 +9,18 @@ from .conftest import notwindows
 @notwindows
 class TestNbGraderFetch(BaseTestApp):
 
-    def _release(self, assignment, exchange, course_dir):
+    def _release(self, assignment, exchange, course_dir, course="abc101"):
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "release", "ps1", "p1.ipynb"))
         run_nbgrader([
             "release", assignment,
-            "--course", "abc101",
+            "--course", course,
             "--TransferApp.exchange_directory={}".format(exchange)
         ])
 
-    def _fetch(self, assignment, exchange, flags=None, retcode=0):
+    def _fetch(self, assignment, exchange, flags=None, retcode=0, course="abc101"):
         cmd = [
             "fetch", assignment,
-            "--course", "abc101",
+            "--course", course,
             "--TransferApp.exchange_directory={}".format(exchange)
         ]
 
@@ -58,3 +58,12 @@ class TestNbGraderFetch(BaseTestApp):
         self._release("ps1", exchange, course_dir)
         self._fetch("--assignment=ps1", exchange)
         assert os.path.isfile(join("ps1", "p1.ipynb"))
+
+    def test_fetch_multiple_courses(self, exchange, course_dir):
+        self._release("ps1", exchange, course_dir, course="abc101")
+        self._fetch("ps1", exchange, course="abc101", flags=["--TransferApp.path_includes_course=True"])
+        assert os.path.isfile(join("abc101", "ps1", "p1.ipynb"))
+
+        self._release("ps1", exchange, course_dir, course="abc102")
+        self._fetch("ps1", exchange, course="abc102", flags=["--TransferApp.path_includes_course=True"])
+        assert os.path.isfile(join("abc102", "ps1", "p1.ipynb"))

--- a/nbgrader/tests/apps/test_nbgrader_list.py
+++ b/nbgrader/tests/apps/test_nbgrader_list.py
@@ -21,21 +21,31 @@ class TestNbGraderList(BaseTestApp):
             "--TransferApp.exchange_directory={}".format(exchange)
         ])
 
-    def _fetch(self, assignment, exchange, cache, course="abc101"):
-        run_nbgrader([
+    def _fetch(self, assignment, exchange, cache, course="abc101", flags=None):
+        cmd = [
             "fetch", assignment,
             "--course", course,
             "--TransferApp.cache_directory={}".format(cache),
             "--TransferApp.exchange_directory={}".format(exchange)
-        ])
+        ]
 
-    def _submit(self, assignment, exchange, cache, course="abc101"):
-        run_nbgrader([
+        if flags is not None:
+            cmd.extend(flags)
+
+        run_nbgrader(cmd)
+
+    def _submit(self, assignment, exchange, cache, course="abc101", flags=None):
+        cmd = [
             "submit", assignment,
             "--course", course,
             "--TransferApp.cache_directory={}".format(cache),
             "--TransferApp.exchange_directory={}".format(exchange)
-        ])
+        ]
+
+        if flags is not None:
+            cmd.extend(flags)
+
+        run_nbgrader(cmd)
 
     def _list(self, exchange, cache, assignment=None, flags=None, retcode=0):
         cmd = [
@@ -383,6 +393,65 @@ class TestNbGraderList(BaseTestApp):
                 "notebooks": [
                     {
                         "path": os.path.join(cache, "abc101", submission, "p1.ipynb"),
+                        "notebook_id": "p1"
+                    }
+                ]
+            }
+        ]
+
+    def test_list_json_multiple_courses(self, exchange, cache, course_dir):
+        self._release("ps1", exchange, cache, course_dir, course="abc101")
+        self._release("ps1", exchange, cache, course_dir, course="abc102")
+        assert json.loads(self._list(exchange, cache, flags=["--json", "--TransferApp.path_includes_course=True"])) == [
+            {
+                "assignment_id": "ps1",
+                "status": "released",
+                "course_id": "abc101",
+                "path": os.path.join(exchange, "abc101", "outbound", "ps1"),
+                "notebooks": [
+                    {
+                        "path": os.path.join(exchange, "abc101", "outbound", "ps1", "p1.ipynb"),
+                        "notebook_id": "p1"
+                    }
+                ]
+            },
+            {
+                "assignment_id": "ps1",
+                "status": "released",
+                "course_id": "abc102",
+                "path": os.path.join(exchange, "abc102", "outbound", "ps1"),
+                "notebooks": [
+                    {
+                        "path": os.path.join(exchange, "abc102", "outbound", "ps1", "p1.ipynb"),
+                        "notebook_id": "p1"
+                    }
+                ]
+            }
+        ]
+
+        self._fetch("ps1", exchange, cache, course="abc101", flags=["--TransferApp.path_includes_course=True"])
+        self._fetch("ps1", exchange, cache, course="abc102", flags=["--TransferApp.path_includes_course=True"])
+        assert json.loads(self._list(exchange, cache, flags=["--json", "--TransferApp.path_includes_course=True"])) == [
+            {
+                "assignment_id": "ps1",
+                "status": "fetched",
+                "course_id": "abc101",
+                "path": os.path.abspath(os.path.join("abc101", "ps1")),
+                "notebooks": [
+                    {
+                        "path": os.path.abspath(os.path.join("abc101", "ps1", "p1.ipynb")),
+                        "notebook_id": "p1"
+                    }
+                ]
+            },
+            {
+                "assignment_id": "ps1",
+                "status": "fetched",
+                "course_id": "abc102",
+                "path": os.path.abspath(os.path.join("abc102", "ps1")),
+                "notebooks": [
+                    {
+                        "path": os.path.abspath(os.path.join("abc102", "ps1", "p1.ipynb")),
                         "notebook_id": "p1"
                     }
                 ]


### PR DESCRIPTION
This adds a new option, `path_includes_course`, to the TransferApps so that they work a little better with multiple courses. If this option is set to True, then `nbgrader fetch` will fetch assignments to `<course_id>/<assignment_id>` (rather than just to `<assignment_id>`). Similarly, if the option is set to True, then `nbgrader submit` will look for assignments at `<course_id>/<assignment_id>`. I have also made sure that this functionality works from the assignment list extension.

This fixes #554 though it doesn't fully address the full issue with multiple courses yet (i.e. #544). I am going to try to address that fully in a separate PR, this is just a first step.

cc @dsblank 

