### PR TITLE
Add catches for empty timestamp files and invalid timestamp strings

### DIFF
--- a/nbgrader/apps/autogradeapp.py
+++ b/nbgrader/apps/autogradeapp.py
@@ -31,6 +31,7 @@ flags.update({
     ),
 })
 
+
 class AutogradeApp(BaseNbConvertApp):
 
     name = u'nbgrader-autograde'

--- a/nbgrader/apps/baseapp.py
+++ b/nbgrader/apps/baseapp.py
@@ -328,7 +328,15 @@ class NbGrader(JupyterApp):
         if os.path.exists(timestamp_path):
             with open(timestamp_path, 'r') as fh:
                 timestamp = fh.read().strip()
-            return parse_utc(timestamp)
+            if not timestamp:
+                self.log.warning(
+                    "Empty timestamp file: {}".format(timestamp_path))
+                return None
+            try:
+                return parse_utc(timestamp)
+            except ValueError:
+                self.fail(
+                    "Invalid timestamp string: {}".format(timestamp_path))
         else:
             return None
 


### PR DESCRIPTION
closes #580 