### PR TITLE
Don't create the gradebook database until formgrader is accessed

### DIFF
--- a/nbgrader/server_extensions/formgrader/base.py
+++ b/nbgrader/server_extensions/formgrader/base.py
@@ -3,6 +3,7 @@ import json
 
 from tornado import web
 from notebook.base.handlers import IPythonHandler
+from ...api import Gradebook
 
 
 class BaseHandler(IPythonHandler):
@@ -12,8 +13,17 @@ class BaseHandler(IPythonHandler):
         return super(BaseHandler, self).base_url.rstrip("/")
 
     @property
+    def db_url(self):
+        return self.settings['nbgrader_db_url']
+
+    @property
     def gradebook(self):
-        return self.settings['nbgrader_gradebook']
+        self.log.debug("getting gradebook")
+        gb = self.settings['nbgrader_gradebook']
+        if gb is None:
+            gb = Gradebook(self.db_url)
+            self.settings['nbgrader_gradebook'] = gb
+        return gb
 
     @property
     def mathjax_url(self):

--- a/nbgrader/server_extensions/formgrader/formgrader.py
+++ b/nbgrader/server_extensions/formgrader/formgrader.py
@@ -8,7 +8,6 @@ from notebook.utils import url_path_join as ujoin
 
 from . import handlers, apihandlers
 from ...apps.baseapp import NbGrader
-from ...api import Gradebook
 
 
 class FormgradeExtension(NbGrader):
@@ -38,7 +37,8 @@ class FormgradeExtension(NbGrader):
             nbgrader_notebook_dir_format=self.coursedir.directory_structure,
             nbgrader_step=self.coursedir.autograded_directory,
             nbgrader_exporter=HTMLExporter(config=self.config),
-            nbgrader_gradebook=Gradebook(self.coursedir.db_url),
+            nbgrader_gradebook=None,
+            nbgrader_db_url=self.coursedir.db_url,
             nbgrader_jinja2_env=jinja_env,
             nbgrader_notebook_url_prefix=os.path.relpath(self.coursedir.root)
         )


### PR DESCRIPTION
Fixes #741 

This will still create an empty gradebook in the directory if the notebook is run if there is no `nbgrader_config.py` file to specify where the gradebook should be. However, this file will now not be created until the formgrader itself is actually accessed.

cc @Szepi @lgpage 