### PR TITLE
Handle autograding failures better

### DIFF
--- a/nbgrader/apps/autogradeapp.py
+++ b/nbgrader/apps/autogradeapp.py
@@ -223,6 +223,7 @@ class AutogradeApp(BaseNbConvertApp):
         self.log.info("Autograding %s", notebook_filename)
         self._sanitizing = False
         self._init_preprocessors()
-        super(AutogradeApp, self).convert_single_notebook(notebook_filename)
-
-        self._sanitizing = True
+        try:
+            super(AutogradeApp, self).convert_single_notebook(notebook_filename)
+        finally:
+            self._sanitizing = True

--- a/nbgrader/apps/baseapp.py
+++ b/nbgrader/apps/baseapp.py
@@ -780,7 +780,6 @@ class BaseNbConvertApp(NbGrader, NbConvertApp):
 
             # parse out the assignment and student ids
             regexp = self._format_source("(?P<assignment_id>.*)", "(?P<student_id>.*)", escape=True)
-            print((regexp, assignment))
             m = re.match(regexp, assignment)
             if m is None:
                 self.fail("Could not match '%s' with regexp '%s'", assignment, regexp)

--- a/nbgrader/preprocessors/execute.py
+++ b/nbgrader/preprocessors/execute.py
@@ -4,6 +4,10 @@ from textwrap import dedent
 
 from . import NbGraderPreprocessor
 
+class UnresponsiveKernelError(Exception):
+    pass
+
+
 class Execute(NbGraderPreprocessor, ExecutePreprocessor):
 
     interrupt_on_timeout = Bool(True)
@@ -21,4 +25,9 @@ class Execute(NbGraderPreprocessor, ExecutePreprocessor):
         if self.extra_arguments == [] and kernel_name == "python":
             self.extra_arguments = ["--HistoryManager.hist_file=:memory:"]
 
-        return super(Execute, self).preprocess(nb, resources)
+        try:
+            output = super(Execute, self).preprocess(nb, resources)
+        except RuntimeError:
+            raise UnresponsiveKernelError()
+
+        return output

--- a/nbgrader/tests/apps/files/infinite-loop-with-output.ipynb
+++ b/nbgrader/tests/apps/files/infinite-loop-with-output.ipynb
@@ -1,0 +1,20 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "x = []\n",
+    "while True:\n",
+    "    x.append(1)"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/nbgrader/tests/apps/files/infinite-loop.ipynb
+++ b/nbgrader/tests/apps/files/infinite-loop.ipynb
@@ -1,0 +1,19 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "while True:\n",
+    "    pass"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/nbgrader/tests/apps/test_nbgrader_autograde.py
+++ b/nbgrader/tests/apps/test_nbgrader_autograde.py
@@ -549,11 +549,14 @@ class TestNbGraderAutograde(BaseTestApp):
         self._empty_notebook(join(course_dir, "source", "ps1", "p2.ipynb"))
         run_nbgrader(["assign", "ps1"])
 
+        self._empty_notebook(join(course_dir, "submitted", "bar", "ps1", "p1.ipynb"))
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "bar", "ps1", "p2.ipynb"))
         self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
-        self._copy_file(join("files", "test.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p2.ipynb"))
+        self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "p2.ipynb"))
         run_nbgrader(["autograde", "ps1"], retcode=1)
 
-        assert not os.path.exists(join(course_dir, "autograded", "foo", "ps1"))
+        assert not os.path.exists(join(course_dir, "autograded", "bar", "ps1"))
+        assert os.path.exists(join(course_dir, "autograded", "foo", "ps1"))
 
     def test_handle_failure_single_notebook(self, course_dir):
         with open("nbgrader_config.py", "a") as fh:
@@ -655,3 +658,32 @@ class TestNbGraderAutograde(BaseTestApp):
             self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", student_fmt.format(i), "ps1", "p1.ipynb"))
 
         run_nbgrader(["autograde", "ps1", "--db", db])
+
+    def test_infinite_loop(self, db, course_dir):
+        with open("nbgrader_config.py", "a") as fh:
+            fh.write("""c.NbGrader.db_assignments = [dict(name='ps1', duedate='2015-02-02 14:58:23.948203 PST')]\n""")
+            fh.write("""c.NbGrader.db_students = [dict(id="foo")]\n""")
+            fh.write("""c.ExecutePreprocessor.timeout = 1""")
+
+        self._copy_file(join("files", "infinite-loop.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
+        run_nbgrader(["assign", "ps1", "--db", db])
+
+        self._copy_file(join("files", "infinite-loop.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
+        run_nbgrader(["autograde", "ps1", "--db", db])
+
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
+
+    def test_infinite_loop_with_output(self, db, course_dir):
+        pytest.skip("this test takes too long to run and consumes a LOT of memory")
+
+        with open("nbgrader_config.py", "a") as fh:
+            fh.write("""c.NbGrader.db_assignments = [dict(name='ps1', duedate='2015-02-02 14:58:23.948203 PST')]\n""")
+            fh.write("""c.NbGrader.db_students = [dict(id="foo")]\n""")
+
+        self._copy_file(join("files", "infinite-loop-with-output.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
+        run_nbgrader(["assign", "ps1", "--db", db])
+
+        self._copy_file(join("files", "infinite-loop-with-output.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
+        run_nbgrader(["autograde", "ps1", "--db", db], retcode=1)
+
+        assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))


### PR DESCRIPTION
cc @ddbourgin

This fixes a bug in handling failures during autograding (if one student's assignment failed, then the whole thing would break, even though it should not). It also prints out a more informative message if the kernel becomes unresponsive.