### PR TITLE
`basename` to wordslist

### DIFF
--- a/nbgrader/docs/source/spelling_wordlist.txt
+++ b/nbgrader/docs/source/spelling_wordlist.txt
@@ -16,6 +16,7 @@ autograder
 Autograder
 autograding
 backends
+basename
 Bitdiddle
 bugfix
 bugtracker


### PR DESCRIPTION
It seems `nbconvert` was updated to v5.0 and released perfectly between my PR's and merge, causing the docs builds to fail on master.