### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,6 @@
 
 We're thrilled you want to contribute to nbgrader.
 
-The [developer documentation](https://nbgrader.readthedocs.org/en/latest/contributor_guide/overview.html)
+The [developer documentation](https://nbgrader.readthedocs.io/en/latest/contributor_guide/overview.html)
 gives an overview of how various parts of the project work and what our
 expectations are for contributions.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A system for assigning and grading Jupyter notebooks.
 
-[Documentation can be found on Read the Docs.](http://nbgrader.readthedocs.org)
+[Documentation can be found on Read the Docs.](https://nbgrader.readthedocs.io)
 
 
 ## Highlights of nbgrader
@@ -24,7 +24,7 @@ submit, and validate their assignments.
 ![nbgrader assignment list](nbgrader/docs/source/user_guide/images/student_assignment.gif "nbgrader assignment list")
 
 ### The command line tools of nbgrader
-[Command line tools](https://nbgrader.readthedocs.org/en/latest/command_line_tools/index.html)
+[Command line tools](https://nbgrader.readthedocs.io/en/latest/command_line_tools/index.html)
 offer an efficient way for the instructor to generate, assign, release, collect,
 and grade notebooks.
 
@@ -39,12 +39,12 @@ Or, if you use [Anaconda](https://www.continuum.io/downloads):
     conda install -c jhamrick nbgrader
 
 For detailed instructions on installing nbgrader and the nbgrader extensions
-for Jupyter notebook, please see [Installation](https://nbgrader.readthedocs.org/en/latest/user_guide/installation.html)
+for Jupyter notebook, please see [Installation](https://nbgrader.readthedocs.io/en/latest/user_guide/installation.html)
 section in the User Guide.
 
 
 ## Contributing
-Please see the [contributing guidelines and documentation](https://nbgrader.readthedocs.org/en/latest/contributor_guide/overview.html).
+Please see the [contributing guidelines and documentation](https://nbgrader.readthedocs.io/en/latest/contributor_guide/overview.html).
 
 If you want to develop features for nbgrader, please follow the
-[development installation instructions](https://nbgrader.readthedocs.org/en/latest/contributor_guide/installation_developer.html).
+[development installation instructions](https://nbgrader.readthedocs.io/en/latest/contributor_guide/installation_developer.html).

--- a/nbgrader/apps/quickstartapp.py
+++ b/nbgrader/apps/quickstartapp.py
@@ -144,7 +144,7 @@ class QuickStartApp(NbGrader):
 
                 For further details, please see the full nbgrader documentation at:
 
-                    http://nbgrader.readthedocs.org/
+                    https://nbgrader.readthedocs.io/
                 """
             ).lstrip(),
             course_path,

--- a/nbgrader/docs/source/configuration/jupyterhub_config.rst
+++ b/nbgrader/docs/source/configuration/jupyterhub_config.rst
@@ -18,7 +18,7 @@ Using nbgrader with JupyterHub
     :doc:`/user_guide/philosophy`
         More details on how the nbgrader hierarchy is structured.
 
-    `JupyterHub Documentation <http://jupyterhub.readthedocs.org/en/latest/getting-started.html>`_
+    `JupyterHub Documentation <https://jupyterhub.readthedocs.io/en/latest/getting-started.html>`_
         Detailed documentation describing how JupyterHub works, which is very
         much required reading if you want to integrate the formgrader with
         JupyterHub.

--- a/nbgrader/docs/source/contributor_guide/documentation.rst
+++ b/nbgrader/docs/source/contributor_guide/documentation.rst
@@ -35,7 +35,7 @@ executed, please make sure you re-run all the documentation before committing.
 While the documentation gets built automatically on Read The Docs, the notebooks do **not** get execute by Read The Docs -- they must be executed manually.
 However, executing the notebooks is easy to do!
 
-Our docs are built with `nbconvert <http://nbconvert.readthedocs.org/en/latest/>`_,
+Our docs are built with `nbconvert <https://nbconvert.readthedocs.io/en/latest/>`_,
 `Pandoc <http://pandoc.org/>`_, and `Sphinx <http://sphinx-doc.org/>`_.
 To build the docs locally, run the following command::
 
@@ -60,4 +60,4 @@ Automatic builds
 ----------------
 When a commit is made on the ``master`` branch, documentation is automatically
 built by Read The Docs and rendered at
-`nbgrader.readthedocs.org <http://nbgrader.readthedocs.org>`_.
+`nbgrader.readthedocs.org <https://nbgrader.readthedocs.io>`_.

--- a/nbgrader/docs/source/user_guide/advanced.rst
+++ b/nbgrader/docs/source/user_guide/advanced.rst
@@ -130,7 +130,7 @@ example:
 
     c.Exporter.preprocessors = ['nbgrader.preprocessors.ClearSolutions']
 
-See also the nbconvert docs on `custom preprocessors <http://nbconvert.readthedocs.io/en/latest/nbconvert_library.html#Custom-Preprocessors>`__.
+See also the nbconvert docs on `custom preprocessors <https://nbconvert.readthedocs.io/en/latest/nbconvert_library.html#Custom-Preprocessors>`__.
 
 Calling nbgrader apps from Python
 ---------------------------------


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.