### PR TITLE
Move some config options into a CourseDirectory object.

### DIFF
--- a/nbgrader/apps/baseapp.py
+++ b/nbgrader/apps/baseapp.py
@@ -233,6 +233,27 @@ class NbGrader(JupyterApp):
             cfg.NbGrader.merge(cfg.BaseApp)
             del cfg.BaseApp
 
+        coursedir_options = [
+            ("student_id", "student_id"),
+            ("assignment_id", "assignment_id"),
+            ("notebook_id", "notebook_id"),
+            ("directory_structure", "directory_structure"),
+            ("source_directory", "source_directory"),
+            ("release_directory", "release_directory"),
+            ("submitted_directory", "submitted_directory"),
+            ("autograded_directory", "autograded_directory"),
+            ("feedback_directory", "feedback_directory"),
+            ("db_url", "db_url"),
+            ("course_directory", "root"),
+            ("ignore", "ignore")
+        ]
+
+        for old_opt, new_opt in coursedir_options:
+            if old_opt in cfg.NbGrader:
+                self.log.warn("Outdated config: use CourseDirectory.{} rather than NbGrader.{}".format(new_opt, old_opt))
+                setattr(cfg.CourseDirectory, new_opt, cfg.NbGrader[old_opt])
+                delattr(cfg.NbGrader, old_opt)
+
         super(NbGrader, self)._load_config(cfg, **kwargs)
         if self.coursedir:
             self.coursedir._load_config(cfg)

--- a/nbgrader/apps/collectapp.py
+++ b/nbgrader/apps/collectapp.py
@@ -96,8 +96,8 @@ class CollectApp(TransferApp):
             self.fail("Course not found: {}".format(self.inbound_path))
         if not check_mode(self.inbound_path, read=True, execute=True):
             self.fail("You don't have read permissions for the directory: {}".format(self.inbound_path))
-        student_id = self.student_id if self.student_id else '*'
-        pattern = os.path.join(self.inbound_path, '{}+{}+*'.format(student_id, self.assignment_id))
+        student_id = self.coursedir.student_id if self.coursedir.student_id else '*'
+        pattern = os.path.join(self.inbound_path, '{}+{}+*'.format(student_id, self.coursedir.assignment_id))
         records = [self._path_to_record(f) for f in glob.glob(pattern)]
         usergroups = groupby(records, lambda item: item['username'])
         self.src_records = [self._sort_by_timestamp(v)[0] for v in usergroups.values()]
@@ -109,7 +109,7 @@ class CollectApp(TransferApp):
         for rec in self.src_records:
             student_id = rec['username']
             src_path = os.path.join(self.inbound_path, rec['filename'])
-            dest_path = self._format_path(self.submitted_directory, student_id, self.assignment_id)
+            dest_path = self.coursedir.format_path(self.coursedir.submitted_directory, student_id, self.coursedir.assignment_id)
             if not os.path.exists(os.path.dirname(dest_path)):
                 os.makedirs(os.path.dirname(dest_path))
 
@@ -126,17 +126,17 @@ class CollectApp(TransferApp):
 
             if copy:
                 if updating:
-                    self.log.info("Updating submission: {} {}".format(student_id, self.assignment_id))
+                    self.log.info("Updating submission: {} {}".format(student_id, self.coursedir.assignment_id))
                     shutil.rmtree(dest_path)
                 else:
-                    self.log.info("Collecting submission: {} {}".format(student_id, self.assignment_id))
+                    self.log.info("Collecting submission: {} {}".format(student_id, self.coursedir.assignment_id))
                 self.do_copy(src_path, dest_path)
             else:
                 if self.update:
                     self.log.info("No newer submission to collect: {} {}".format(
-                        student_id, self.assignment_id
+                        student_id, self.coursedir.assignment_id
                     ))
                 else:
                     self.log.info("Submission already exists, use --update to update: {} {}".format(
-                        student_id, self.assignment_id
+                        student_id, self.coursedir.assignment_id
                     ))

--- a/nbgrader/apps/dbapp.py
+++ b/nbgrader/apps/dbapp.py
@@ -12,8 +12,8 @@ from ..api import Gradebook, MissingEntry
 
 aliases = {
     'log-level': 'Application.log_level',
-    'course-dir': 'NbGrader.course_directory',
-    'db': 'NbGrader.db_url'
+    'course-dir': 'CourseDirectory.root',
+    'db': 'CourseDirectory.db_url'
 }
 flags = {}
 
@@ -65,7 +65,7 @@ class DbStudentAddApp(NbGrader):
         }
 
         self.log.info("Creating/updating student with ID '%s': %s", student_id, student)
-        with Gradebook(self.db_url) as gb:
+        with Gradebook(self.coursedir.db_url) as gb:
             gb.update_or_create_student(student_id, **student)
 
 student_remove_flags = {}
@@ -95,7 +95,7 @@ class DbStudentRemoveApp(NbGrader):
 
         student_id = self.extra_args[0]
 
-        with Gradebook(self.db_url) as gb:
+        with Gradebook(self.coursedir.db_url) as gb:
             try:
                 student = gb.find_student(student_id)
             except MissingEntry:
@@ -134,7 +134,7 @@ class DbStudentImportApp(NbGrader):
 
         allowed_keys = ["last_name", "first_name", "email", "id"]
 
-        with Gradebook(self.db_url) as gb:
+        with Gradebook(self.coursedir.db_url) as gb:
             with open(path, 'r') as fh:
                 reader = csv.DictReader(fh)
                 for row in reader:
@@ -168,7 +168,7 @@ class DbStudentListApp(NbGrader):
     def start(self):
         super(DbStudentListApp, self).start()
 
-        with Gradebook(self.db_url) as gb:
+        with Gradebook(self.coursedir.db_url) as gb:
             print("There are %d students in the database:" % len(gb.students))
             for student in gb.students:
                 print("%s (%s, %s) -- %s" % (student.id, student.last_name, student.first_name, student.email))
@@ -206,7 +206,7 @@ class DbAssignmentAddApp(NbGrader):
         }
 
         self.log.info("Creating/updating assignment with ID '%s': %s", assignment_id, assignment)
-        with Gradebook(self.db_url) as gb:
+        with Gradebook(self.coursedir.db_url) as gb:
             gb.update_or_create_assignment(assignment_id, **assignment)
 
 
@@ -237,7 +237,7 @@ class DbAssignmentRemoveApp(NbGrader):
 
         assignment_id = self.extra_args[0]
 
-        with Gradebook(self.db_url) as gb:
+        with Gradebook(self.coursedir.db_url) as gb:
             try:
                 assignment = gb.find_assignment(assignment_id)
             except MissingEntry:
@@ -276,7 +276,7 @@ class DbAssignmentImportApp(NbGrader):
 
         allowed_keys = ["duedate", "name"]
 
-        with Gradebook(self.db_url) as gb:
+        with Gradebook(self.coursedir.db_url) as gb:
             with open(path, 'r') as fh:
                 reader = csv.DictReader(fh)
                 for row in reader:
@@ -310,7 +310,7 @@ class DbAssignmentListApp(NbGrader):
     def start(self):
         super(DbAssignmentListApp, self).start()
 
-        with Gradebook(self.db_url) as gb:
+        with Gradebook(self.coursedir.db_url) as gb:
             print("There are %d assignments in the database:" % len(gb.assignments))
             for assignment in gb.assignments:
                 print("%s (due: %s)" % (assignment.name, assignment.duedate))

--- a/nbgrader/apps/exportapp.py
+++ b/nbgrader/apps/exportapp.py
@@ -5,7 +5,7 @@ from ..api import Gradebook
 
 aliases = {
     'log-level' : 'Application.log_level',
-    'db': 'NbGrader.db_url',
+    'db': 'CourseDirectory.db_url',
     'to' : 'ExportPlugin.to',
     'exporter': 'ExportApp.plugin_class'
 }
@@ -60,5 +60,5 @@ class ExportApp(NbGrader):
     def start(self):
         super(ExportApp, self).start()
         self.init_plugin()
-        with Gradebook(self.db_url) as gb:
+        with Gradebook(self.coursedir.db_url) as gb:
             self.plugin_inst.export(gb)

--- a/nbgrader/apps/feedbackapp.py
+++ b/nbgrader/apps/feedbackapp.py
@@ -53,11 +53,11 @@ class FeedbackApp(BaseNbConvertApp):
 
     @property
     def _input_directory(self):
-        return self.autograded_directory
+        return self.coursedir.autograded_directory
 
     @property
     def _output_directory(self):
-        return self.feedback_directory
+        return self.coursedir.feedback_directory
 
     preprocessors = List([
         GetGrades,

--- a/nbgrader/apps/fetchapp.py
+++ b/nbgrader/apps/fetchapp.py
@@ -59,7 +59,7 @@ class FetchApp(TransferApp):
 
         self.course_path = os.path.join(self.exchange_directory, self.course_id)
         self.outbound_path = os.path.join(self.course_path, 'outbound')
-        self.src_path = os.path.join(self.outbound_path, self.assignment_id)
+        self.src_path = os.path.join(self.outbound_path, self.coursedir.assignment_id)
         if not os.path.isdir(self.src_path):
             self.fail("Assignment not found: {}".format(self.src_path))
         if not check_mode(self.src_path, read=True, execute=True):
@@ -67,9 +67,9 @@ class FetchApp(TransferApp):
 
     def init_dest(self):
         if self.path_includes_course:
-            root = os.path.join(self.course_id, self.assignment_id)
+            root = os.path.join(self.course_id, self.coursedir.assignment_id)
         else:
-            root = self.assignment_id
+            root = self.coursedir.assignment_id
         self.dest_path = os.path.abspath(os.path.join('.', root))
         if os.path.isdir(self.dest_path) and not self.replace_missing_files:
             self.fail("You already have a copy of the assignment in this directory: {}".format(root))
@@ -98,11 +98,11 @@ class FetchApp(TransferApp):
 
 
     def do_copy(self, src, dest, perms=None):
-        """Copy the src dir to the dest dir omitting the self.ignore globs."""
+        """Copy the src dir to the dest dir omitting the self.coursedir.ignore globs."""
         if os.path.isdir(self.dest_path):
-            self.copy_if_missing(src, dest, ignore=shutil.ignore_patterns(*self.ignore))
+            self.copy_if_missing(src, dest, ignore=shutil.ignore_patterns(*self.coursedir.ignore))
         else:
-            shutil.copytree(src, dest, ignore=shutil.ignore_patterns(*self.ignore))
+            shutil.copytree(src, dest, ignore=shutil.ignore_patterns(*self.coursedir.ignore))
 
         if perms:
             for dirname, dirnames, filenames in os.walk(dest):
@@ -113,4 +113,4 @@ class FetchApp(TransferApp):
         self.log.info("Source: {}".format(self.src_path))
         self.log.info("Destination: {}".format(self.dest_path))
         self.do_copy(self.src_path, self.dest_path)
-        self.log.info("Fetched as: {} {}".format(self.course_id, self.assignment_id))
+        self.log.info("Fetched as: {} {}".format(self.course_id, self.coursedir.assignment_id))

--- a/nbgrader/apps/listapp.py
+++ b/nbgrader/apps/listapp.py
@@ -99,8 +99,8 @@ class ListApp(TransferApp):
 
     def init_dest(self):
         course_id = self.course_id if self.course_id else '*'
-        assignment_id = self.assignment_id if self.assignment_id else '*'
-        student_id = self.student_id if self.student_id else '*'
+        assignment_id = self.coursedir.assignment_id if self.coursedir.assignment_id else '*'
+        student_id = self.coursedir.student_id if self.coursedir.student_id else '*'
 
         if self.inbound:
             pattern = os.path.join(self.exchange_directory, course_id, 'inbound', '{}+{}+*'.format(student_id, assignment_id))

--- a/nbgrader/apps/releaseapp.py
+++ b/nbgrader/apps/releaseapp.py
@@ -72,14 +72,14 @@ class ReleaseApp(TransferApp):
 
     def build_extra_config(self):
         extra_config = super(ReleaseApp, self).build_extra_config()
-        extra_config.NbGrader.student_id = '.'
-        extra_config.NbGrader.notebook_id = '*'
+        extra_config.CourseDirectory.student_id = '.'
+        extra_config.CourseDirectory.notebook_id = '*'
         return extra_config
 
     def init_src(self):
-        self.src_path = self._format_path(self.release_directory, self.student_id, self.assignment_id)
+        self.src_path = self.coursedir.format_path(self.coursedir.release_directory, self.coursedir.student_id, self.coursedir.assignment_id)
         if not os.path.isdir(self.src_path):
-            source = self._format_path(self.source_directory, self.student_id, self.assignment_id)
+            source = self.coursedir.format_path(self.coursedir.source_directory, self.coursedir.student_id, self.coursedir.assignment_id)
             if os.path.isdir(source):
                 # Looks like the instructor forgot to assign
                 self.fail("Assignment found in '{}' but not '{}', run `nbgrader assign` first.".format(
@@ -94,7 +94,7 @@ class ReleaseApp(TransferApp):
         self.course_path = os.path.join(self.exchange_directory, self.course_id)
         self.outbound_path = os.path.join(self.course_path, 'outbound')
         self.inbound_path = os.path.join(self.course_path, 'inbound')
-        self.dest_path = os.path.join(self.outbound_path, self.assignment_id)
+        self.dest_path = os.path.join(self.outbound_path, self.coursedir.assignment_id)
         # 0755
         self.ensure_directory(
             self.course_path,
@@ -126,15 +126,15 @@ class ReleaseApp(TransferApp):
         if os.path.isdir(self.dest_path):
             if self.force:
                 self.log.info("Overwriting files: {} {}".format(
-                    self.course_id, self.assignment_id
+                    self.course_id, self.coursedir.assignment_id
                 ))
                 shutil.rmtree(self.dest_path)
             else:
                 self.fail("Destination already exists, add --force to overwrite: {} {}".format(
-                    self.course_id, self.assignment_id
+                    self.course_id, self.coursedir.assignment_id
                 ))
         self.log.info("Source: {}".format(self.src_path))
         self.log.info("Destination: {}".format(self.dest_path))
         perms = S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH
         self.do_copy(self.src_path, self.dest_path, perms=perms)
-        self.log.info("Released as: {} {}".format(self.course_id, self.assignment_id))
+        self.log.info("Released as: {} {}".format(self.course_id, self.coursedir.assignment_id))

--- a/nbgrader/apps/submitapp.py
+++ b/nbgrader/apps/submitapp.py
@@ -67,11 +67,11 @@ class SubmitApp(TransferApp):
 
     def init_src(self):
         if self.path_includes_course:
-            root = os.path.join(self.course_id, self.assignment_id)
+            root = os.path.join(self.course_id, self.coursedir.assignment_id)
         else:
-            root = self.assignment_id
+            root = self.coursedir.assignment_id
         self.src_path = os.path.abspath(root)
-        self.assignment_id = os.path.split(self.src_path)[-1]
+        self.coursedir.assignment_id = os.path.split(self.src_path)[-1]
         if not os.path.isdir(self.src_path):
             self.fail("Assignment not found: {}".format(self.src_path))
 
@@ -86,7 +86,7 @@ class SubmitApp(TransferApp):
             self.fail("You don't have write permissions to the directory: {}".format(self.inbound_path))
 
         self.cache_path = os.path.join(self.cache_directory, self.course_id)
-        self.assignment_filename = '{}+{}+{}'.format(get_username(), self.assignment_id, self.timestamp)
+        self.assignment_filename = '{}+{}+{}'.format(get_username(), self.coursedir.assignment_id, self.timestamp)
 
     def init_release(self):
         if self.course_id == '':
@@ -94,7 +94,7 @@ class SubmitApp(TransferApp):
 
         course_path = os.path.join(self.exchange_directory, self.course_id)
         outbound_path = os.path.join(course_path, 'outbound')
-        self.release_path = os.path.join(outbound_path, self.assignment_id)
+        self.release_path = os.path.join(outbound_path, self.coursedir.assignment_id)
         if not os.path.isdir(self.release_path):
             self.fail("Assignment not found: {}".format(self.release_path))
         if not check_mode(self.release_path, read=True, execute=True):
@@ -135,13 +135,13 @@ class SubmitApp(TransferApp):
                 self.fail(
                     "Assignment {} not submitted. "
                     "There are missing notebooks for the submission:\n{}"
-                    "".format(self.assignment_id, diff_msg)
+                    "".format(self.coursedir.assignment_id, diff_msg)
                 )
             else:
                 self.log.warning(
                     "Possible missing notebooks and/or extra notebooks "
                     "submitted for assignment {}:\n{}"
-                    "".format(self.assignment_id, diff_msg)
+                    "".format(self.coursedir.assignment_id, diff_msg)
                 )
 
     def copy_files(self):
@@ -174,5 +174,5 @@ class SubmitApp(TransferApp):
             fh.write(self.timestamp)
 
         self.log.info("Submitted as: {} {} {}".format(
-            self.course_id, self.assignment_id, str(self.timestamp)
+            self.course_id, self.coursedir.assignment_id, str(self.timestamp)
         ))

--- a/nbgrader/apps/zipcollectapp.py
+++ b/nbgrader/apps/zipcollectapp.py
@@ -191,12 +191,12 @@ class ZipCollectApp(NbGrader):
     def _format_collect_path(self, collect_step):
         kwargs = dict(
             downloaded=self.downloaded_directory,
-            assignment_id=self.assignment_id,
+            assignment_id=self.coursedir.assignment_id,
             collect_step=collect_step,
         )
 
         path = os.path.join(
-            self.course_directory,
+            self.coursedir.root,
             self.collect_directory_structure,
         ).format(**kwargs)
 
@@ -282,13 +282,13 @@ class ZipCollectApp(NbGrader):
             }
         """
         self.log.info("Start collecting files...")
-        released_path = self._format_path(
-            self.release_directory, '.', self.assignment_id)
+        released_path = self.coursedir.format_path(
+            self.coursedir.release_directory, '.', self.coursedir.assignment_id)
         released_notebooks = find_all_notebooks(released_path)
         if not released_notebooks:
             self.log.warn(
                 "No release notebooks found for assignment {}"
-                "".format(self.assignment_id)
+                "".format(self.coursedir.assignment_id)
             )
 
         data = dict()
@@ -332,8 +332,8 @@ class ZipCollectApp(NbGrader):
                 self.log.warn(
                     "Invalid submission notebook name '{}'".format(submission))
 
-            submitted_path = self._format_path(
-                self.submitted_directory, info['student_id'], self.assignment_id)
+            submitted_path = self.coursedir.format_path(
+                self.coursedir.submitted_directory, info['student_id'], self.coursedir.assignment_id)
             dest_path = os.path.join(submitted_path, submission)
 
             timestamp = None
@@ -431,8 +431,8 @@ class ZipCollectApp(NbGrader):
 
         self.log.info("Start transfering files...")
         for student_id, data in collected_data.items():
-            dest_path = self._format_path(
-                self.submitted_directory, student_id, self.assignment_id)
+            dest_path = self.coursedir.format_path(
+                self.coursedir.submitted_directory, student_id, self.coursedir.assignment_id)
             self._mkdirs_if_missing(dest_path)
             self._clear_existing_files(dest_path)
 
@@ -476,10 +476,10 @@ class ZipCollectApp(NbGrader):
 
         # set assignemnt and course
         if len(self.extra_args) == 1:
-            self.assignment_id = self.extra_args[0]
+            self.coursedir.assignment_id = self.extra_args[0]
         elif len(self.extra_args) > 2:
             self.fail("Too many arguments")
-        elif self.assignment_id == "":
+        elif self.coursedir.assignment_id == "":
             self.fail(
                 "Must provide assignment name:\n"
                 "nbgrader zip_collect ASSIGNMENT"

--- a/nbgrader/coursedir.py
+++ b/nbgrader/coursedir.py
@@ -1,0 +1,173 @@
+import os
+import re
+
+from textwrap import dedent
+
+from traitlets.config import LoggingConfigurable
+from traitlets import Unicode, List, default
+
+from .utils import full_split
+
+
+class CourseDirectory(LoggingConfigurable):
+
+    student_id = Unicode(
+        "*",
+        help=dedent(
+            """
+            File glob to match student IDs. This can be changed to filter by
+            student. Note: this is always changed to '.' when running `nbgrader
+            assign`, as the assign step doesn't have any student ID associated
+            with it.
+            """
+        )
+    ).tag(config=True)
+
+    assignment_id = Unicode(
+        "",
+        help=dedent(
+            """
+            The assignment name. This MUST be specified, either by setting the
+            config option, passing an argument on the command line, or using the
+            --assignment option on the command line.
+            """
+        )
+    ).tag(config=True)
+
+    notebook_id = Unicode(
+        "*",
+        help=dedent(
+            """
+            File glob to match notebook names, excluding the '.ipynb' extension.
+            This can be changed to filter by notebook.
+            """
+        )
+    ).tag(config=True)
+
+    directory_structure = Unicode(
+        os.path.join("{nbgrader_step}", "{student_id}", "{assignment_id}"),
+        help=dedent(
+            """
+            Format string for the directory structure that nbgrader works
+            over during the grading process. This MUST contain named keys for
+            'nbgrader_step', 'student_id', and 'assignment_id'. It SHOULD NOT
+            contain a key for 'notebook_id', as this will be automatically joined
+            with the rest of the path.
+            """
+        )
+    ).tag(config=True)
+
+    source_directory = Unicode(
+        'source',
+        help=dedent(
+            """
+            The name of the directory that contains the master/instructor
+            version of assignments. This corresponds to the `nbgrader_step`
+            variable in the `directory_structure` config option.
+            """
+        )
+    ).tag(config=True)
+
+    release_directory = Unicode(
+        'release',
+        help=dedent(
+            """
+            The name of the directory that contains the version of the
+            assignment that will be released to students. This corresponds to
+            the `nbgrader_step` variable in the `directory_structure` config
+            option.
+            """
+        )
+    ).tag(config=True)
+
+    submitted_directory = Unicode(
+        'submitted',
+        help=dedent(
+            """
+            The name of the directory that contains assignments that have been
+            submitted by students for grading. This corresponds to the
+            `nbgrader_step` variable in the `directory_structure` config option.
+            """
+        )
+    ).tag(config=True)
+
+    autograded_directory = Unicode(
+        'autograded',
+        help=dedent(
+            """
+            The name of the directory that contains assignment submissions after
+            they have been autograded. This corresponds to the `nbgrader_step`
+            variable in the `directory_structure` config option.
+            """
+        )
+    ).tag(config=True)
+
+    feedback_directory = Unicode(
+        'feedback',
+        help=dedent(
+            """
+            The name of the directory that contains assignment feedback after
+            grading has been completed. This corresponds to the `nbgrader_step`
+            variable in the `directory_structure` config option.
+            """
+        )
+    ).tag(config=True)
+
+    db_url = Unicode(
+        "",
+        help=dedent(
+            """
+            URL to the database. Defaults to sqlite:///<root>/gradebook.db,
+            where <root> is another configurable variable.
+            """
+        )
+    ).tag(config=True)
+
+    @default("db_url")
+    def _db_url_default(self):
+        return "sqlite:///{}".format(
+            os.path.abspath(os.path.join(self.root, "gradebook.db")))
+
+    root = Unicode(
+        '',
+        help=dedent(
+            """
+            The root directory for the course files (that includes the `source`,
+            `release`, `submitted`, `autograded`, etc. directories). Defaults to
+            the current working directory.
+            """
+        )
+    ).tag(config=True)
+
+    @default("root")
+    def _root_default(self):
+        return os.getcwd()
+
+    ignore = List(
+        [
+            ".ipynb_checkpoints",
+            "*.pyc",
+            "__pycache__"
+        ],
+        help=dedent(
+            """
+            List of file names or file globs to be ignored when copying directories.
+            """
+        )
+    ).tag(config=True)
+
+    def format_path(self, nbgrader_step, student_id, assignment_id, escape=False):
+        kwargs = dict(
+            nbgrader_step=nbgrader_step,
+            student_id=student_id,
+            assignment_id=assignment_id
+        )
+
+        if escape:
+            base = re.escape(self.root)
+            structure = [x.format(**kwargs) for x in full_split(self.directory_structure)]
+            path = re.escape(os.path.sep).join([base] + structure)
+        else:
+            path = os.path.join(self.root, self.directory_structure).format(**kwargs)
+
+        return path

--- a/nbgrader/docs/source/configuration/jupyterhub_config.rst
+++ b/nbgrader/docs/source/configuration/jupyterhub_config.rst
@@ -48,7 +48,7 @@ directory is properly set in ``~/.jupyter/nbgrader_config.py``:
 .. code:: python
 
     c = get_config()
-    c.NbGrader.course_directory = 'path/to/course/files'
+    c.CourseDirectory.root = 'path/to/course/files'
 
 If you have multiple graders, then you can set up a `shared notebook server
 <https://github.com/jupyterhub/jupyterhub/tree/master/examples/service-notebook>`_

--- a/nbgrader/server_extensions/formgrader/formgrader.py
+++ b/nbgrader/server_extensions/formgrader/formgrader.py
@@ -34,13 +34,13 @@ class FormgradeExtension(NbGrader):
 
         # Configure the formgrader settings
         tornado_settings = dict(
-            nbgrader_notebook_dir=self.course_directory,
-            nbgrader_notebook_dir_format=self.directory_structure,
-            nbgrader_step=self.autograded_directory,
+            nbgrader_notebook_dir=self.coursedir.root,
+            nbgrader_notebook_dir_format=self.coursedir.directory_structure,
+            nbgrader_step=self.coursedir.autograded_directory,
             nbgrader_exporter=HTMLExporter(config=self.config),
-            nbgrader_gradebook=Gradebook(self.db_url),
+            nbgrader_gradebook=Gradebook(self.coursedir.db_url),
             nbgrader_jinja2_env=jinja_env,
-            nbgrader_notebook_url_prefix=os.path.relpath(self.course_directory)
+            nbgrader_notebook_url_prefix=os.path.relpath(self.coursedir.root)
         )
 
         webapp.settings.update(tornado_settings)

--- a/nbgrader/tests/apps/conftest.py
+++ b/nbgrader/tests/apps/conftest.py
@@ -43,7 +43,7 @@ def temp_cwd(request, course_dir):
         fh.write(dedent(
             """
             c = get_config()
-            c.NbGrader.course_directory = r"{}"
+            c.CourseDirectory.root = r"{}"
             """.format(course_dir)
         ))
 

--- a/nbgrader/tests/apps/test_nbgrader_assign.py
+++ b/nbgrader/tests/apps/test_nbgrader_assign.py
@@ -34,7 +34,7 @@ class TestNbGraderAssign(BaseTestApp):
         self._empty_notebook(join(course_dir, 'source', 'ps1', 'foo.ipynb'))
         run_nbgrader(["assign", "ps1"], retcode=1)
         # check that the --create flag works
-        run_nbgrader(["assign", "ps1", "--create"])
+        run_nbgrader(["assign", "ps1", "--create", "--debug"])
 
     def test_single_file(self, course_dir, temp_cwd):
         """Can a single file be assigned?"""

--- a/nbgrader/tests/nbextensions/test_assignment_list.py
+++ b/nbgrader/tests/nbextensions/test_assignment_list.py
@@ -36,7 +36,7 @@ def class_files(coursedir):
     with open("nbgrader_config.py", "a") as fh:
         fh.write(dedent(
             """
-            c.NbGrader.course_directory = '{}'
+            c.CourseDirectory.root = '{}'
             """.format(coursedir)
         ))
 


### PR DESCRIPTION
#705 will require quite a bit of refactoring in order to separate the config options from the apps that rely on them. This PR is a first step in that direction. This makes a `CourseDirectory` object that manages the actual directory containing the source files. It's a relatively sparse object at the moment except for its config options, but I am hoping to move more functionality (e.g. stuff from the nbconvert apps) into it in the future.

I will wait to merge this I think until after #526