### PR TITLE
Use sys.executable when executing nbgrader

### DIFF
--- a/nbgrader/tests/apps/test_nbgrader.py
+++ b/nbgrader/tests/apps/test_nbgrader.py
@@ -31,7 +31,7 @@ class TestNbGrader(BaseTestApp):
     def test_check_version(self, capfd):
         """Is the version the same regardless of how we run nbgrader?"""
         out1 = '\n'.join(
-            run_command(["nbgrader", "--version"]).splitlines()[-3:]
+            run_command([sys.executable, "-m", "nbgrader", "--version"]).splitlines()[-3:]
         ).strip()
         out2 = '\n'.join(
             run_nbgrader(["--version"], stdout=True).splitlines()[-3:]


### PR DESCRIPTION
Just in case it is somehow finding another version of nbgrader...