### PR TITLE
Move exchange functionality into non-application classes

### DIFF
--- a/nbgrader/apps/autogradeapp.py
+++ b/nbgrader/apps/autogradeapp.py
@@ -163,7 +163,7 @@ class AutogradeApp(BaseNbConvertApp):
 
         # try to read in a timestamp from file
         src_path = self._format_source(assignment_id, student_id)
-        timestamp = self._get_existing_timestamp(src_path)
+        timestamp = self.coursedir.get_existing_timestamp(src_path)
         with Gradebook(self.coursedir.db_url) as gb:
             if timestamp:
                 submission = gb.update_or_create_submission(

--- a/nbgrader/apps/collectapp.py
+++ b/nbgrader/apps/collectapp.py
@@ -1,35 +1,26 @@
-import os
-import glob
-import shutil
-from collections import defaultdict
+from traitlets import default
 
-from traitlets import Bool
-
-from .baseapp import TransferApp, transfer_aliases, transfer_flags
-from ..utils import check_mode, parse_utc
+from .baseapp import NbGrader, nbgrader_aliases, nbgrader_flags
+from ..exchange import Exchange, ExchangeCollect, ExchangeError
 
 
 aliases = {}
-aliases.update(transfer_aliases)
+aliases.update(nbgrader_aliases)
 aliases.update({
+    "timezone": "Exchange.timezone",
+    "course": "Exchange.course_id",
 })
 
 flags = {}
-flags.update(transfer_flags)
+flags.update(nbgrader_flags)
 flags.update({
     'update': (
-        {'CollectApp' : {'update': True}},
+        {'ExchangeCollect' : {'update': True}},
         "Update existing submissions with ones that have newer timestamps."
     ),
 })
 
-def groupby(l, key=lambda x: x):
-    d = defaultdict(list)
-    for item in l:
-        d[key(item)].append(item)
-    return d
-
-class CollectApp(TransferApp):
+class CollectApp(NbGrader):
 
     name = u'nbgrader-collect'
     description = u'Collect an assignment from the nbgrader exchange'
@@ -68,75 +59,39 @@ class CollectApp(TransferApp):
             nbgrader collect --update assignment1
         """
 
-    update = Bool(
-        False,
-        help="Update existing submissions with ones that have newer timestamps."
-    ).tag(config=True)
+    @default("classes")
+    def _classes_default(self):
+        classes = super(CollectApp, self)._classes_default()
+        classes.extend([Exchange, ExchangeCollect])
+        return classes
 
-    def _path_to_record(self, path):
-        filename = os.path.split(path)[1]
-        # Only split twice on +, giving three components. This allows usernames with +.
-        filename_list = filename.rsplit('+', 2)
-        if len(filename_list) != 3:
-            self.fail("Invalid filename: {}".format(filename))
-        username = filename_list[0]
-        timestamp = parse_utc(filename_list[2])
-        return {'username': username, 'filename': filename, 'timestamp': timestamp}
+    def _load_config(self, cfg, **kwargs):
+        if 'CollectApp' in cfg:
+            self.log.warn(
+                "Use ExchangeCollect in config, not CollectApp. Outdated config:\n%s",
+                '\n'.join(
+                    'CollectApp.{key} = {value!r}'.format(key=key, value=value)
+                    for key, value in cfg.CollectApp.items()
+                )
+            )
+            cfg.ExchangeCollect.merge(cfg.CollectApp)
+            del cfg.CollectApp
 
-    def _sort_by_timestamp(self, records):
-        return sorted(records, key=lambda item: item['timestamp'], reverse=True)
+        super(CollectApp, self)._load_config(cfg, **kwargs)
 
-    def init_src(self):
-        if self.exchange.course_id == '':
-            self.fail("No course id specified. Re-run with --course flag.")
+    def start(self):
+        super(CollectApp, self).start()
 
-        self.course_path = os.path.join(self.exchange.root, self.exchange.course_id)
-        self.inbound_path = os.path.join(self.course_path, 'inbound')
-        if not os.path.isdir(self.inbound_path):
-            self.fail("Course not found: {}".format(self.inbound_path))
-        if not check_mode(self.inbound_path, read=True, execute=True):
-            self.fail("You don't have read permissions for the directory: {}".format(self.inbound_path))
-        student_id = self.coursedir.student_id if self.coursedir.student_id else '*'
-        pattern = os.path.join(self.inbound_path, '{}+{}+*'.format(student_id, self.coursedir.assignment_id))
-        records = [self._path_to_record(f) for f in glob.glob(pattern)]
-        usergroups = groupby(records, lambda item: item['username'])
-        self.src_records = [self._sort_by_timestamp(v)[0] for v in usergroups.values()]
+        # set assignemnt and course
+        if len(self.extra_args) == 1:
+            self.coursedir.assignment_id = self.extra_args[0]
+        elif len(self.extra_args) > 2:
+            self.fail("Too many arguments")
+        elif self.coursedir.assignment_id == "":
+            self.fail("Must provide assignment name:\nnbgrader <command> ASSIGNMENT [ --course COURSE ]")
 
-    def init_dest(self):
-        pass
-
-    def copy_files(self):
-        for rec in self.src_records:
-            student_id = rec['username']
-            src_path = os.path.join(self.inbound_path, rec['filename'])
-            dest_path = self.coursedir.format_path(self.coursedir.submitted_directory, student_id, self.coursedir.assignment_id)
-            if not os.path.exists(os.path.dirname(dest_path)):
-                os.makedirs(os.path.dirname(dest_path))
-
-            copy = False
-            updating = False
-            if os.path.isdir(dest_path):
-                existing_timestamp = self._get_existing_timestamp(dest_path)
-                new_timestamp = rec['timestamp']
-                if self.update and (existing_timestamp is None or new_timestamp > existing_timestamp):
-                    copy = True
-                    updating = True
-            else:
-                copy = True
-
-            if copy:
-                if updating:
-                    self.log.info("Updating submission: {} {}".format(student_id, self.coursedir.assignment_id))
-                    shutil.rmtree(dest_path)
-                else:
-                    self.log.info("Collecting submission: {} {}".format(student_id, self.coursedir.assignment_id))
-                self.do_copy(src_path, dest_path)
-            else:
-                if self.update:
-                    self.log.info("No newer submission to collect: {} {}".format(
-                        student_id, self.coursedir.assignment_id
-                    ))
-                else:
-                    self.log.info("Submission already exists, use --update to update: {} {}".format(
-                        student_id, self.coursedir.assignment_id
-                    ))
+        collect = ExchangeCollect(coursedir=self.coursedir, parent=self)
+        try:
+            collect.start()
+        except ExchangeError:
+            self.fail("nbgrader collect failed")

--- a/nbgrader/apps/collectapp.py
+++ b/nbgrader/apps/collectapp.py
@@ -45,7 +45,7 @@ class CollectApp(TransferApp):
         It must be unique for each instructor/course combination. To set it in
         the config file add a line to the `nbgrader_config.py` file:
 
-            c.NbGrader.course_id = 'phys101'
+            c.Exchange.course_id = 'phys101'
 
         To pass the `course_id` at the command line, add `--course=phys101` to any
         of the below commands.
@@ -87,10 +87,10 @@ class CollectApp(TransferApp):
         return sorted(records, key=lambda item: item['timestamp'], reverse=True)
 
     def init_src(self):
-        if self.course_id == '':
+        if self.exchange.course_id == '':
             self.fail("No course id specified. Re-run with --course flag.")
 
-        self.course_path = os.path.join(self.exchange_directory, self.course_id)
+        self.course_path = os.path.join(self.exchange.root, self.exchange.course_id)
         self.inbound_path = os.path.join(self.course_path, 'inbound')
         if not os.path.isdir(self.inbound_path):
             self.fail("Course not found: {}".format(self.inbound_path))

--- a/nbgrader/apps/fetchapp.py
+++ b/nbgrader/apps/fetchapp.py
@@ -54,10 +54,10 @@ class FetchApp(TransferApp):
     replace_missing_files = Bool(False, help="Whether to replace missing files on fetch").tag(config=True)
 
     def init_src(self):
-        if self.course_id == '':
+        if self.exchange.course_id == '':
             self.fail("No course id specified. Re-run with --course flag.")
 
-        self.course_path = os.path.join(self.exchange_directory, self.course_id)
+        self.course_path = os.path.join(self.exchange.root, self.exchange.course_id)
         self.outbound_path = os.path.join(self.course_path, 'outbound')
         self.src_path = os.path.join(self.outbound_path, self.coursedir.assignment_id)
         if not os.path.isdir(self.src_path):
@@ -66,8 +66,8 @@ class FetchApp(TransferApp):
             self.fail("You don't have read permissions for the directory: {}".format(self.src_path))
 
     def init_dest(self):
-        if self.path_includes_course:
-            root = os.path.join(self.course_id, self.coursedir.assignment_id)
+        if self.exchange.path_includes_course:
+            root = os.path.join(self.exchange.course_id, self.coursedir.assignment_id)
         else:
             root = self.coursedir.assignment_id
         self.dest_path = os.path.abspath(os.path.join('.', root))
@@ -113,4 +113,4 @@ class FetchApp(TransferApp):
         self.log.info("Source: {}".format(self.src_path))
         self.log.info("Destination: {}".format(self.dest_path))
         self.do_copy(self.src_path, self.dest_path)
-        self.log.info("Fetched as: {} {}".format(self.course_id, self.coursedir.assignment_id))
+        self.log.info("Fetched as: {} {}".format(self.exchange.course_id, self.coursedir.assignment_id))

--- a/nbgrader/apps/fetchapp.py
+++ b/nbgrader/apps/fetchapp.py
@@ -1,28 +1,27 @@
-import os
-import shutil
+from traitlets import default
 
-from textwrap import dedent
-from traitlets import Bool
-
-from .baseapp import TransferApp, transfer_aliases, transfer_flags
-from ..utils import check_mode
+from .baseapp import NbGrader, nbgrader_aliases, nbgrader_flags
+from ..exchange import Exchange, ExchangeFetch, ExchangeError
 
 
 aliases = {}
-aliases.update(transfer_aliases)
+aliases.update(nbgrader_aliases)
 aliases.update({
+    "timezone": "Exchange.timezone",
+    "course": "Exchange.course_id",
 })
 
 flags = {}
-flags.update(transfer_flags)
+flags.update(nbgrader_flags)
 flags.update({
     'replace': (
-        {'FetchApp' : {'replace_missing_files' : True}},
+        {'ExchangeFetch' : {'replace_missing_files' : True}},
         "replace missing files, even if the assignment has already been fetched"
     ),
 })
 
-class FetchApp(TransferApp):
+
+class FetchApp(NbGrader):
 
     name = u'nbgrader-fetch'
     description = u'Fetch an assignment from the nbgrader exchange'
@@ -51,66 +50,39 @@ class FetchApp(TransferApp):
         to turn in the assignment.
         """
 
-    replace_missing_files = Bool(False, help="Whether to replace missing files on fetch").tag(config=True)
+    @default("classes")
+    def _classes_default(self):
+        classes = super(FetchApp, self)._classes_default()
+        classes.extend([Exchange, ExchangeFetch])
+        return classes
 
-    def init_src(self):
-        if self.exchange.course_id == '':
-            self.fail("No course id specified. Re-run with --course flag.")
+    def _load_config(self, cfg, **kwargs):
+        if 'FetchApp' in cfg:
+            self.log.warn(
+                "Use ExchangeFetch in config, not FetchApp. Outdated config:\n%s",
+                '\n'.join(
+                    'FetchApp.{key} = {value!r}'.format(key=key, value=value)
+                    for key, value in cfg.FetchApp.items()
+                )
+            )
+            cfg.ExchangeFetch.merge(cfg.FetchApp)
+            del cfg.FetchApp
 
-        self.course_path = os.path.join(self.exchange.root, self.exchange.course_id)
-        self.outbound_path = os.path.join(self.course_path, 'outbound')
-        self.src_path = os.path.join(self.outbound_path, self.coursedir.assignment_id)
-        if not os.path.isdir(self.src_path):
-            self.fail("Assignment not found: {}".format(self.src_path))
-        if not check_mode(self.src_path, read=True, execute=True):
-            self.fail("You don't have read permissions for the directory: {}".format(self.src_path))
+        super(FetchApp, self)._load_config(cfg, **kwargs)
 
-    def init_dest(self):
-        if self.exchange.path_includes_course:
-            root = os.path.join(self.exchange.course_id, self.coursedir.assignment_id)
-        else:
-            root = self.coursedir.assignment_id
-        self.dest_path = os.path.abspath(os.path.join('.', root))
-        if os.path.isdir(self.dest_path) and not self.replace_missing_files:
-            self.fail("You already have a copy of the assignment in this directory: {}".format(root))
+    def start(self):
+        super(FetchApp, self).start()
 
-    def copy_if_missing(self, src, dest, ignore=None):
-        filenames = sorted(os.listdir(src))
-        if ignore:
-            bad_filenames = ignore(src, filenames)
-            filenames = sorted(list(set(filenames) - bad_filenames))
+        # set assignemnt and course
+        if len(self.extra_args) == 1:
+            self.coursedir.assignment_id = self.extra_args[0]
+        elif len(self.extra_args) > 2:
+            self.fail("Too many arguments")
+        elif self.coursedir.assignment_id == "":
+            self.fail("Must provide assignment name:\nnbgrader <command> ASSIGNMENT [ --course COURSE ]")
 
-        for filename in filenames:
-            srcpath = os.path.join(src, filename)
-            destpath = os.path.join(dest, filename)
-            relpath = os.path.relpath(destpath, os.getcwd())
-            if not os.path.exists(destpath):
-                if os.path.isdir(srcpath):
-                    self.log.warn("Creating missing directory '%s'", relpath)
-                    os.mkdir(destpath)
-
-                else:
-                    self.log.warn("Replacing missing file '%s'", relpath)
-                    shutil.copy(srcpath, destpath)
-
-            if os.path.isdir(srcpath):
-                self.copy_if_missing(srcpath, destpath, ignore=ignore)
-
-
-    def do_copy(self, src, dest, perms=None):
-        """Copy the src dir to the dest dir omitting the self.coursedir.ignore globs."""
-        if os.path.isdir(self.dest_path):
-            self.copy_if_missing(src, dest, ignore=shutil.ignore_patterns(*self.coursedir.ignore))
-        else:
-            shutil.copytree(src, dest, ignore=shutil.ignore_patterns(*self.coursedir.ignore))
-
-        if perms:
-            for dirname, dirnames, filenames in os.walk(dest):
-                for filename in filenames:
-                    os.chmod(os.path.join(dirname, filename), perms)
-
-    def copy_files(self):
-        self.log.info("Source: {}".format(self.src_path))
-        self.log.info("Destination: {}".format(self.dest_path))
-        self.do_copy(self.src_path, self.dest_path)
-        self.log.info("Fetched as: {} {}".format(self.exchange.course_id, self.coursedir.assignment_id))
+        fetch = ExchangeFetch(coursedir=self.coursedir, parent=self)
+        try:
+            fetch.start()
+        except ExchangeError:
+            self.fail("nbgrader fetch failed")

--- a/nbgrader/apps/listapp.py
+++ b/nbgrader/apps/listapp.py
@@ -98,16 +98,16 @@ class ListApp(TransferApp):
         pass
 
     def init_dest(self):
-        course_id = self.course_id if self.course_id else '*'
+        course_id = self.exchange.course_id if self.exchange.course_id else '*'
         assignment_id = self.coursedir.assignment_id if self.coursedir.assignment_id else '*'
         student_id = self.coursedir.student_id if self.coursedir.student_id else '*'
 
         if self.inbound:
-            pattern = os.path.join(self.exchange_directory, course_id, 'inbound', '{}+{}+*'.format(student_id, assignment_id))
+            pattern = os.path.join(self.exchange.root, course_id, 'inbound', '{}+{}+*'.format(student_id, assignment_id))
         elif self.cached:
-            pattern = os.path.join(self.cache_directory, course_id, '{}+{}+*'.format(student_id, assignment_id))
+            pattern = os.path.join(self.exchange.cache, course_id, '{}+{}+*'.format(student_id, assignment_id))
         else:
-            pattern = os.path.join(self.exchange_directory, course_id, 'outbound', '{}'.format(assignment_id))
+            pattern = os.path.join(self.exchange.root, course_id, 'outbound', '{}'.format(assignment_id))
 
         self.assignments = sorted(glob.glob(pattern))
 
@@ -140,7 +140,7 @@ class ListApp(TransferApp):
         assignments = []
         for path in self.assignments:
             info = self.parse_assignment(path)
-            if self.path_includes_course:
+            if self.exchange.path_includes_course:
                 root = os.path.join(info['course_id'], info['assignment_id'])
             else:
                 root = info['assignment_id']

--- a/nbgrader/apps/nbgraderapp.py
+++ b/nbgrader/apps/nbgraderapp.py
@@ -13,6 +13,8 @@ from jupyter_core.application import NoStart
 import nbgrader
 from .. import preprocessors
 from .. import plugins
+from ..coursedir import CourseDirectory
+from ..exchange import Exchange
 from .baseapp import nbgrader_aliases, nbgrader_flags
 from . import (
     NbGrader,
@@ -237,6 +239,9 @@ class NbGraderApp(NbGrader):
     @default("classes")
     def _classes_default(self):
         classes = super(NbGraderApp, self)._classes_default()
+
+        # include the coursedirectory and exchange
+        classes.extend([CourseDirectory, Exchange])
 
         # include all the apps that have configurable options
         for appname, (app, help) in self.subcommands.items():

--- a/nbgrader/apps/nbgraderapp.py
+++ b/nbgrader/apps/nbgraderapp.py
@@ -14,7 +14,7 @@ import nbgrader
 from .. import preprocessors
 from .. import plugins
 from ..coursedir import CourseDirectory
-from ..exchange import Exchange
+from .. import exchange
 from .baseapp import nbgrader_aliases, nbgrader_flags
 from . import (
     NbGrader,
@@ -240,11 +240,11 @@ class NbGraderApp(NbGrader):
     def _classes_default(self):
         classes = super(NbGraderApp, self)._classes_default()
 
-        # include the coursedirectory and exchange
-        classes.extend([CourseDirectory, Exchange])
+        # include the coursedirectory
+        classes.append(CourseDirectory)
 
         # include all the apps that have configurable options
-        for appname, (app, help) in self.subcommands.items():
+        for _, (app, _) in self.subcommands.items():
             if len(app.class_traits(config=True)) > 0:
                 classes.append(app)
 
@@ -259,6 +259,12 @@ class NbGraderApp(NbGrader):
             pp = getattr(preprocessors, pp_name)
             if len(pp.class_traits(config=True)) > 0:
                 classes.append(pp)
+
+        # include all the exchange actions
+        for ex_name in exchange.__all__:
+            ex = getattr(exchange, ex_name)
+            if hasattr(ex, "class_traits") and ex.class_traits(config=True):
+                classes.append(ex)
 
         return classes
 

--- a/nbgrader/apps/quickstartapp.py
+++ b/nbgrader/apps/quickstartapp.py
@@ -42,8 +42,8 @@ class QuickStartApp(NbGrader):
             nbgrader quickstart course101
 
         Note that this class name need not necessarily be the same as the
-        `NbGrader.course_id` configuration option, however by default, the
-        quickstart command will set `NbGrader.course_id` to be the name you give
+        `Exchange.course_id` configuration option, however by default, the
+        quickstart command will set `Exchange.course_id` to be the name you give
         on the command line. If you want to use a different folder name, go
         ahead and just provide the name of the folder where your class files
         will be stored, e.g.:
@@ -51,7 +51,7 @@ class QuickStartApp(NbGrader):
             nbgrader quickstart "World Music"
 
         and then after running the quickstart commmand, you can edit the
-        `nbgrader_config.py` file to change `NbGrader.course_id`.
+        `nbgrader_config.py` file to change `Exchange.course_id`.
 
         """
 
@@ -110,7 +110,7 @@ class QuickStartApp(NbGrader):
                 """
                 # You only need this if you are running nbgrader on a shared
                 # server set up.
-                c.NbGrader.course_id = "{}"
+                c.Exchange.course_id = "{}"
 
                 # Update this list with other assignments you want
                 c.NbGrader.db_assignments = [dict(name="ps1")]

--- a/nbgrader/apps/releaseapp.py
+++ b/nbgrader/apps/releaseapp.py
@@ -1,33 +1,26 @@
-import os
-import shutil
-from stat import (
-    S_IRUSR, S_IWUSR, S_IXUSR,
-    S_IRGRP, S_IWGRP, S_IXGRP,
-    S_IROTH, S_IWOTH, S_IXOTH,
-    S_ISVTX, S_ISGID
-)
+from traitlets import default
 
-from traitlets import Bool
-
-from .baseapp import TransferApp, transfer_aliases, transfer_flags
-from ..utils import self_owned
+from .baseapp import NbGrader, nbgrader_aliases, nbgrader_flags
+from ..exchange import Exchange, ExchangeRelease, ExchangeError
 
 
 aliases = {}
-aliases.update(transfer_aliases)
+aliases.update(nbgrader_aliases)
 aliases.update({
+    "timezone": "Exchange.timezone",
+    "course": "Exchange.course_id",
 })
 
 flags = {}
-flags.update(transfer_flags)
+flags.update(nbgrader_flags)
 flags.update({
     'force': (
-        {'ReleaseApp' : {'force' : True}},
+        {'ExchangeRelease' : {'force' : True}},
         "Force overwrite of existing files in the exchange."
     ),
 })
 
-class ReleaseApp(TransferApp):
+class ReleaseApp(NbGrader):
 
     name = u'nbgrader-release'
     description = u'Release an assignment to the nbgrader exchange'
@@ -68,73 +61,39 @@ class ReleaseApp(TransferApp):
             nbgrader list
         """
 
-    force = Bool(False, help="Force overwrite existing files in the exchange.").tag(config=True)
+    @default("classes")
+    def _classes_default(self):
+        classes = super(ReleaseApp, self)._classes_default()
+        classes.extend([Exchange, ExchangeRelease])
+        return classes
 
-    def build_extra_config(self):
-        extra_config = super(ReleaseApp, self).build_extra_config()
-        extra_config.CourseDirectory.student_id = '.'
-        extra_config.CourseDirectory.notebook_id = '*'
-        return extra_config
+    def _load_config(self, cfg, **kwargs):
+        if 'ReleaseApp' in cfg:
+            self.log.warn(
+                "Use ExchangeRelease in config, not ReleaseApp. Outdated config:\n%s",
+                '\n'.join(
+                    'ReleaseApp.{key} = {value!r}'.format(key=key, value=value)
+                    for key, value in cfg.ReleaseApp.items()
+                )
+            )
+            cfg.ExchangeRelease.merge(cfg.ReleaseApp)
+            del cfg.ReleaseApp
 
-    def init_src(self):
-        self.src_path = self.coursedir.format_path(self.coursedir.release_directory, self.coursedir.student_id, self.coursedir.assignment_id)
-        if not os.path.isdir(self.src_path):
-            source = self.coursedir.format_path(self.coursedir.source_directory, self.coursedir.student_id, self.coursedir.assignment_id)
-            if os.path.isdir(source):
-                # Looks like the instructor forgot to assign
-                self.fail("Assignment found in '{}' but not '{}', run `nbgrader assign` first.".format(
-                    source, self.src_path))
-            else:
-                self.fail("Assignment not found: {}".format(self.src_path))
+        super(ReleaseApp, self)._load_config(cfg, **kwargs)
 
-    def init_dest(self):
-        if self.exchange.course_id == '':
-            self.fail("No course id specified. Re-run with --course flag.")
+    def start(self):
+        super(ReleaseApp, self).start()
 
-        self.course_path = os.path.join(self.exchange.root, self.exchange.course_id)
-        self.outbound_path = os.path.join(self.course_path, 'outbound')
-        self.inbound_path = os.path.join(self.course_path, 'inbound')
-        self.dest_path = os.path.join(self.outbound_path, self.coursedir.assignment_id)
-        # 0755
-        self.ensure_directory(
-            self.course_path,
-            S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH
-        )
-        # 0755
-        self.ensure_directory(
-            self.outbound_path,
-            S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH
-        )
-        # 0733 with set GID so student submission will have the instructors group
-        self.ensure_directory(
-            self.inbound_path,
-            S_ISGID|S_IRUSR|S_IWUSR|S_IXUSR|S_IWGRP|S_IXGRP|S_IWOTH|S_IXOTH
-        )
+        # set assignemnt and course
+        if len(self.extra_args) == 1:
+            self.coursedir.assignment_id = self.extra_args[0]
+        elif len(self.extra_args) > 2:
+            self.fail("Too many arguments")
+        elif self.coursedir.assignment_id == "":
+            self.fail("Must provide assignment name:\nnbgrader <command> ASSIGNMENT [ --course COURSE ]")
 
-    def ensure_directory(self, path, mode):
-        """Ensure that the path exists, has the right mode and is self owned."""
-        if not os.path.isdir(path):
-            os.mkdir(path)
-            # For some reason, Python won't create a directory with a mode of 0o733
-            # so we have to create and then chmod.
-            os.chmod(path, mode)
-        else:
-            if not self_owned(path):
-                self.fail("You don't own the directory: {}".format(path))
-
-    def copy_files(self):
-        if os.path.isdir(self.dest_path):
-            if self.force:
-                self.log.info("Overwriting files: {} {}".format(
-                    self.exchange.course_id, self.coursedir.assignment_id
-                ))
-                shutil.rmtree(self.dest_path)
-            else:
-                self.fail("Destination already exists, add --force to overwrite: {} {}".format(
-                    self.exchange.course_id, self.coursedir.assignment_id
-                ))
-        self.log.info("Source: {}".format(self.src_path))
-        self.log.info("Destination: {}".format(self.dest_path))
-        perms = S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH
-        self.do_copy(self.src_path, self.dest_path, perms=perms)
-        self.log.info("Released as: {} {}".format(self.exchange.course_id, self.coursedir.assignment_id))
+        release = ExchangeRelease(coursedir=self.coursedir, parent=self)
+        try:
+            release.start()
+        except ExchangeError:
+            self.fail("nbgrader release failed")

--- a/nbgrader/apps/releaseapp.py
+++ b/nbgrader/apps/releaseapp.py
@@ -45,7 +45,7 @@ class ReleaseApp(TransferApp):
         unique for each instructor/course combination. To set it in the config
         file add a line to the `nbgrader_config.py` file:
 
-            c.NbGrader.course_id = 'phys101'
+            c.Exchange.course_id = 'phys101'
 
         To pass the `course_id` at the command line, add `--course=phys101` to any
         of the below commands.
@@ -88,10 +88,10 @@ class ReleaseApp(TransferApp):
                 self.fail("Assignment not found: {}".format(self.src_path))
 
     def init_dest(self):
-        if self.course_id == '':
+        if self.exchange.course_id == '':
             self.fail("No course id specified. Re-run with --course flag.")
 
-        self.course_path = os.path.join(self.exchange_directory, self.course_id)
+        self.course_path = os.path.join(self.exchange.root, self.exchange.course_id)
         self.outbound_path = os.path.join(self.course_path, 'outbound')
         self.inbound_path = os.path.join(self.course_path, 'inbound')
         self.dest_path = os.path.join(self.outbound_path, self.coursedir.assignment_id)
@@ -126,15 +126,15 @@ class ReleaseApp(TransferApp):
         if os.path.isdir(self.dest_path):
             if self.force:
                 self.log.info("Overwriting files: {} {}".format(
-                    self.course_id, self.coursedir.assignment_id
+                    self.exchange.course_id, self.coursedir.assignment_id
                 ))
                 shutil.rmtree(self.dest_path)
             else:
                 self.fail("Destination already exists, add --force to overwrite: {} {}".format(
-                    self.course_id, self.coursedir.assignment_id
+                    self.exchange.course_id, self.coursedir.assignment_id
                 ))
         self.log.info("Source: {}".format(self.src_path))
         self.log.info("Destination: {}".format(self.dest_path))
         perms = S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH
         self.do_copy(self.src_path, self.dest_path, perms=perms)
-        self.log.info("Released as: {} {}".format(self.course_id, self.coursedir.assignment_id))
+        self.log.info("Released as: {} {}".format(self.exchange.course_id, self.coursedir.assignment_id))

--- a/nbgrader/apps/submitapp.py
+++ b/nbgrader/apps/submitapp.py
@@ -1,34 +1,27 @@
-import os
-from stat import (
-    S_IRUSR, S_IWUSR, S_IXUSR,
-    S_IRGRP, S_IWGRP, S_IXGRP,
-    S_IROTH, S_IWOTH, S_IXOTH,
-    S_ISVTX, S_ISGID
-)
+from traitlets import default
 
-from textwrap import dedent
-from traitlets import Bool
-
-from .baseapp import TransferApp, transfer_aliases, transfer_flags
-from ..utils import get_username, check_mode, find_all_notebooks
+from .baseapp import NbGrader, nbgrader_aliases, nbgrader_flags
+from ..exchange import Exchange, ExchangeSubmit, ExchangeError
 
 
 aliases = {}
-aliases.update(transfer_aliases)
+aliases.update(nbgrader_aliases)
 aliases.update({
+    "timezone": "Exchange.timezone",
+    "course": "Exchange.course_id",
 })
 
 flags = {}
-flags.update(transfer_flags)
+flags.update(nbgrader_flags)
 flags.update({
     'strict': (
-        {'SubmitApp': {'strict': True}},
+        {'ExchangeSubmit': {'strict': True}},
         "Fail if the submission is missing notebooks for the assignment"
     ),
 })
 
 
-class SubmitApp(TransferApp):
+class SubmitApp(NbGrader):
 
     name = u'nbgrader-submit'
     description = u'Submit an assignment to the nbgrader exchange'
@@ -57,122 +50,39 @@ class SubmitApp(TransferApp):
         be able to see your submissions.
         """
 
-    strict = Bool(
-        False,
-        help=dedent(
-            "Whether or not to submit the assignment if there are missing "
-            "notebooks from the released assignment notebooks."
-        )
-    ).tag(config=True)
+    @default("classes")
+    def _classes_default(self):
+        classes = super(SubmitApp, self)._classes_default()
+        classes.extend([Exchange, ExchangeSubmit])
+        return classes
 
-    def init_src(self):
-        if self.exchange.path_includes_course:
-            root = os.path.join(self.exchange.course_id, self.coursedir.assignment_id)
-        else:
-            root = self.coursedir.assignment_id
-        self.src_path = os.path.abspath(root)
-        self.coursedir.assignment_id = os.path.split(self.src_path)[-1]
-        if not os.path.isdir(self.src_path):
-            self.fail("Assignment not found: {}".format(self.src_path))
-
-    def init_dest(self):
-        if self.exchange.course_id == '':
-            self.fail("No course id specified. Re-run with --course flag.")
-
-        self.inbound_path = os.path.join(self.exchange.root, self.exchange.course_id, 'inbound')
-        if not os.path.isdir(self.inbound_path):
-            self.fail("Inbound directory doesn't exist: {}".format(self.inbound_path))
-        if not check_mode(self.inbound_path, write=True, execute=True):
-            self.fail("You don't have write permissions to the directory: {}".format(self.inbound_path))
-
-        self.cache_path = os.path.join(self.exchange.cache, self.exchange.course_id)
-        self.assignment_filename = '{}+{}+{}'.format(get_username(), self.coursedir.assignment_id, self.exchange.timestamp)
-
-    def init_release(self):
-        if self.exchange.course_id == '':
-            self.fail("No course id specified. Re-run with --course flag.")
-
-        course_path = os.path.join(self.exchange.root, self.exchange.course_id)
-        outbound_path = os.path.join(course_path, 'outbound')
-        self.release_path = os.path.join(outbound_path, self.coursedir.assignment_id)
-        if not os.path.isdir(self.release_path):
-            self.fail("Assignment not found: {}".format(self.release_path))
-        if not check_mode(self.release_path, read=True, execute=True):
-            self.fail("You don't have read permissions for the directory: {}".format(self.release_path))
-
-    def check_filename_diff(self):
-        released_notebooks = find_all_notebooks(self.release_path)
-        submitted_notebooks = find_all_notebooks(self.src_path)
-
-        # Look for missing notebooks in submitted notebooks
-        missing = False
-        release_diff = list()
-        for filename in released_notebooks:
-            if filename in submitted_notebooks:
-                release_diff.append("{}: {}".format(filename, 'FOUND'))
-            else:
-                missing = True
-                release_diff.append("{}: {}".format(filename, 'MISSING'))
-
-        # Look for extra notebooks in submitted notebooks
-        extra = False
-        submitted_diff = list()
-        for filename in submitted_notebooks:
-            if filename in released_notebooks:
-                submitted_diff.append("{}: {}".format(filename, 'OK'))
-            else:
-                extra = True
-                submitted_diff.append("{}: {}".format(filename, 'EXTRA'))
-
-        if missing or extra:
-            diff_msg = (
-                "Expected:\n\t{}\nSubmitted:\n\t{}".format(
-                    '\n\t'.join(release_diff),
-                    '\n\t'.join(submitted_diff),
+    def _load_config(self, cfg, **kwargs):
+        if 'SubmitApp' in cfg:
+            self.log.warn(
+                "Use ExchangeSubmit in config, not SubmitApp. Outdated config:\n%s",
+                '\n'.join(
+                    'SubmitApp.{key} = {value!r}'.format(key=key, value=value)
+                    for key, value in cfg.SubmitApp.items()
                 )
             )
-            if missing and self.strict:
-                self.fail(
-                    "Assignment {} not submitted. "
-                    "There are missing notebooks for the submission:\n{}"
-                    "".format(self.coursedir.assignment_id, diff_msg)
-                )
-            else:
-                self.log.warning(
-                    "Possible missing notebooks and/or extra notebooks "
-                    "submitted for assignment {}:\n{}"
-                    "".format(self.coursedir.assignment_id, diff_msg)
-                )
+            cfg.ExchangeSubmit.merge(cfg.SubmitApp)
+            del cfg.SubmitApp
 
-    def copy_files(self):
-        self.init_release()
+        super(SubmitApp, self)._load_config(cfg, **kwargs)
 
-        dest_path = os.path.join(self.inbound_path, self.assignment_filename)
-        cache_path = os.path.join(self.cache_path, self.assignment_filename)
+    def start(self):
+        super(SubmitApp, self).start()
 
-        self.log.info("Source: {}".format(self.src_path))
-        self.log.info("Destination: {}".format(dest_path))
+        # set assignemnt and course
+        if len(self.extra_args) == 1:
+            self.coursedir.assignment_id = self.extra_args[0]
+        elif len(self.extra_args) > 2:
+            self.fail("Too many arguments")
+        elif self.coursedir.assignment_id == "":
+            self.fail("Must provide assignment name:\nnbgrader <command> ASSIGNMENT [ --course COURSE ]")
 
-        # copy to the real location
-        self.check_filename_diff()
-        self.do_copy(self.src_path, dest_path)
-        with open(os.path.join(dest_path, "timestamp.txt"), "w") as fh:
-            fh.write(self.exchange.timestamp)
-        self.exchange.set_perms(dest_path, perms=(S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH))
-
-        # Make this 0777=ugo=rwx so the instructor can delete later. Hidden from other users by the timestamp.
-        os.chmod(
-            dest_path,
-            S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IWGRP|S_IXGRP|S_IROTH|S_IWOTH|S_IXOTH
-        )
-
-        # also copy to the cache
-        if not os.path.isdir(self.cache_path):
-            os.makedirs(self.cache_path)
-        self.do_copy(self.src_path, cache_path)
-        with open(os.path.join(cache_path, "timestamp.txt"), "w") as fh:
-            fh.write(self.exchange.timestamp)
-
-        self.log.info("Submitted as: {} {} {}".format(
-            self.exchange.course_id, self.coursedir.assignment_id, str(self.exchange.timestamp)
-        ))
+        submit = ExchangeSubmit(coursedir=self.coursedir, parent=self)
+        try:
+            submit.start()
+        except ExchangeError:
+            self.fail("nbgrader submit failed")

--- a/nbgrader/coursedir.py
+++ b/nbgrader/coursedir.py
@@ -6,7 +6,7 @@ from textwrap import dedent
 from traitlets.config import LoggingConfigurable
 from traitlets import Unicode, List, default
 
-from .utils import full_split
+from .utils import full_split, parse_utc
 
 
 class CourseDirectory(LoggingConfigurable):
@@ -171,3 +171,21 @@ class CourseDirectory(LoggingConfigurable):
             path = os.path.join(self.root, self.directory_structure).format(**kwargs)
 
         return path
+
+    def get_existing_timestamp(self, dest_path):
+        """Get the timestamp, as a datetime object, of an existing submission."""
+        timestamp_path = os.path.join(dest_path, 'timestamp.txt')
+        if os.path.exists(timestamp_path):
+            with open(timestamp_path, 'r') as fh:
+                timestamp = fh.read().strip()
+            if not timestamp:
+                self.log.warning(
+                    "Empty timestamp file: {}".format(timestamp_path))
+                return None
+            try:
+                return parse_utc(timestamp)
+            except ValueError:
+                self.fail(
+                    "Invalid timestamp string: {}".format(timestamp_path))
+        else:
+            return None

--- a/nbgrader/docs/source/user_guide/faq.rst
+++ b/nbgrader/docs/source/user_guide/faq.rst
@@ -113,7 +113,7 @@ in your students' ``nbgrader_config.py`` files:
 .. code:: python
 
     c = get_config()
-    c.TransferApp.path_includes_course = True
+    c.Exchange.path_includes_course = True
 
 This will tell the transfer apps (i.e. ``nbgrader fetch``, ``nbgrader submit``,
 and ``nbgrader list``) to assume that the paths for assignments include the

--- a/nbgrader/docs/source/user_guide/managing_assignment_files.ipynb
+++ b/nbgrader/docs/source/user_guide/managing_assignment_files.ipynb
@@ -713,7 +713,7 @@
     "c = get_config()\n",
     "c.Exchange.root = '/tmp/exchange'\n",
     "c.Exchange.course_id = \"example_course\"\n",
-    "c.SubmitApp.strict = True"
+    "c.ExchangeSubmit.strict = True"
    ]
   },
   {

--- a/nbgrader/docs/source/user_guide/managing_assignment_files.ipynb
+++ b/nbgrader/docs/source/user_guide/managing_assignment_files.ipynb
@@ -80,8 +80,8 @@
     "\n",
     "c = get_config()\n",
     "\n",
-    "c.NbGrader.course_id = \"example_course\"\n",
-    "c.TransferApp.exchange_directory = \"/tmp/exchange\""
+    "c.Exchange.course_id = \"example_course\"\n",
+    "c.Exchange.root = \"/tmp/exchange\""
    ]
   },
   {
@@ -255,8 +255,8 @@
     "%%file /tmp/student_home/nbgrader_config.py\n",
     "\n",
     "c = get_config()\n",
-    "c.TransferApp.exchange_directory = '/tmp/exchange'\n",
-    "c.NbGrader.course_id = \"example_course\""
+    "c.Exchange.root = '/tmp/exchange'\n",
+    "c.Exchange.course_id = \"example_course\""
    ]
   },
   {
@@ -463,8 +463,8 @@
      "text": [
       "\n",
       "c = get_config()\n",
-      "c.TransferApp.exchange_directory = '/tmp/exchange'\n",
-      "c.NbGrader.course_id = \"example_course\""
+      "c.Exchange.root = '/tmp/exchange'\n",
+      "c.Exchange.course_id = \"example_course\""
      ]
     }
    ],
@@ -711,8 +711,8 @@
     "%%file /tmp/student_home/nbgrader_config.py\n",
     "\n",
     "c = get_config()\n",
-    "c.TransferApp.exchange_directory = '/tmp/exchange'\n",
-    "c.NbGrader.course_id = \"example_course\"\n",
+    "c.Exchange.root = '/tmp/exchange'\n",
+    "c.Exchange.course_id = \"example_course\"\n",
     "c.SubmitApp.strict = True"
    ]
   },
@@ -869,8 +869,8 @@
       "\n",
       "c = get_config()\n",
       "\n",
-      "c.NbGrader.course_id = \"example_course\"\n",
-      "c.TransferApp.exchange_directory = \"/tmp/exchange\""
+      "c.Exchange.course_id = \"example_course\"\n",
+      "c.Exchange.root = \"/tmp/exchange\""
      ]
     }
    ],

--- a/nbgrader/exchange.py
+++ b/nbgrader/exchange.py
@@ -1,0 +1,83 @@
+import os
+import datetime
+
+from textwrap import dedent
+
+from dateutil.tz import gettz
+from traitlets.config import LoggingConfigurable
+from traitlets import Unicode, Bool, default
+from jupyter_core.paths import jupyter_data_dir
+
+from .utils import check_directory
+
+
+class Exchange(LoggingConfigurable):
+
+    course_id = Unicode(
+        '',
+        help=dedent(
+            """
+            A key that is unique per instructor and course. This MUST be
+            specified, either by setting the config option, or using the
+            --course option on the command line.
+            """
+        )
+    ).tag(config=True)
+
+    timezone = Unicode(
+        "UTC",
+        help="Timezone for recording timestamps"
+    ).tag(config=True)
+
+    timestamp_format = Unicode(
+        "%Y-%m-%d %H:%M:%S %Z",
+        help="Format string for timestamps"
+    ).tag(config=True)
+
+    root = Unicode(
+        "/srv/nbgrader/exchange",
+        help="The nbgrader exchange directory writable to everyone. MUST be preexisting."
+    ).tag(config=True)
+
+    cache = Unicode(
+        "",
+        help="Local cache directory for nbgrader submit and nbgrader list. Defaults to $JUPYTER_DATA_DIR/nbgrader_cache"
+    ).tag(config=True)
+
+    @default("cache")
+    def _cache_default(self):
+        return os.path.join(jupyter_data_dir(), 'nbgrader_cache')
+
+    path_includes_course = Bool(
+        False,
+        help=dedent(
+            """
+            Whether the path for fetching/submitting  assignments should be
+            prefixed with the course name. If this is `False`, then the path
+            will be something like `./ps1`. If this is `True`, then the path
+            will be something like `./course123/ps1`.
+            """
+        )
+    ).tag(config=True)
+
+    def set_timestamp(self):
+        """Set the timestap using the configured timezone."""
+        tz = gettz(self.timezone)
+        if tz is None:
+            self.fail("Invalid timezone: {}".format(self.timezone))
+        self.timestamp = datetime.datetime.now(tz).strftime(self.timestamp_format)
+
+    def set_perms(self, dest, perms):
+        all_dirs = []
+        for dirname, _, filenames in os.walk(dest):
+            for filename in filenames:
+                os.chmod(os.path.join(dirname, filename), perms)
+            all_dirs.append(dirname)
+
+        for dirname in all_dirs[::-1]:
+            os.chmod(dirname, perms)
+
+    def ensure_root(self):
+        """See if the exchange directory exists and is writable, fail if not."""
+        if not check_directory(self.root, write=True, execute=True):
+            self.fail("Unwritable directory, please contact your instructor: {}".format(self.root))

--- a/nbgrader/exchange/__init__.py
+++ b/nbgrader/exchange/__init__.py
@@ -1,0 +1,16 @@
+from .exchange import Exchange, ExchangeError
+from .collect import ExchangeCollect
+from .fetch import ExchangeFetch
+from .list import ExchangeList
+from .release import ExchangeRelease
+from .submit import ExchangeSubmit
+
+__all__ = [
+    "Exchange",
+    "ExchangeError",
+    "ExchangeCollect",
+    "ExchangeFetch",
+    "ExchangeList",
+    "ExchangeRelease",
+    "ExchangeSubmit"
+]

--- a/nbgrader/exchange/collect.py
+++ b/nbgrader/exchange/collect.py
@@ -1,0 +1,92 @@
+import os
+import glob
+import shutil
+from collections import defaultdict
+
+from traitlets import Bool
+
+from .exchange import Exchange
+from ..utils import check_mode, parse_utc
+
+
+def groupby(l, key=lambda x: x):
+    d = defaultdict(list)
+    for item in l:
+        d[key(item)].append(item)
+    return d
+
+
+class ExchangeCollect(Exchange):
+
+    update = Bool(
+        False,
+        help="Update existing submissions with ones that have newer timestamps."
+    ).tag(config=True)
+
+    def _path_to_record(self, path):
+        filename = os.path.split(path)[1]
+        # Only split twice on +, giving three components. This allows usernames with +.
+        filename_list = filename.rsplit('+', 2)
+        if len(filename_list) != 3:
+            self.fail("Invalid filename: {}".format(filename))
+        username = filename_list[0]
+        timestamp = parse_utc(filename_list[2])
+        return {'username': username, 'filename': filename, 'timestamp': timestamp}
+
+    def _sort_by_timestamp(self, records):
+        return sorted(records, key=lambda item: item['timestamp'], reverse=True)
+
+    def init_src(self):
+        if self.course_id == '':
+            self.fail("No course id specified. Re-run with --course flag.")
+
+        self.course_path = os.path.join(self.root, self.course_id)
+        self.inbound_path = os.path.join(self.course_path, 'inbound')
+        if not os.path.isdir(self.inbound_path):
+            self.fail("Course not found: {}".format(self.inbound_path))
+        if not check_mode(self.inbound_path, read=True, execute=True):
+            self.fail("You don't have read permissions for the directory: {}".format(self.inbound_path))
+        student_id = self.coursedir.student_id if self.coursedir.student_id else '*'
+        pattern = os.path.join(self.inbound_path, '{}+{}+*'.format(student_id, self.coursedir.assignment_id))
+        records = [self._path_to_record(f) for f in glob.glob(pattern)]
+        usergroups = groupby(records, lambda item: item['username'])
+        self.src_records = [self._sort_by_timestamp(v)[0] for v in usergroups.values()]
+
+    def init_dest(self):
+        pass
+
+    def copy_files(self):
+        for rec in self.src_records:
+            student_id = rec['username']
+            src_path = os.path.join(self.inbound_path, rec['filename'])
+            dest_path = self.coursedir.format_path(self.coursedir.submitted_directory, student_id, self.coursedir.assignment_id)
+            if not os.path.exists(os.path.dirname(dest_path)):
+                os.makedirs(os.path.dirname(dest_path))
+
+            copy = False
+            updating = False
+            if os.path.isdir(dest_path):
+                existing_timestamp = self.coursedir.get_existing_timestamp(dest_path)
+                new_timestamp = rec['timestamp']
+                if self.update and (existing_timestamp is None or new_timestamp > existing_timestamp):
+                    copy = True
+                    updating = True
+            else:
+                copy = True
+
+            if copy:
+                if updating:
+                    self.log.info("Updating submission: {} {}".format(student_id, self.coursedir.assignment_id))
+                    shutil.rmtree(dest_path)
+                else:
+                    self.log.info("Collecting submission: {} {}".format(student_id, self.coursedir.assignment_id))
+                self.do_copy(src_path, dest_path)
+            else:
+                if self.update:
+                    self.log.info("No newer submission to collect: {} {}".format(
+                        student_id, self.coursedir.assignment_id
+                    ))
+                else:
+                    self.log.info("Submission already exists, use --update to update: {} {}".format(
+                        student_id, self.coursedir.assignment_id
+                    ))

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -1,14 +1,21 @@
 import os
 import datetime
+import sys
+import shutil
 
 from textwrap import dedent
 
 from dateutil.tz import gettz
 from traitlets.config import LoggingConfigurable
-from traitlets import Unicode, Bool, default
+from traitlets import Unicode, Bool, Instance, default
 from jupyter_core.paths import jupyter_data_dir
 
-from .utils import check_directory
+from ..utils import check_directory
+from ..coursedir import CourseDirectory
+
+
+class ExchangeError(Exception):
+    pass
 
 
 class Exchange(LoggingConfigurable):
@@ -60,6 +67,18 @@ class Exchange(LoggingConfigurable):
         )
     ).tag(config=True)
 
+    coursedir = Instance(CourseDirectory, allow_none=True)
+
+    def __init__(self, coursedir=None, **kwargs):
+        self.coursedir = coursedir
+        super(Exchange, self).__init__(**kwargs)
+        if self.parent:
+            self.log = self.parent.log
+
+    def fail(self, msg):
+        self.log.fatal(msg)
+        raise ExchangeError(msg)
+
     def set_timestamp(self):
         """Set the timestap using the configured timezone."""
         tz = gettz(self.timezone)
@@ -81,3 +100,32 @@ class Exchange(LoggingConfigurable):
         """See if the exchange directory exists and is writable, fail if not."""
         if not check_directory(self.root, write=True, execute=True):
             self.fail("Unwritable directory, please contact your instructor: {}".format(self.root))
+
+    def init_src(self):
+        """Compute and check the source paths for the transfer."""
+        raise NotImplementedError
+
+    def init_dest(self):
+        """Compute and check the destination paths for the transfer."""
+        raise NotImplementedError
+
+    def copy_files(self):
+        """Actually do the file transfer."""
+        raise NotImplementedError
+
+    def do_copy(self, src, dest, perms=None):
+        """Copy the src dir to the dest dir omitting the self.coursedir.ignore globs."""
+        shutil.copytree(src, dest, ignore=shutil.ignore_patterns(*self.coursedir.ignore))
+        if perms:
+            self.set_perms(dest, perms=perms)
+
+    def start(self):
+        if sys.platform == 'win32':
+            self.fail("Sorry, the exchange is not available on Windows.")
+
+        self.ensure_root()
+        self.set_timestamp()
+
+        self.init_src()
+        self.init_dest()
+        self.copy_files()

--- a/nbgrader/exchange/fetch.py
+++ b/nbgrader/exchange/fetch.py
@@ -1,0 +1,74 @@
+import os
+import shutil
+
+from traitlets import Bool
+
+from .exchange import Exchange
+from ..utils import check_mode
+
+
+class ExchangeFetch(Exchange):
+
+    replace_missing_files = Bool(False, help="Whether to replace missing files on fetch").tag(config=True)
+
+    def init_src(self):
+        if self.course_id == '':
+            self.fail("No course id specified. Re-run with --course flag.")
+
+        self.course_path = os.path.join(self.root, self.course_id)
+        self.outbound_path = os.path.join(self.course_path, 'outbound')
+        self.src_path = os.path.join(self.outbound_path, self.coursedir.assignment_id)
+        if not os.path.isdir(self.src_path):
+            self.fail("Assignment not found: {}".format(self.src_path))
+        if not check_mode(self.src_path, read=True, execute=True):
+            self.fail("You don't have read permissions for the directory: {}".format(self.src_path))
+
+    def init_dest(self):
+        if self.path_includes_course:
+            root = os.path.join(self.course_id, self.coursedir.assignment_id)
+        else:
+            root = self.coursedir.assignment_id
+        self.dest_path = os.path.abspath(os.path.join('.', root))
+        if os.path.isdir(self.dest_path) and not self.replace_missing_files:
+            self.fail("You already have a copy of the assignment in this directory: {}".format(root))
+
+    def copy_if_missing(self, src, dest, ignore=None):
+        filenames = sorted(os.listdir(src))
+        if ignore:
+            bad_filenames = ignore(src, filenames)
+            filenames = sorted(list(set(filenames) - bad_filenames))
+
+        for filename in filenames:
+            srcpath = os.path.join(src, filename)
+            destpath = os.path.join(dest, filename)
+            relpath = os.path.relpath(destpath, os.getcwd())
+            if not os.path.exists(destpath):
+                if os.path.isdir(srcpath):
+                    self.log.warn("Creating missing directory '%s'", relpath)
+                    os.mkdir(destpath)
+
+                else:
+                    self.log.warn("Replacing missing file '%s'", relpath)
+                    shutil.copy(srcpath, destpath)
+
+            if os.path.isdir(srcpath):
+                self.copy_if_missing(srcpath, destpath, ignore=ignore)
+
+
+    def do_copy(self, src, dest, perms=None):
+        """Copy the src dir to the dest dir omitting the self.coursedir.ignore globs."""
+        if os.path.isdir(self.dest_path):
+            self.copy_if_missing(src, dest, ignore=shutil.ignore_patterns(*self.coursedir.ignore))
+        else:
+            shutil.copytree(src, dest, ignore=shutil.ignore_patterns(*self.coursedir.ignore))
+
+        if perms:
+            for dirname, _, filenames in os.walk(dest):
+                for filename in filenames:
+                    os.chmod(os.path.join(dirname, filename), perms)
+
+    def copy_files(self):
+        self.log.info("Source: {}".format(self.src_path))
+        self.log.info("Destination: {}".format(self.dest_path))
+        self.do_copy(self.src_path, self.dest_path)
+        self.log.info("Fetched as: {} {}".format(self.course_id, self.coursedir.assignment_id))

--- a/nbgrader/exchange/list.py
+++ b/nbgrader/exchange/list.py
@@ -1,0 +1,140 @@
+import os
+import glob
+import shutil
+import re
+import json
+
+from traitlets import Bool
+
+from .exchange import Exchange
+
+
+class ExchangeList(Exchange):
+
+    inbound = Bool(False, help="List inbound files rather than outbound.").tag(config=True)
+    cached = Bool(False, help="List assignments in submission cache.").tag(config=True)
+    remove = Bool(False, help="Remove, rather than list files.").tag(config=True)
+    as_json = Bool(False, help="Print out assignments as json").tag(config=True)
+
+    def init_src(self):
+        pass
+
+    def init_dest(self):
+        course_id = self.course_id if self.course_id else '*'
+        assignment_id = self.coursedir.assignment_id if self.coursedir.assignment_id else '*'
+        student_id = self.coursedir.student_id if self.coursedir.student_id else '*'
+
+        if self.inbound:
+            pattern = os.path.join(self.root, course_id, 'inbound', '{}+{}+*'.format(student_id, assignment_id))
+        elif self.cached:
+            pattern = os.path.join(self.cache, course_id, '{}+{}+*'.format(student_id, assignment_id))
+        else:
+            pattern = os.path.join(self.root, course_id, 'outbound', '{}'.format(assignment_id))
+
+        self.assignments = sorted(glob.glob(pattern))
+
+    def parse_assignment(self, assignment):
+        if self.inbound:
+            regexp = r".*/(?P<course_id>.*)/inbound/(?P<student_id>.*)\+(?P<assignment_id>.*)\+(?P<timestamp>.*)"
+        elif self.cached:
+            regexp = r".*/(?P<course_id>.*)/(?P<student_id>.*)\+(?P<assignment_id>.*)\+(?P<timestamp>.*)"
+        else:
+            regexp = r".*/(?P<course_id>.*)/outbound/(?P<assignment_id>.*)"
+
+        m = re.match(regexp, assignment)
+        if m is None:
+            raise RuntimeError("Could not match '%s' with regexp '%s'", assignment, regexp)
+        return m.groupdict()
+
+    def format_inbound_assignment(self, info):
+        return "{course_id} {student_id} {assignment_id} {timestamp}".format(**info)
+
+    def format_outbound_assignment(self, info):
+        msg = "{course_id} {assignment_id}".format(**info)
+        if os.path.exists(info['assignment_id']):
+            msg += " (already downloaded)"
+        return msg
+
+    def copy_files(self):
+        pass
+
+    def parse_assignments(self):
+        assignments = []
+        for path in self.assignments:
+            info = self.parse_assignment(path)
+            if self.path_includes_course:
+                root = os.path.join(info['course_id'], info['assignment_id'])
+            else:
+                root = info['assignment_id']
+
+            if self.inbound or self.cached:
+                info['status'] = 'submitted'
+                info['path'] = path
+            elif os.path.exists(root):
+                info['status'] = 'fetched'
+                info['path'] = os.path.abspath(root)
+            else:
+                info['status'] = 'released'
+                info['path'] = path
+
+            if self.remove:
+                info['status'] = 'removed'
+
+            info['notebooks'] = []
+            for notebook in sorted(glob.glob(os.path.join(info['path'], '*.ipynb'))):
+                info['notebooks'].append({
+                    'notebook_id': os.path.splitext(os.path.split(notebook)[1])[0],
+                    'path': os.path.abspath(notebook)
+                })
+
+            assignments.append(info)
+
+        return assignments
+
+    def list_files(self):
+        """List files."""
+        assignments = self.parse_assignments()
+
+        if self.as_json:
+            print(json.dumps(assignments))
+
+        else:
+            if self.inbound or self.cached:
+                self.log.info("Submitted assignments:")
+                for info in assignments:
+                    self.log.info(self.format_inbound_assignment(info))
+            else:
+                self.log.info("Released assignments:")
+                for info in assignments:
+                    self.log.info(self.format_outbound_assignment(info))
+
+    def remove_files(self):
+        """List and remove files."""
+        assignments = self.parse_assignments()
+
+        if self.as_json:
+            print(json.dumps(assignments))
+
+        else:
+            if self.inbound or self.cached:
+                self.log.info("Removing submitted assignments:")
+                for info in assignments:
+                    self.log.info(self.format_inbound_assignment(info))
+            else:
+                self.log.info("Removing released assignments:")
+                for info in assignments:
+                    self.log.info(self.format_outbound_assignment(info))
+
+        for assignment in self.assignments:
+            shutil.rmtree(assignment)
+
+    def start(self):
+        if self.inbound and self.cached:
+            self.fail("Options --inbound and --cached are incompatible.")
+
+        super(ExchangeList, self).start()
+
+        if self.remove:
+            self.remove_files()
+        else:
+            self.list_files()

--- a/nbgrader/exchange/release.py
+++ b/nbgrader/exchange/release.py
@@ -1,0 +1,81 @@
+import os
+import shutil
+from stat import (
+    S_IRUSR, S_IWUSR, S_IXUSR,
+    S_IRGRP, S_IWGRP, S_IXGRP,
+    S_IROTH, S_IWOTH, S_IXOTH,
+    S_ISGID
+)
+
+from traitlets import Bool
+
+from .exchange import Exchange
+from ..utils import self_owned
+
+
+class ExchangeRelease(Exchange):
+
+    force = Bool(False, help="Force overwrite existing files in the exchange.").tag(config=True)
+
+    def init_src(self):
+        self.src_path = self.coursedir.format_path(self.coursedir.release_directory, '.', self.coursedir.assignment_id)
+        if not os.path.isdir(self.src_path):
+            source = self.coursedir.format_path(self.coursedir.source_directory, '.', self.coursedir.assignment_id)
+            if os.path.isdir(source):
+                # Looks like the instructor forgot to assign
+                self.fail("Assignment found in '{}' but not '{}', run `nbgrader assign` first.".format(
+                    source, self.src_path))
+            else:
+                self.fail("Assignment not found: {}".format(self.src_path))
+
+    def init_dest(self):
+        if self.course_id == '':
+            self.fail("No course id specified. Re-run with --course flag.")
+
+        self.course_path = os.path.join(self.root, self.course_id)
+        self.outbound_path = os.path.join(self.course_path, 'outbound')
+        self.inbound_path = os.path.join(self.course_path, 'inbound')
+        self.dest_path = os.path.join(self.outbound_path, self.coursedir.assignment_id)
+        # 0755
+        self.ensure_directory(
+            self.course_path,
+            S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH
+        )
+        # 0755
+        self.ensure_directory(
+            self.outbound_path,
+            S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH
+        )
+        # 0733 with set GID so student submission will have the instructors group
+        self.ensure_directory(
+            self.inbound_path,
+            S_ISGID|S_IRUSR|S_IWUSR|S_IXUSR|S_IWGRP|S_IXGRP|S_IWOTH|S_IXOTH
+        )
+
+    def ensure_directory(self, path, mode):
+        """Ensure that the path exists, has the right mode and is self owned."""
+        if not os.path.isdir(path):
+            os.mkdir(path)
+            # For some reason, Python won't create a directory with a mode of 0o733
+            # so we have to create and then chmod.
+            os.chmod(path, mode)
+        else:
+            if not self_owned(path):
+                self.fail("You don't own the directory: {}".format(path))
+
+    def copy_files(self):
+        if os.path.isdir(self.dest_path):
+            if self.force:
+                self.log.info("Overwriting files: {} {}".format(
+                    self.course_id, self.coursedir.assignment_id
+                ))
+                shutil.rmtree(self.dest_path)
+            else:
+                self.fail("Destination already exists, add --force to overwrite: {} {}".format(
+                    self.course_id, self.coursedir.assignment_id
+                ))
+        self.log.info("Source: {}".format(self.src_path))
+        self.log.info("Destination: {}".format(self.dest_path))
+        perms = S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH
+        self.do_copy(self.src_path, self.dest_path, perms=perms)
+        self.log.info("Released as: {} {}".format(self.course_id, self.coursedir.assignment_id))

--- a/nbgrader/exchange/submit.py
+++ b/nbgrader/exchange/submit.py
@@ -1,0 +1,135 @@
+import os
+from stat import (
+    S_IRUSR, S_IWUSR, S_IXUSR,
+    S_IRGRP, S_IWGRP, S_IXGRP,
+    S_IROTH, S_IWOTH, S_IXOTH
+)
+
+from textwrap import dedent
+from traitlets import Bool
+
+from .exchange import Exchange
+from ..utils import get_username, check_mode, find_all_notebooks
+
+
+class ExchangeSubmit(Exchange):
+
+    strict = Bool(
+        False,
+        help=dedent(
+            "Whether or not to submit the assignment if there are missing "
+            "notebooks from the released assignment notebooks."
+        )
+    ).tag(config=True)
+
+    def init_src(self):
+        if self.path_includes_course:
+            root = os.path.join(self.course_id, self.coursedir.assignment_id)
+        else:
+            root = self.coursedir.assignment_id
+        self.src_path = os.path.abspath(root)
+        self.coursedir.assignment_id = os.path.split(self.src_path)[-1]
+        if not os.path.isdir(self.src_path):
+            self.fail("Assignment not found: {}".format(self.src_path))
+
+    def init_dest(self):
+        if self.course_id == '':
+            self.fail("No course id specified. Re-run with --course flag.")
+
+        self.inbound_path = os.path.join(self.root, self.course_id, 'inbound')
+        if not os.path.isdir(self.inbound_path):
+            self.fail("Inbound directory doesn't exist: {}".format(self.inbound_path))
+        if not check_mode(self.inbound_path, write=True, execute=True):
+            self.fail("You don't have write permissions to the directory: {}".format(self.inbound_path))
+
+        self.cache_path = os.path.join(self.cache, self.course_id)
+        self.assignment_filename = '{}+{}+{}'.format(get_username(), self.coursedir.assignment_id, self.timestamp)
+
+    def init_release(self):
+        if self.course_id == '':
+            self.fail("No course id specified. Re-run with --course flag.")
+
+        course_path = os.path.join(self.root, self.course_id)
+        outbound_path = os.path.join(course_path, 'outbound')
+        self.release_path = os.path.join(outbound_path, self.coursedir.assignment_id)
+        if not os.path.isdir(self.release_path):
+            self.fail("Assignment not found: {}".format(self.release_path))
+        if not check_mode(self.release_path, read=True, execute=True):
+            self.fail("You don't have read permissions for the directory: {}".format(self.release_path))
+
+    def check_filename_diff(self):
+        released_notebooks = find_all_notebooks(self.release_path)
+        submitted_notebooks = find_all_notebooks(self.src_path)
+
+        # Look for missing notebooks in submitted notebooks
+        missing = False
+        release_diff = list()
+        for filename in released_notebooks:
+            if filename in submitted_notebooks:
+                release_diff.append("{}: {}".format(filename, 'FOUND'))
+            else:
+                missing = True
+                release_diff.append("{}: {}".format(filename, 'MISSING'))
+
+        # Look for extra notebooks in submitted notebooks
+        extra = False
+        submitted_diff = list()
+        for filename in submitted_notebooks:
+            if filename in released_notebooks:
+                submitted_diff.append("{}: {}".format(filename, 'OK'))
+            else:
+                extra = True
+                submitted_diff.append("{}: {}".format(filename, 'EXTRA'))
+
+        if missing or extra:
+            diff_msg = (
+                "Expected:\n\t{}\nSubmitted:\n\t{}".format(
+                    '\n\t'.join(release_diff),
+                    '\n\t'.join(submitted_diff),
+                )
+            )
+            if missing and self.strict:
+                self.fail(
+                    "Assignment {} not submitted. "
+                    "There are missing notebooks for the submission:\n{}"
+                    "".format(self.coursedir.assignment_id, diff_msg)
+                )
+            else:
+                self.log.warning(
+                    "Possible missing notebooks and/or extra notebooks "
+                    "submitted for assignment {}:\n{}"
+                    "".format(self.coursedir.assignment_id, diff_msg)
+                )
+
+    def copy_files(self):
+        self.init_release()
+
+        dest_path = os.path.join(self.inbound_path, self.assignment_filename)
+        cache_path = os.path.join(self.cache_path, self.assignment_filename)
+
+        self.log.info("Source: {}".format(self.src_path))
+        self.log.info("Destination: {}".format(dest_path))
+
+        # copy to the real location
+        self.check_filename_diff()
+        self.do_copy(self.src_path, dest_path)
+        with open(os.path.join(dest_path, "timestamp.txt"), "w") as fh:
+            fh.write(self.timestamp)
+        self.set_perms(dest_path, perms=(S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH))
+
+        # Make this 0777=ugo=rwx so the instructor can delete later. Hidden from other users by the timestamp.
+        os.chmod(
+            dest_path,
+            S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IWGRP|S_IXGRP|S_IROTH|S_IWOTH|S_IXOTH
+        )
+
+        # also copy to the cache
+        if not os.path.isdir(self.cache_path):
+            os.makedirs(self.cache_path)
+        self.do_copy(self.src_path, cache_path)
+        with open(os.path.join(cache_path, "timestamp.txt"), "w") as fh:
+            fh.write(self.timestamp)
+
+        self.log.info("Submitted as: {} {} {}".format(
+            self.course_id, self.coursedir.assignment_id, str(self.timestamp)
+        ))

--- a/nbgrader/tests/apps/test_nbgrader_collect.py
+++ b/nbgrader/tests/apps/test_nbgrader_collect.py
@@ -15,27 +15,27 @@ class TestNbGraderCollect(BaseTestApp):
         run_nbgrader([
             "release", assignment,
             "--course", "abc101",
-            "--TransferApp.exchange_directory={}".format(exchange)
+            "--Exchange.root={}".format(exchange)
         ])
         run_nbgrader([
             "fetch", assignment,
             "--course", "abc101",
-            "--TransferApp.exchange_directory={}".format(exchange)
+            "--Exchange.root={}".format(exchange)
         ])
 
     def _submit(self, assignment, exchange, cache):
         run_nbgrader([
             "submit", assignment,
             "--course", "abc101",
-            "--TransferApp.cache_directory={}".format(cache),
-            "--TransferApp.exchange_directory={}".format(exchange)
+            "--Exchange.cache={}".format(cache),
+            "--Exchange.root={}".format(exchange)
         ])
 
     def _collect(self, assignment, exchange, flags=None, retcode=0):
         cmd = [
             "collect", assignment,
             "--course", "abc101",
-            "--TransferApp.exchange_directory={}".format(exchange)
+            "--Exchange.root={}".format(exchange)
         ]
 
         if flags is not None:
@@ -58,7 +58,7 @@ class TestNbGraderCollect(BaseTestApp):
         self._submit("ps1", exchange, cache)
         cmd = [
             "collect", "ps1",
-            "--TransferApp.exchange_directory={}".format(exchange)
+            "--Exchange.root={}".format(exchange)
         ]
         run_nbgrader(cmd, retcode=1)
 

--- a/nbgrader/tests/apps/test_nbgrader_fetch.py
+++ b/nbgrader/tests/apps/test_nbgrader_fetch.py
@@ -14,14 +14,14 @@ class TestNbGraderFetch(BaseTestApp):
         run_nbgrader([
             "release", assignment,
             "--course", course,
-            "--TransferApp.exchange_directory={}".format(exchange)
+            "--Exchange.root={}".format(exchange)
         ])
 
     def _fetch(self, assignment, exchange, flags=None, retcode=0, course="abc101"):
         cmd = [
             "fetch", assignment,
             "--course", course,
-            "--TransferApp.exchange_directory={}".format(exchange)
+            "--Exchange.root={}".format(exchange)
         ]
 
         if flags is not None:
@@ -38,7 +38,7 @@ class TestNbGraderFetch(BaseTestApp):
         self._release("ps1", exchange, course_dir)
         cmd = [
             "fetch", "ps1",
-            "--TransferApp.exchange_directory={}".format(exchange)
+            "--Exchange.root={}".format(exchange)
         ]
         run_nbgrader(cmd, retcode=1)
 
@@ -74,9 +74,9 @@ class TestNbGraderFetch(BaseTestApp):
 
     def test_fetch_multiple_courses(self, exchange, course_dir):
         self._release("ps1", exchange, course_dir, course="abc101")
-        self._fetch("ps1", exchange, course="abc101", flags=["--TransferApp.path_includes_course=True"])
+        self._fetch("ps1", exchange, course="abc101", flags=["--Exchange.path_includes_course=True"])
         assert os.path.isfile(join("abc101", "ps1", "p1.ipynb"))
 
         self._release("ps1", exchange, course_dir, course="abc102")
-        self._fetch("ps1", exchange, course="abc102", flags=["--TransferApp.path_includes_course=True"])
+        self._fetch("ps1", exchange, course="abc102", flags=["--Exchange.path_includes_course=True"])
         assert os.path.isfile(join("abc102", "ps1", "p1.ipynb"))

--- a/nbgrader/tests/apps/test_nbgrader_list.py
+++ b/nbgrader/tests/apps/test_nbgrader_list.py
@@ -17,16 +17,16 @@ class TestNbGraderList(BaseTestApp):
         run_nbgrader([
             "release", assignment,
             "--course", course,
-            "--TransferApp.cache_directory={}".format(cache),
-            "--TransferApp.exchange_directory={}".format(exchange)
+            "--Exchange.cache={}".format(cache),
+            "--Exchange.root={}".format(exchange)
         ])
 
     def _fetch(self, assignment, exchange, cache, course="abc101", flags=None):
         cmd = [
             "fetch", assignment,
             "--course", course,
-            "--TransferApp.cache_directory={}".format(cache),
-            "--TransferApp.exchange_directory={}".format(exchange)
+            "--Exchange.cache={}".format(cache),
+            "--Exchange.root={}".format(exchange)
         ]
 
         if flags is not None:
@@ -38,8 +38,8 @@ class TestNbGraderList(BaseTestApp):
         cmd = [
             "submit", assignment,
             "--course", course,
-            "--TransferApp.cache_directory={}".format(cache),
-            "--TransferApp.exchange_directory={}".format(exchange)
+            "--Exchange.cache={}".format(cache),
+            "--Exchange.root={}".format(exchange)
         ]
 
         if flags is not None:
@@ -50,8 +50,8 @@ class TestNbGraderList(BaseTestApp):
     def _list(self, exchange, cache, assignment=None, flags=None, retcode=0):
         cmd = [
             "list",
-            "--TransferApp.cache_directory={}".format(cache),
-            "--TransferApp.exchange_directory={}".format(exchange),
+            "--Exchange.cache={}".format(cache),
+            "--Exchange.root={}".format(exchange),
         ]
 
         if flags is not None:
@@ -402,7 +402,7 @@ class TestNbGraderList(BaseTestApp):
     def test_list_json_multiple_courses(self, exchange, cache, course_dir):
         self._release("ps1", exchange, cache, course_dir, course="abc101")
         self._release("ps1", exchange, cache, course_dir, course="abc102")
-        assert json.loads(self._list(exchange, cache, flags=["--json", "--TransferApp.path_includes_course=True"])) == [
+        assert json.loads(self._list(exchange, cache, flags=["--json", "--Exchange.path_includes_course=True"])) == [
             {
                 "assignment_id": "ps1",
                 "status": "released",
@@ -429,9 +429,9 @@ class TestNbGraderList(BaseTestApp):
             }
         ]
 
-        self._fetch("ps1", exchange, cache, course="abc101", flags=["--TransferApp.path_includes_course=True"])
-        self._fetch("ps1", exchange, cache, course="abc102", flags=["--TransferApp.path_includes_course=True"])
-        assert json.loads(self._list(exchange, cache, flags=["--json", "--TransferApp.path_includes_course=True"])) == [
+        self._fetch("ps1", exchange, cache, course="abc101", flags=["--Exchange.path_includes_course=True"])
+        self._fetch("ps1", exchange, cache, course="abc102", flags=["--Exchange.path_includes_course=True"])
+        assert json.loads(self._list(exchange, cache, flags=["--json", "--Exchange.path_includes_course=True"])) == [
             {
                 "assignment_id": "ps1",
                 "status": "fetched",

--- a/nbgrader/tests/apps/test_nbgrader_release.py
+++ b/nbgrader/tests/apps/test_nbgrader_release.py
@@ -13,7 +13,7 @@ class TestNbGraderRelease(BaseTestApp):
         cmd = [
             "release", assignment,
             "--course", "abc101",
-            "--TransferApp.exchange_directory={}".format(exchange)
+            "--Exchange.root={}".format(exchange)
         ]
 
         if flags is not None:
@@ -29,7 +29,7 @@ class TestNbGraderRelease(BaseTestApp):
         """Does releasing without a course id thrown an error?"""
         cmd = [
             "release", "ps1",
-            "--TransferApp.exchange_directory={}".format(exchange)
+            "--Exchange.root={}".format(exchange)
         ]
         run_nbgrader(cmd, retcode=1)
 

--- a/nbgrader/tests/apps/test_nbgrader_submit.py
+++ b/nbgrader/tests/apps/test_nbgrader_submit.py
@@ -19,16 +19,16 @@ class TestNbGraderSubmit(BaseTestApp):
         run_nbgrader([
             "release", assignment,
             "--course", course,
-            "--TransferApp.cache_directory={}".format(cache),
-            "--TransferApp.exchange_directory={}".format(exchange)
+            "--Exchange.cache={}".format(cache),
+            "--Exchange.root={}".format(exchange)
         ])
 
     def _fetch(self, assignment, exchange, cache, course="abc101", flags=None):
         cmd = [
             "fetch", assignment,
             "--course", course,
-            "--TransferApp.cache_directory={}".format(cache),
-            "--TransferApp.exchange_directory={}".format(exchange)
+            "--Exchange.cache={}".format(cache),
+            "--Exchange.root={}".format(exchange)
         ]
 
         if flags is not None:
@@ -44,8 +44,8 @@ class TestNbGraderSubmit(BaseTestApp):
         cmd = [
             "submit", assignment,
             "--course", course,
-            "--TransferApp.cache_directory={}".format(cache),
-            "--TransferApp.exchange_directory={}".format(exchange)
+            "--Exchange.cache={}".format(cache),
+            "--Exchange.root={}".format(exchange)
         ]
 
         if flags is not None:
@@ -62,8 +62,8 @@ class TestNbGraderSubmit(BaseTestApp):
         self._release_and_fetch("ps1", exchange, cache, course_dir)
         cmd = [
             "submit", "ps1",
-            "--TransferApp.cache_directory={}".format(cache),
-            "--TransferApp.exchange_directory={}".format(exchange)
+            "--Exchange.cache={}".format(cache),
+            "--Exchange.root={}".format(exchange)
         ]
         run_nbgrader(cmd, retcode=1)
 
@@ -164,14 +164,14 @@ class TestNbGraderSubmit(BaseTestApp):
         self._release("ps1", exchange, cache, course_dir, course="abc102")
         self._fetch(
             "ps1", exchange, cache, course="abc101",
-            flags=["--TransferApp.path_includes_course=True"])
+            flags=["--Exchange.path_includes_course=True"])
         self._fetch(
             "ps1", exchange, cache, course="abc102",
-            flags=["--TransferApp.path_includes_course=True"])
+            flags=["--Exchange.path_includes_course=True"])
 
         self._submit(
             "ps1", exchange, cache, course="abc101",
-            flags=["--TransferApp.path_includes_course=True"])
+            flags=["--Exchange.path_includes_course=True"])
 
         filename, = os.listdir(join(exchange, "abc101", "inbound"))
         username, assignment, _ = filename.split("+")
@@ -189,7 +189,7 @@ class TestNbGraderSubmit(BaseTestApp):
 
         self._submit(
             "ps1", exchange, cache, course="abc102",
-            flags=["--TransferApp.path_includes_course=True"])
+            flags=["--Exchange.path_includes_course=True"])
 
         filename, = os.listdir(join(exchange, "abc102", "inbound"))
         username, assignment, _ = filename.split("+")

--- a/nbgrader/tests/nbextensions/conftest.py
+++ b/nbgrader/tests/nbextensions/conftest.py
@@ -120,8 +120,8 @@ def nbserver(request, port, tempdir, jupyter_config_dir, jupyter_data_dir, excha
         if sys.platform != 'win32':
             fh.write(dedent(
                 """
-                c.TransferApp.exchange_directory = "{}"
-                c.TransferApp.cache_directory = "{}"
+                c.Exchange.root = "{}"
+                c.Exchange.cache = "{}"
                 """.format(exchange, cache)
             ))
 

--- a/nbgrader/tests/nbextensions/test_assignment_list.py
+++ b/nbgrader/tests/nbextensions/test_assignment_list.py
@@ -299,7 +299,7 @@ def test_submit_assignment_missing_notebooks(browser, port, class_files, tempdir
 
     # set strict flag
     with open('nbgrader_config.py', 'a') as config:
-        config.write('c.SubmitApp.strict = True')
+        config.write('c.ExchangeSubmit.strict = True')
 
     # submit it again
     rows = browser.find_elements_by_css_selector("#fetched_assignments_list > .list_item")


### PR DESCRIPTION
This is the second step after #711 towards addressing #705 

This moves the functionality from applications based on `TransferApp` to standalone objects that inherit from a class called `Exchange`. I have deprecated `TransferApp` entirely, though the other apps (e.g. `FetchApp`) still exist and now inherit directly from `NbGrader`. This shouldn't change the functionality of the exchange apps at all, except for renaming the config options. In general, the config options get renamed as follows:

* `TransferApp` --> `Exchange`
* `ReleaseApp` --> `ExchangeRelease`
* `FetchApp` --> `ExchangeFetch`
* `SubmitApp` --> `ExchangeSubmit`
* `CollectApp` --> `ExchangeCollect`
* `ListApp` --> `ExchangeList`

Still need to make sure all the docs etc. are updated.