### PR TITLE
Set random cell ids

### DIFF
--- a/nbgrader/nbextensions/create_assignment/main.js
+++ b/nbgrader/nbextensions/create_assignment/main.js
@@ -75,6 +75,16 @@ define([
         validate_ids();
     });
 
+    var randomString = function(length) {
+        var result = '';
+        var chars = 'abcdef0123456789';
+        var i;
+        for (i=0; i < length; i++) {
+            result += chars[Math.floor(Math.random() * chars.length)];
+        }
+        return result;
+    };
+
     var to_float = function(val) {
         if (val === undefined || val === "") {
             return 0;
@@ -219,9 +229,9 @@ define([
 
     var get_grade_id = function (cell) {
         if (cell.metadata.nbgrader === undefined) {
-            return '';
+            return "cell-" + randomString(16);
         } else if (cell.metadata.nbgrader.grade_id === undefined) {
-            return '';
+            return "cell-" + randomString(16);
         } else {
             return cell.metadata.nbgrader.grade_id;
         }
@@ -376,6 +386,7 @@ define([
         var lbl = $('<label/>').append($('<span/>').text('ID: '));
         lbl.append(text);
 
+        set_grade_id(cell, get_grade_id(cell));
         text.addClass('nbgrader-id-input');
         text.attr("value", get_grade_id(cell));
         text.change(function () {

--- a/nbgrader/tests/nbextensions/test_create_assignment.py
+++ b/nbgrader/tests/nbextensions/test_create_assignment.py
@@ -498,6 +498,7 @@ def test_cell_ids(browser, port):
 
     # turn it into a cell with an id
     _select_solution(browser)
+    _set_id(browser, cell_id="")
 
     # save and check for an error (blank id)
     _save(browser)

--- a/nbgrader/tests/nbextensions/test_create_assignment.py
+++ b/nbgrader/tests/nbextensions/test_create_assignment.py
@@ -167,6 +167,7 @@ def test_manual_cell(browser, port):
     assert 2 == _get_metadata(browser)['points']
 
     # set the id
+    assert _get_metadata(browser)['grade_id'].startswith("cell-")
     _set_id(browser)
     assert "foo" == _get_metadata(browser)['grade_id']
 
@@ -198,6 +199,7 @@ def test_solution_cell(browser, port):
         EC.presence_of_all_elements_located((By.CSS_SELECTOR, ".nbgrader-id")))
 
     # set the id
+    assert _get_metadata(browser)['grade_id'].startswith("cell-")
     _set_id(browser)
     assert "foo" == _get_metadata(browser)['grade_id']
 
@@ -237,6 +239,7 @@ def test_tests_cell(browser, port):
     assert 2 == _get_metadata(browser)['points']
 
     # set the id
+    assert _get_metadata(browser)['grade_id'].startswith("cell-")
     _set_id(browser)
     assert "foo" == _get_metadata(browser)['grade_id']
 
@@ -276,6 +279,7 @@ def test_tests_to_solution_cell(browser, port):
     assert 2 == _get_metadata(browser)['points']
 
     # set the id
+    assert _get_metadata(browser)['grade_id'].startswith("cell-")
     _set_id(browser)
     assert "foo" == _get_metadata(browser)['grade_id']
 
@@ -317,6 +321,7 @@ def test_locked_cell(browser, port):
         EC.presence_of_all_elements_located((By.CSS_SELECTOR, ".lock-button")))
 
     # set the id
+    assert _get_metadata(browser)['grade_id'].startswith("cell-")
     _set_id(browser)
     assert "foo" == _get_metadata(browser)['grade_id']
 


### PR DESCRIPTION
Fixes #684 by setting cell ids by default to `cell-xxxxxxxxxxxxxxxx` where `xxxxxxxxxxxxxxxx` is a random hex string of length 16.

cc @ellisonbg 