### PR TITLE
Better cleanup when nbconvert-based apps crash

### DIFF
--- a/nbgrader/apps/baseapp.py
+++ b/nbgrader/apps/baseapp.py
@@ -55,6 +55,10 @@ def format_excepthook(etype, evalue, tb):
     ), file=sys.stderr)
 
 
+class NbGraderException(Exception):
+    pass
+
+
 class NbGrader(JupyterApp):
     """A base class for all the nbgrader apps."""
 
@@ -350,8 +354,8 @@ class BaseNbConvertApp(NbGrader, NbConvertApp):
         help=dedent(
             """
             Permissions to set on files output by nbgrader. The default is generally
-            read-only (444), with the exception of nbgrader assign, in which case the
-            user also has write permission.
+            read-only (444), with the exception of nbgrader assign and nbgrader feedback,
+            in which case the user also has write permission.
             """
         )
     ).tag(config=True)
@@ -590,6 +594,10 @@ class BaseNbConvertApp(NbGrader, NbConvertApp):
                     "the issue, first BACK UP your database and then run the "
                     "command `nbgrader db upgrade`."
                 )
+
+            except KeyboardInterrupt:
+                _handle_failure(gd)
+                self.fail("Canceled")
 
             except Exception:
                 self.log.error("There was an error processing assignment: %s", assignment)

--- a/nbgrader/apps/feedbackapp.py
+++ b/nbgrader/apps/feedbackapp.py
@@ -74,6 +74,10 @@ class FeedbackApp(BaseNbConvertApp):
     def _export_format_default(self):
         return 'html'
 
+    @default("permissions")
+    def _permissions_default(self):
+        return 644
+
     def build_extra_config(self):
         extra_config = super(FeedbackApp, self).build_extra_config()
 

--- a/nbgrader/tests/apps/test_nbgrader_feedback.py
+++ b/nbgrader/tests/apps/test_nbgrader_feedback.py
@@ -129,8 +129,13 @@ class TestNbGraderFeedback(BaseTestApp):
         run_nbgrader(["autograde", "ps1"])
         run_nbgrader(["feedback", "ps1"])
 
+        if sys.platform == 'win32':
+            perms = '666'
+        else:
+            perms = '644'
+
         assert isfile(join(course_dir, "feedback", "foo", "ps1", "foo.html"))
-        assert self._get_permissions(join(course_dir, "feedback", "foo", "ps1", "foo.html")) == "444"
+        assert self._get_permissions(join(course_dir, "feedback", "foo", "ps1", "foo.html")) == perms
 
     def test_custom_permissions(self, course_dir):
         """Are custom permissions properly set?"""
@@ -142,15 +147,10 @@ class TestNbGraderFeedback(BaseTestApp):
 
         self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "foo.ipynb"))
         run_nbgrader(["autograde", "ps1"])
-        run_nbgrader(["feedback", "ps1", "--FeedbackApp.permissions=644"])
-
-        if sys.platform == 'win32':
-            perms = '666'
-        else:
-            perms = '644'
+        run_nbgrader(["feedback", "ps1", "--FeedbackApp.permissions=444"])
 
         assert isfile(join(course_dir, "feedback", "foo", "ps1", "foo.html"))
-        assert self._get_permissions(join(course_dir, "feedback", "foo", "ps1", "foo.html")) == perms
+        assert self._get_permissions(join(course_dir, "feedback", "foo", "ps1", "foo.html")) == '444'
 
     def test_force_single_notebook(self, course_dir):
         with open("nbgrader_config.py", "a") as fh:


### PR DESCRIPTION
I am not sure if this totally fixes #570 but I think it does. In particular, this removes uses of `self.fail` in the nbconvert-based apps and throws an error instead. This is important because the nbconvert apps will catch the error and then cleanup, but if `self.fail` is used, the program terminates immediately.