### PR TITLE
Changes for Notebook v4.3 tests

### DIFF
--- a/nbgrader/apps/notebookapp.py
+++ b/nbgrader/apps/notebookapp.py
@@ -1,9 +1,11 @@
 from tornado import ioloop
 from notebook.notebookapp import NotebookApp
 
+
 class FormgradeNotebookApp(NotebookApp):
     """A Subclass of the regular NotebookApp that can be spawned by the form grader."""
     open_browser = False
+    token = ''  # Notebook >=4.3
 
     def _profile_default(self):
         return 'nbgrader'

--- a/nbgrader/tests/nbextensions/conftest.py
+++ b/nbgrader/tests/nbextensions/conftest.py
@@ -149,7 +149,7 @@ def nbserver(request, port, tempdir, coursedir, jupyter_config_dir, jupyter_data
     nbserver = sp.Popen([
         sys.executable, "-m", "jupyter", "notebook",
         "--no-browser",
-        "--NotebookApp.token=",
+        "--NotebookApp.token=''",  # Notebook >=4.3
         "--port", str(port)], **kwargs)
 
     def fin():

--- a/nbgrader/tests/nbextensions/conftest.py
+++ b/nbgrader/tests/nbextensions/conftest.py
@@ -149,6 +149,7 @@ def nbserver(request, port, tempdir, coursedir, jupyter_config_dir, jupyter_data
     nbserver = sp.Popen([
         sys.executable, "-m", "jupyter", "notebook",
         "--no-browser",
+        "--NotebookApp.token=",
         "--port", str(port)], **kwargs)
 
     def fin():


### PR DESCRIPTION
Turns out it is actually easy to disable token auth for the nbextension tests and for the FormgradeNotebookApp.

It will be a bit more work if you actually want to use token auth for the FormgradeNotebookApp.

Closes #582 