### PR TITLE
use check_call for extension installation in tests

### DIFF
--- a/nbgrader/tests/nbextensions/conftest.py
+++ b/nbgrader/tests/nbextensions/conftest.py
@@ -121,9 +121,9 @@ def nbserver(request, port, tempdir, coursedir, jupyter_config_dir, jupyter_data
     env['JUPYTER_DATA_DIR'] = jupyter_data_dir
     env['HOME'] = tempdir
 
-    sp.Popen([sys.executable, "-m", "jupyter", "nbextension", "install", "--user", "--py", "nbgrader"], env=env)
-    sp.Popen([sys.executable, "-m", "jupyter", "nbextension", "enable", "--user", "--py", "nbgrader"], env=env)
-    sp.Popen([sys.executable, "-m", "jupyter", "serverextension", "enable", "--user", "--py", "nbgrader"], env=env)
+    sp.check_call([sys.executable, "-m", "jupyter", "nbextension", "install", "--user", "--py", "nbgrader"], env=env)
+    sp.check_call([sys.executable, "-m", "jupyter", "nbextension", "enable", "--user", "--py", "nbgrader"], env=env)
+    sp.check_call([sys.executable, "-m", "jupyter", "serverextension", "enable", "--user", "--py", "nbgrader"], env=env)
 
     # create nbgrader_config.py file
     if sys.platform != 'win32':


### PR DESCRIPTION
rather than Popen, which just launches the program.

check_call adds:

- wait for it to finish
- raise error on nonzero exit code

should close #694, if slow extension enabling was indeed the culprit.