### PR TITLE
Force phantomjs service to terminate in Linux

### DIFF
--- a/nbgrader/tests/nbextensions/conftest.py
+++ b/nbgrader/tests/nbextensions/conftest.py
@@ -205,9 +205,10 @@ def browser(request, tempdir, nbserver):
                 print(message)
             print("<------------------------------------------>")
         browser.save_screenshot(os.path.join(os.path.dirname(__file__), 'selenium.screenshot.png'))
+        browser.service.process.send_signal(signal.SIGTERM)
         browser.quit()
-    request.addfinalizer(fin)
 
+    request.addfinalizer(fin)
     return browser
 
 


### PR DESCRIPTION
See https://github.com/SeleniumHQ/selenium/issues/767

This gave me grief while messing around with ``nbextension`` tests, managed to freeze up my PC after running out of memory.