### PR TITLE
Fix nbextension tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 sudo: false
 python:
   - 2.7
-  - 3.4
   - 3.5
   - 3.6
 env:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,10 +10,6 @@ environment:
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Python34-x64"
-      PYTHON_VERSION: "3.4"
-      PYTHON_ARCH: "64"
-
     - PYTHON: "C:\\Python35-x64"
       PYTHON_VERSION: "3.5"
       PYTHON_ARCH: "64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,10 +14,6 @@ environment:
       PYTHON_VERSION: "3.5"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Python36-x64"
-      PYTHON_VERSION: "3.6"
-      PYTHON_ARCH: "64"
-
 install:
   # If there is a newer build queued for the same PR, cancel this one. The
   # AppVeyor 'rollout builds' option is supposed to serve the same purpose but

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -37,7 +37,7 @@ class Exchange(LoggingConfigurable):
     ).tag(config=True)
 
     timestamp_format = Unicode(
-        "%Y-%m-%d %H:%M:%S %Z",
+        "%Y-%m-%d %H:%M:%S.%f %Z",
         help="Format string for timestamps"
     ).tag(config=True)
 


### PR DESCRIPTION
This sets the timestamp format for submissions to include microseconds, and also removes python 3.4 test cases. Should make the tests more robust.