### PR TITLE
Add metadata schema and documentation

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - tornado
     - six
     - requests
+    - jsonschema
   run:
     - python
     - sqlalchemy
@@ -38,6 +39,7 @@ requirements:
     - tornado
     - six
     - requests
+    - jsonschema
 
 test:
   requires:

--- a/nbgrader/apps/assignapp.py
+++ b/nbgrader/apps/assignapp.py
@@ -142,7 +142,8 @@ class AssignApp(BaseNbConvertApp):
         ClearOutput,
         CheckCellMetadata,
         ComputeChecksums,
-        SaveCells
+        SaveCells,
+        CheckCellMetadata
     ])
 
     def build_extra_config(self):

--- a/nbgrader/apps/autogradeapp.py
+++ b/nbgrader/apps/autogradeapp.py
@@ -6,7 +6,8 @@ from traitlets import List, Bool
 
 from .baseapp import BaseNbConvertApp, nbconvert_aliases, nbconvert_flags
 from ..preprocessors import (
-    AssignLatePenalties, ClearOutput, DeduplicateIds, OverwriteCells, SaveAutoGrades, Execute, LimitOutput)
+    AssignLatePenalties, ClearOutput, DeduplicateIds, OverwriteCells, SaveAutoGrades,
+    Execute, LimitOutput, CheckCellMetadata)
 from ..api import Gradebook, MissingEntry
 from .. import utils
 
@@ -115,13 +116,15 @@ class AutogradeApp(BaseNbConvertApp):
     sanitize_preprocessors = List([
         ClearOutput,
         DeduplicateIds,
-        OverwriteCells
+        OverwriteCells,
+        CheckCellMetadata
     ])
     autograde_preprocessors = List([
         Execute,
         LimitOutput,
         SaveAutoGrades,
         AssignLatePenalties,
+        CheckCellMetadata
     ])
 
     preprocessors = List([])

--- a/nbgrader/apps/validateapp.py
+++ b/nbgrader/apps/validateapp.py
@@ -1,6 +1,6 @@
 from traitlets import Unicode, List, Bool
 from nbconvert.nbconvertapp import NbConvertApp, DottedOrNone
-from ..preprocessors import DisplayAutoGrades, Execute, ClearOutput
+from ..preprocessors import DisplayAutoGrades, Execute, ClearOutput, CheckCellMetadata
 from .baseapp import NbGrader
 
 aliases = {}
@@ -36,6 +36,7 @@ class ValidateApp(NbGrader, NbConvertApp):
         """
 
     preprocessors = List([
+        CheckCellMetadata,
         ClearOutput,
         Execute,
         DisplayAutoGrades

--- a/nbgrader/docs/source/contributor_guide/metadata.rst
+++ b/nbgrader/docs/source/contributor_guide/metadata.rst
@@ -1,0 +1,84 @@
+JSON Metadata Format
+====================
+
+nbgrader relies on metadata stored in the JSON notebook source. When you create
+a notebook using the "Create Assignment" extension, this extension saves
+various keys into the metadata that it then relies on during the steps of
+``nbgrader assign``. The ``nbgrader assign`` command also adds new metadata to
+the notebooks, which is used by ``nbgrader validate`` and ``nbgrader
+autograde``.
+
+The metadata is always stored at the cell level, in the cell's ``metadata`` field, under a dictionary called ``nbgrader``. This makes the notebook source look like::
+
+    {
+        "cells": [
+            {
+                "cell_type": "markdown",
+                "metadata": {
+                    "nbgrader": {
+                        ...
+                    }
+                },
+                "source": ["an example cell\n"]
+            },
+            ... more cells ...
+        ],
+        ... other notebook information ...
+    }
+
+Details about the metadata are given below.
+
+Version 1
+---------
+
+The metadata may contain the following keys:
+
+.. data:: schema_version
+
+    The version of the metadata schema. Defaults to 1.
+
+.. data:: grade
+
+    Added by the "Create Assignment" extension.
+
+    Whether the cell should be graded (which essentially means whether it
+    gets a point value). This should be true for manually graded answer
+    cells and for autograder test cells.
+
+.. data:: solution
+
+    Added by the "Create Assignment" extension.
+
+    Whether the cell is a solution cell (which essentially means whether
+    students should put their answers in it or not). This should be true
+    for manually graded answer cells and autograded answer cells.
+
+.. data:: locked
+
+    Added by the "Create Assignment" extension.
+
+    Whether nbgrader should prevent the cell from being edited. This should
+    be true for autograder test cells and any other cells that are marked
+    as locked/read-only in the create assignment interface.
+
+.. data:: grade_id
+
+    Added by the "Create Assignment" extension.
+
+    This is the nbgrader cell id so that nbgrader can track its contents,
+    outputs, etc.
+
+.. data:: points
+
+    Added by the "Create Assignment" extension.
+
+    This is the number of points that a cell is worth. It should only be
+    set if ``grade`` is also set to true.
+
+.. data:: checksum
+
+    Added by ``nbgrader assign``.
+
+    This is the checksum of the cell's contents that can then be used by
+    ``nbgrader validate`` and ``nbgrader autograde`` to determine whether
+    the student has edited the cell.

--- a/nbgrader/docs/source/index.rst
+++ b/nbgrader/docs/source/index.rst
@@ -34,6 +34,7 @@ nbgrader
 
     contributor_guide/overview
     contributor_guide/installation_developer
+    contributor_guide/metadata
     contributor_guide/pull_request
     contributor_guide/testing
     contributor_guide/documentation

--- a/nbgrader/nbformat/__init__.py
+++ b/nbgrader/nbformat/__init__.py
@@ -1,0 +1,4 @@
+from .common import ValidationError
+from .v1 import ValidatorV1 as Validator
+from .v1 import read_v1 as read, write_v1 as write
+from .v1 import reads_v1 as reads, writes_v1 as writes

--- a/nbgrader/nbformat/common.py
+++ b/nbgrader/nbformat/common.py
@@ -1,0 +1,29 @@
+import json
+import os
+import jsonschema
+
+from jsonschema import ValidationError
+
+
+root = os.path.dirname(__file__)
+
+class BaseValidator(object):
+
+    schema = None
+
+    def __init__(self, version):
+        if self.schema is None:
+            with open(os.path.join(root, "v{:d}.json".format(version)), "r") as fh:
+                self.schema = json.loads(fh.read())
+
+    def upgrade_cell_metadata(self, cell):
+        raise NotImplementedError("this method must be implemented by subclasses")
+
+    def validate_cell(self, cell):
+        if 'nbgrader' not in cell.metadata:
+            return
+        jsonschema.validate(cell.metadata['nbgrader'], self.schema)
+
+    def validate_nb(self, nb):
+        for cell in nb.cells:
+            self.validate_cell(cell)

--- a/nbgrader/nbformat/v1.json
+++ b/nbgrader/nbformat/v1.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "nbgrader cell metadata schema",
+    "type": "object",
+    "properties": {
+        "schema_version": {
+            "description": "the version of the cell metadata schema",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 1
+        },
+        "grade": {
+            "description": "whether this cell should be graded",
+            "type": "boolean",
+            "default": false
+        },
+        "locked": {
+            "description": "whether the cell should be editable",
+            "type": "boolean",
+            "default": false
+        },
+        "solution": {
+            "description": "whether this cell contains a solution",
+            "type": "boolean",
+            "default": false
+        },
+        "grade_id": {
+            "description": "the nbgrader id of the cell, only present if one or more of grade/locked/solution is true",
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_\\-]*$"
+        },
+        "points": {
+            "description": "the number of points this cell is worth; only present if grade is true",
+            "type": "number",
+            "minimum": 0
+        },
+        "checksum": {
+            "description": "a checksum of the cell contents; generally only present in the student version of an assignment",
+            "type": "string",
+            "minLength": 32,
+            "maxLength": 32
+        }
+    },
+    "required": ["grade", "locked", "solution"],
+    "additionalProperties": false
+}

--- a/nbgrader/nbformat/v1.py
+++ b/nbgrader/nbformat/v1.py
@@ -1,0 +1,133 @@
+import warnings
+
+from nbformat import read as _read, reads as _reads
+from nbformat import write as _write, writes as _writes
+from .common import BaseValidator, ValidationError
+
+class ValidatorV1(BaseValidator):
+
+    schema = None
+
+    def __init__(self):
+        super(ValidatorV1, self).__init__(1)
+
+    def _upgrade_v0_to_v1(self, cell):
+        meta = cell.metadata['nbgrader']
+
+        if 'grade' not in meta:
+            meta['grade'] = False
+        if 'solution' not in meta:
+            meta['solution'] = False
+        if 'locked' not in meta:
+            meta['locked'] = False
+
+        if not meta['grade'] and not meta['solution'] and not meta['locked']:
+            if 'grade_id' in meta:
+                del meta['grade_id']
+            if 'points' in meta:
+                del meta['points']
+
+        if 'points' in meta:
+            meta['points'] = float(meta['points'])
+
+        allowed = set(self.schema["properties"].keys())
+        keys = set(meta.keys()) - allowed
+        if len(keys) > 0:
+            warnings.warn("extra keys detected in metadata, these will be removed: {}".format(keys))
+            for key in keys:
+                del meta[key]
+
+        meta['schema_version'] = 1
+
+        return cell
+
+    def upgrade_cell_metadata(self, cell):
+        if 'nbgrader' not in cell.metadata:
+            return cell
+
+        meta = cell.metadata['nbgrader']
+
+        if 'schema_version' not in meta:
+            warnings.warn("nbgrader schema version is not defined, assuming version 0")
+            meta['schema_version'] = 0
+
+        if meta['schema_version'] == 0:
+            cell = self._upgrade_v0_to_v1(cell)
+
+        return cell
+
+    def validate_cell(self, cell):
+        super(ValidatorV1, self).validate_cell(self.upgrade_cell_metadata(cell))
+
+        if 'nbgrader' not in cell.metadata:
+            return
+
+        meta = cell.metadata['nbgrader']
+        grade = meta['grade']
+        solution = meta['solution']
+        locked = meta['locked']
+
+        # check for a valid grade id
+        if grade or solution or locked:
+            if 'grade_id' not in meta:
+                raise ValidationError("nbgrader cell does not have a grade_id: {}".format(cell.source))
+            if meta['grade_id'] == '':
+                raise ValidationError("grade_id is empty")
+
+        # check for valid points
+        if grade:
+            if 'points' not in meta:
+                raise ValidationError("nbgrader cell '{}' does not have points".format(
+                    meta['grade_id']))
+
+        # check that markdown cells are grade AND solution (not either/or)
+        if cell.cell_type == "markdown" and grade and not solution:
+            raise ValidationError(
+                "Markdown grade cell '{}' is not marked as a solution cell".format(
+                    meta['grade_id']))
+        if cell.cell_type == "markdown" and not grade and solution:
+            raise ValidationError(
+                "Markdown solution cell is not marked as a grade cell: {}".format(cell.source))
+
+    def validate_nb(self, nb):
+        super(ValidatorV1, self).validate_nb(nb)
+
+        ids = set([])
+        for cell in nb.cells:
+
+            if 'nbgrader' not in cell.metadata:
+                continue
+
+            grade = cell.metadata['nbgrader']['grade']
+            solution = cell.metadata['nbgrader']['solution']
+            locked = cell.metadata['nbgrader']['locked']
+
+            if not grade and not solution and not locked:
+                continue
+
+            grade_id = cell.metadata['nbgrader']['grade_id']
+            if grade_id in ids:
+                raise ValidationError("Duplicate grade id: {}".format(grade_id))
+            ids.add(grade_id)
+
+
+def read_v1(source, **kwargs):
+    nb = _read(source, **kwargs)
+    ValidatorV1().validate_nb(nb)
+    return nb
+
+
+def write_v1(nb, **kwargs):
+    ValidatorV1().validate_nb(nb)
+    return _write(nb, **kwargs)
+
+
+def reads_v1(source, **kwargs):
+    nb = _reads(source, **kwargs)
+    ValidatorV1().validate_nb(nb)
+    return nb
+
+
+def writes_v1(nb, **kwargs):
+    ValidatorV1().validate_nb(nb)
+    return _writes(nb, **kwargs)

--- a/nbgrader/preprocessors/checkcellmetadata.py
+++ b/nbgrader/preprocessors/checkcellmetadata.py
@@ -1,54 +1,9 @@
-import re
-
-from .. import utils
+from ..nbformat import Validator
 from . import NbGraderPreprocessor
 
 class CheckCellMetadata(NbGraderPreprocessor):
     """A preprocessor for checking that grade ids are unique."""
 
     def preprocess(self, nb, resources):
-        resources['grade_ids'] = ids = []
-        nb, resources = super(CheckCellMetadata, self).preprocess(nb, resources)
-
-        id_set = set([])
-        for grade_id in ids:
-            if grade_id in id_set:
-                raise RuntimeError("Duplicate grade id: {}".format(grade_id))
-            id_set.add(grade_id)
-
+        Validator().validate_nb(nb)
         return nb, resources
-
-    def preprocess_cell(self, cell, resources, cell_index):
-        if utils.is_grade(cell) or utils.is_solution(cell):
-            # check for invalid grade ids
-            grade_id = cell.metadata.nbgrader.get("grade_id", "")
-            if not re.match(r"^[a-zA-Z0-9_\-]+$", grade_id):
-                raise RuntimeError("Invalid grade id: {}".format(grade_id))
-            resources['grade_ids'].append(grade_id)
-
-        if utils.is_grade(cell):
-            # check for valid points
-            points = cell.metadata.nbgrader.get("points", "")
-            try:
-                points = float(points)
-            except ValueError:
-                raise RuntimeError(
-                    "Point value for grade cell {} is invalid: {}".format(
-                        grade_id, points))
-
-        # check that markdown cells are grade AND solution (not either/or)
-        if cell.cell_type == "markdown" and utils.is_grade(cell) and not utils.is_solution(cell):
-            raise RuntimeError(
-                "Markdown grade cell '{}' is not marked as a solution cell".format(
-                    grade_id))
-        if cell.cell_type == "markdown" and not utils.is_grade(cell) and utils.is_solution(cell):
-            raise RuntimeError(
-                "Markdown solution cell (index {}) is not marked as a grade cell".format(
-                    cell_index))
-
-        if 'nbgrader' in cell.metadata and 'grade_id' in cell.metadata.nbgrader:
-            if (not utils.is_grade(cell) and not utils.is_solution(cell) and not utils.is_locked(cell)):
-                self.log.warn("Removing unused grade_id from cell {}".format(cell_index))
-                del cell.metadata.nbgrader['grade_id']
-
-        return cell, resources

--- a/nbgrader/preprocessors/headerfooter.py
+++ b/nbgrader/preprocessors/headerfooter.py
@@ -1,8 +1,8 @@
-from nbformat import read as read_nb
 from nbformat import current_nbformat
 from traitlets import Unicode
 
 from . import NbGraderPreprocessor
+from ..nbformat import read as read_nb
 
 
 class IncludeHeaderFooter(NbGraderPreprocessor):

--- a/nbgrader/tests/apps/test_nbgrader_autograde.py
+++ b/nbgrader/tests/apps/test_nbgrader_autograde.py
@@ -5,10 +5,11 @@ import pytest
 
 from os.path import join
 from textwrap import dedent
-from nbformat.v4 import reads
+from nbformat import current_nbformat
 
 from ...api import Gradebook
 from ...utils import remove
+from ...nbformat import reads
 from .. import run_nbgrader
 from .base import BaseTestApp
 
@@ -628,11 +629,11 @@ class TestNbGraderAutograde(BaseTestApp):
 
         self._copy_file(join("files", "test-with-output.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         with open(join(os.path.dirname(__file__), "files", "test-with-output.ipynb"), "r") as fh:
-            orig_contents = reads(fh.read())
+            orig_contents = reads(fh.read(), as_version=current_nbformat)
 
         run_nbgrader(["autograde", "ps1"])
         with open(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"), "r") as fh:
-            new_contents = reads(fh.read())
+            new_contents = reads(fh.read(), as_version=current_nbformat)
 
         different = False
         for i in range(len(orig_contents.cells)):
@@ -649,7 +650,7 @@ class TestNbGraderAutograde(BaseTestApp):
 
         run_nbgrader(["autograde", "ps1", "--force", "--no-execute"])
         with open(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"), "r") as fh:
-            new_contents = reads(fh.read())
+            new_contents = reads(fh.read(), as_version=current_nbformat)
 
         for i in range(len(orig_contents.cells)):
             orig_cell = orig_contents.cells[i]

--- a/nbgrader/tests/preprocessors/base.py
+++ b/nbgrader/tests/preprocessors/base.py
@@ -1,7 +1,7 @@
 import os
 
 from nbformat import current_nbformat
-from nbformat import read as read_nb
+from ...nbformat import read as read_nb
 
 
 class BaseTestPreprocessor(object):

--- a/nbgrader/tests/preprocessors/base.py
+++ b/nbgrader/tests/preprocessors/base.py
@@ -1,13 +1,16 @@
 import os
 
-from nbformat import current_nbformat
+from nbformat import current_nbformat, read
 from ...nbformat import read as read_nb
 
 
 class BaseTestPreprocessor(object):
 
-    def _read_nb(self, filename):
+    def _read_nb(self, filename, validate=True):
         fullpath = os.path.join(os.path.dirname(__file__), filename)
         with open(fullpath, "r") as fh:
-            nb = read_nb(fh, as_version=current_nbformat)
+            if validate:
+                nb = read_nb(fh, as_version=current_nbformat)
+            else:
+                nb = read(fh, as_version=current_nbformat)
         return nb

--- a/nbgrader/tests/preprocessors/test_checkcellmetadata.py
+++ b/nbgrader/tests/preprocessors/test_checkcellmetadata.py
@@ -5,7 +5,7 @@ from ...preprocessors import CheckCellMetadata
 from .base import BaseTestPreprocessor
 from .. import create_grade_cell, create_solution_cell
 from nbformat.v4 import new_notebook
-from ...metadata_format import ValidationError
+from ...nbformat import ValidationError
 
 @pytest.fixture
 def preprocessor():
@@ -16,13 +16,13 @@ class TestCheckCellMetadata(BaseTestPreprocessor):
 
     def test_duplicate_grade_ids(self, preprocessor):
         """Check that an error is raised when there are duplicate grade ids"""
-        nb = self._read_nb(os.path.join("files", "duplicate-grade-ids.ipynb"))
+        nb = self._read_nb(os.path.join("files", "duplicate-grade-ids.ipynb"), validate=False)
         with pytest.raises(ValidationError):
             preprocessor.preprocess(nb, {})
 
     def test_blank_grade_id(self, preprocessor):
         """Check that an error is raised when the grade id is blank"""
-        nb = self._read_nb(os.path.join("files", "blank-grade-id.ipynb"))
+        nb = self._read_nb(os.path.join("files", "blank-grade-id.ipynb"), validate=False)
         with pytest.raises(ValidationError):
             preprocessor.preprocess(nb, {})
 
@@ -68,29 +68,29 @@ class TestCheckCellMetadata(BaseTestPreprocessor):
 
     def test_blank_points(self, preprocessor):
         """Check that an error is raised if the points are blank"""
-        nb = self._read_nb(os.path.join("files", "blank-points.ipynb"))
+        nb = self._read_nb(os.path.join("files", "blank-points.ipynb"), validate=False)
         with pytest.raises(ValidationError):
             preprocessor.preprocess(nb, {})
 
     def test_no_duplicate_grade_ids(self, preprocessor):
         """Check that no errors are raised when grade ids are unique and not blank"""
-        nb = self._read_nb(os.path.join("files", "test.ipynb"))
+        nb = self._read_nb(os.path.join("files", "test.ipynb"), validate=False)
         preprocessor.preprocess(nb, {})
 
     def test_code_cell_solution_grade(self, preprocessor):
         """Check that an error is not raised when a code cell is marked as both solution and grade"""
-        nb = self._read_nb(os.path.join("files", "manually-graded-code-cell.ipynb"))
+        nb = self._read_nb(os.path.join("files", "manually-graded-code-cell.ipynb"), validate=False)
         preprocessor.preprocess(nb, {})
 
     def test_markdown_cell_grade(self, preprocessor):
         """Check that an error is raised when a markdown cell is only marked as grade"""
-        nb = self._read_nb(os.path.join("files", "bad-markdown-cell-1.ipynb"))
+        nb = self._read_nb(os.path.join("files", "bad-markdown-cell-1.ipynb"), validate=False)
         with pytest.raises(ValidationError):
             preprocessor.preprocess(nb, {})
 
     def test_markdown_cell_solution(self, preprocessor):
         """Check that an error is raised when a markdown cell is only marked as solution"""
-        nb = self._read_nb(os.path.join("files", "bad-markdown-cell-2.ipynb"))
+        nb = self._read_nb(os.path.join("files", "bad-markdown-cell-2.ipynb"), validate=False)
         with pytest.raises(ValidationError):
             preprocessor.preprocess(nb, {})
 

--- a/nbgrader/tests/preprocessors/test_checkcellmetadata.py
+++ b/nbgrader/tests/preprocessors/test_checkcellmetadata.py
@@ -4,6 +4,8 @@ import os
 from ...preprocessors import CheckCellMetadata
 from .base import BaseTestPreprocessor
 from .. import create_grade_cell, create_solution_cell
+from nbformat.v4 import new_notebook
+from ...metadata_format import ValidationError
 
 @pytest.fixture
 def preprocessor():
@@ -15,57 +17,59 @@ class TestCheckCellMetadata(BaseTestPreprocessor):
     def test_duplicate_grade_ids(self, preprocessor):
         """Check that an error is raised when there are duplicate grade ids"""
         nb = self._read_nb(os.path.join("files", "duplicate-grade-ids.ipynb"))
-        with pytest.raises(RuntimeError):
+        with pytest.raises(ValidationError):
             preprocessor.preprocess(nb, {})
 
     def test_blank_grade_id(self, preprocessor):
         """Check that an error is raised when the grade id is blank"""
         nb = self._read_nb(os.path.join("files", "blank-grade-id.ipynb"))
-        with pytest.raises(RuntimeError):
+        with pytest.raises(ValidationError):
             preprocessor.preprocess(nb, {})
 
     def test_invalid_grade_cell_id(self, preprocessor):
         """Check that an error is raised when the grade cell id is invalid"""
         resources = dict(grade_ids=[])
+        nb = new_notebook()
 
-        cell = create_grade_cell("", "code", "", 1)
-        with pytest.raises(RuntimeError):
-            preprocessor.preprocess_cell(cell, resources, 0)
+        nb.cells = [create_grade_cell("", "code", "", 1)]
+        with pytest.raises(ValidationError):
+            preprocessor.preprocess(nb, resources)
 
-        cell = create_grade_cell("", "code", "a b", 1)
-        with pytest.raises(RuntimeError):
-            preprocessor.preprocess_cell(cell, resources, 0)
+        nb.cells = [create_grade_cell("", "code", "a b", 1)]
+        with pytest.raises(ValidationError):
+            preprocessor.preprocess(nb, resources)
 
-        cell = create_grade_cell("", "code", "a\"b", 1)
-        with pytest.raises(RuntimeError):
-            preprocessor.preprocess_cell(cell, resources, 0)
+        nb.cells = [create_grade_cell("", "code", "a\"b", 1)]
+        with pytest.raises(ValidationError):
+            preprocessor.preprocess(nb, resources)
 
-        cell = create_solution_cell("", "code", "abc-ABC_0")
-        preprocessor.preprocess_cell(cell, resources, 0)
+        nb.cells = [create_solution_cell("", "code", "abc-ABC_0")]
+        preprocessor.preprocess(nb, resources)
 
     def test_invalid_solution_cell_id(self, preprocessor):
         """Check that an error is raised when the solution id is invalid"""
         resources = dict(grade_ids=[])
+        nb = new_notebook()
 
-        cell = create_solution_cell("", "code", "")
-        with pytest.raises(RuntimeError):
-            preprocessor.preprocess_cell(cell, resources, 0)
+        nb.cells = [create_solution_cell("", "code", "")]
+        with pytest.raises(ValidationError):
+            preprocessor.preprocess(nb, resources)
 
-        cell = create_solution_cell("", "code", "a b")
-        with pytest.raises(RuntimeError):
-            preprocessor.preprocess_cell(cell, resources, 0)
+        nb.cells = [create_solution_cell("", "code", "a b")]
+        with pytest.raises(ValidationError):
+            preprocessor.preprocess(nb, resources)
 
-        cell = create_solution_cell("", "code", "a\"b")
-        with pytest.raises(RuntimeError):
-            preprocessor.preprocess_cell(cell, resources, 0)
+        nb.cells = [create_solution_cell("", "code", "a\"b")]
+        with pytest.raises(ValidationError):
+            preprocessor.preprocess(nb, resources)
 
-        cell = create_solution_cell("", "code", "abc-ABC_0")
-        preprocessor.preprocess_cell(cell, resources, 0)
+        nb.cells = [create_solution_cell("", "code", "abc-ABC_0")]
+        preprocessor.preprocess(nb, resources)
 
     def test_blank_points(self, preprocessor):
         """Check that an error is raised if the points are blank"""
         nb = self._read_nb(os.path.join("files", "blank-points.ipynb"))
-        with pytest.raises(RuntimeError):
+        with pytest.raises(ValidationError):
             preprocessor.preprocess(nb, {})
 
     def test_no_duplicate_grade_ids(self, preprocessor):
@@ -81,24 +85,37 @@ class TestCheckCellMetadata(BaseTestPreprocessor):
     def test_markdown_cell_grade(self, preprocessor):
         """Check that an error is raised when a markdown cell is only marked as grade"""
         nb = self._read_nb(os.path.join("files", "bad-markdown-cell-1.ipynb"))
-        with pytest.raises(RuntimeError):
+        with pytest.raises(ValidationError):
             preprocessor.preprocess(nb, {})
 
     def test_markdown_cell_solution(self, preprocessor):
         """Check that an error is raised when a markdown cell is only marked as solution"""
         nb = self._read_nb(os.path.join("files", "bad-markdown-cell-2.ipynb"))
-        with pytest.raises(RuntimeError):
+        with pytest.raises(ValidationError):
             preprocessor.preprocess(nb, {})
 
     def test_non_nbgrader_cell_blank_grade_id(self, preprocessor):
         resources = dict(grade_ids=[])
+        nb = new_notebook()
         cell = create_grade_cell("", "code", "", 1)
         cell.metadata.nbgrader['grade'] = False
-        new_cell, _ = preprocessor.preprocess_cell(cell, resources, 0)
-        assert 'grade_id' not in new_cell.metadata.nbgrader
+        nb.cells = [cell]
+        new_nb, _ = preprocessor.preprocess(nb, resources)
+        assert 'grade_id' not in new_nb.cells[0].metadata.nbgrader
 
         resources = dict(grade_ids=[])
+        nb = new_notebook()
         cell = create_solution_cell("", "code", "")
         cell.metadata.nbgrader['solution'] = False
-        new_cell, _ = preprocessor.preprocess_cell(cell, resources, 0)
-        assert 'grade_id' not in new_cell.metadata.nbgrader
+        nb.cells = [cell]
+        new_nb, _ = preprocessor.preprocess(nb, resources)
+        assert 'grade_id' not in new_nb.cells[0].metadata.nbgrader
+
+    def test_extra_properties(self, preprocessor):
+        resources = dict(grade_ids=[])
+        nb = new_notebook()
+        cell = create_grade_cell("", "code", "asawef", 1)
+        cell.metadata.nbgrader['foo'] = "blah"
+        nb.cells = [cell]
+        new_nb, _ = preprocessor.preprocess(nb, resources)
+        assert 'foo' not in new_nb.cells[0].metadata.nbgrader

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,8 @@ setup_args = dict(
         "jupyter_client",
         "tornado",
         "six",
-        "requests"
+        "requests",
+        "jsonschema"
     ]
 )
 


### PR DESCRIPTION
Fixes #478

This adds in a schema for the nbgrader metadata, and validates it in a number of places. There is no validation of the metadata currently in the create assignment extension, but I think that is going to be fairly complicated to implement so I'm saving it for a future PR.