### PR TITLE
Preventing URI Encoding of the base-url in the assignment_list extension

### DIFF
--- a/nbgrader/nbextensions/assignment_list/assignment_list.js
+++ b/nbgrader/nbextensions/assignment_list/assignment_list.js
@@ -35,7 +35,6 @@ define([
         this.data = undefined;
     };
 
-
     CourseList.prototype.bind_events = function () {
         var that = this;
         this.refresh_element.click(function () {
@@ -73,7 +72,7 @@ define([
             success : $.proxy(this.handle_load_list, this),
             error : utils.log_ajax_error,
         };
-        var url = utils.url_join_encode(this.base_url, 'courses');
+        var url = utils.url_path_join(this.base_url, 'courses');
         ajax(url, settings);
     };
 
@@ -174,7 +173,7 @@ define([
             success : $.proxy(this.handle_load_list, this),
             error : utils.log_ajax_error,
         };
-        var url = utils.url_join_encode(this.base_url, 'assignments');
+        var url = utils.url_path_join(this.base_url, 'assignments');
         ajax(url, settings);
     };
 
@@ -413,7 +412,7 @@ define([
                 };
                 button.text('Fetching...');
                 button.attr('disabled', 'disabled');
-                var url = utils.url_join_encode(
+                var url = utils.url_path_join(
                     that.base_url,
                     'assignments',
                     'fetch'
@@ -448,7 +447,7 @@ define([
                 };
                 button.text('Submitting...');
                 button.attr('disabled', 'disabled');
-                var url = utils.url_join_encode(
+                var url = utils.url_path_join(
                     that.base_url,
                     'assignments',
                     'submit'
@@ -475,7 +474,7 @@ define([
 
     Notebook.prototype.make_row = function () {
         var container = $('<div/>').addClass('col-md-12');
-        var url = utils.url_join_encode(this.base_url, 'tree', this.data.path);
+        var url = utils.url_path_join(this.base_url, 'tree', utils.url_join_encode(this.data.path));
         var link = $('<span/>').addClass('item_name col-sm-6').append(
             $('<a/>')
                 .attr("href", url)
@@ -512,7 +511,7 @@ define([
             };
             button.text('Validating...');
             button.attr('disabled', 'disabled');
-            var url = utils.url_join_encode(
+            var url = utils.url_path_join(
                 that.base_url,
                 'assignments',
                 'validate'


### PR DESCRIPTION
The base-url is not expected to be encoded in the server-side jupyter web handlers, so certain character (e.g., @)  were causing 404s due to mismatch between the nbextension URLs and the server extension API URLs.

You can see an example of how this is dealt with in the jupyter project [here](https://github.com/jupyter/jupyter_server/blob/dd4b052403cc0ce70dbde9bfc6c71d6b09e814ec/notebook/static/services/config.js#L26) and [here](https://github.com/jupyter/jupyter_server/blob/dd4b052403cc0ce70dbde9bfc6c71d6b09e814ec/notebook/static/services/contents.js#L45).

This is an issue because in my JupyterHub deployment, usernames are email addresses which contain `@`, which becomes `%40` when encoded. This means the URLs for the AJAX calls are invalid.

I left the URI encoding of the file paths, as is done in other jupyter extensions. 

This is a very helpful project, by the way. Thank you.