### PR TITLE
Don't fail `test_check_version` test on `'import sitecustomize' failed error`

### DIFF
--- a/nbgrader/tests/apps/test_nbgrader.py
+++ b/nbgrader/tests/apps/test_nbgrader.py
@@ -30,6 +30,10 @@ class TestNbGrader(BaseTestApp):
 
     def test_check_version(self, capfd):
         """Is the version the same regardless of how we run nbgrader?"""
-        out1 = "\n".join(run_command(["nbgrader", "--version"]).splitlines()).strip()
-        out2 = run_nbgrader(["--version"], stdout=True).strip()
+        out1 = '\n'.join(
+            run_command(["nbgrader", "--version"]).splitlines()[-3:]
+        ).strip()
+        out2 = '\n'.join(
+            run_nbgrader(["--version"], stdout=True).splitlines()[-3:]
+        ).strip()
         assert out1 == out2


### PR DESCRIPTION
On the conda forge linux image the stupid `'import sitecustomize' failed` error pops up which causes the `test_check_version` test to fail, eg: https://circleci.com/gh/lgpage/staged-recipes/48

This PR updated the test to only check the last line output, I.e. only checks the `nbgrader` version info and not anything else.