### PR TITLE
Clarify formgrader port and suppress notebook output

### DIFF
--- a/nbgrader/auth/hubauth.py
+++ b/nbgrader/auth/hubauth.py
@@ -138,6 +138,7 @@ class HubAuth(BaseAuth):
 
     def __init__(self, *args, **kwargs):
         super(HubAuth, self).__init__(*args, **kwargs)
+        self._user = None
         self._base_url = self.hub_base_url + self.remap_url
         self.register_with_proxy()
 

--- a/nbgrader/auth/noauth.py
+++ b/nbgrader/auth/noauth.py
@@ -5,6 +5,7 @@ import subprocess as sp
 import time
 import sys
 import signal
+import logging
 
 from textwrap import dedent
 from traitlets import Bool, Integer, Unicode
@@ -53,13 +54,19 @@ class NoAuth(BaseAuth):
             if sys.platform == 'win32':
                 kwargs['creationflags'] = sp.CREATE_NEW_PROCESS_GROUP
 
+            if self.log.level <= logging.DEBUG:
+                level = "DEBUG"
+            else:
+                level = "CRITICAL"
+
             self._notebook_server_ip = self._ip
             self._notebook_server_port = str(self.nbserver_port)
             self._notebook_server = sp.Popen(
                 [
                     sys.executable, notebookapp,
                     "--ip", self._notebook_server_ip,
-                    "--port", self._notebook_server_port
+                    "--port", self._notebook_server_port,
+                    "--log-level", level
                 ],
                 **kwargs)
             self._notebook_server_exists = True


### PR DESCRIPTION
Fixes #472

This prints a more useful error message:

```
$ nbgrader formgrade
[FormgradeApp | INFO] Serving MathJax from /Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.5/site-packages/notebook/static/components/MathJax/MathJax.js
[FormgradeApp | ERROR] Address already in use by another process: http://localhost:5000
[FormgradeApp | ERROR] Try running nbgrader with a different port, e.g. nbgrader formgrade --port=5001
```

and also is more explicit about where the formgrader is running:

```
$ nbgrader formgrade --port=5001
[FormgradeApp | INFO] Serving MathJax from /Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.5/site-packages/notebook/static/components/MathJax/MathJax.js
[FormgradeApp | INFO] Notebook server is running at http://localhost:55550/notebooks/
[FormgradeApp | INFO] The formgrader is running at http://localhost:5001/
[FormgradeApp | INFO] --> Go to http://localhost:5001/ to access the formgrader
[FormgradeApp | INFO] Use Control-C to stop this server
```