### PR TITLE
Fix slow API calls

### DIFF
--- a/nbgrader/apps/api.py
+++ b/nbgrader/apps/api.py
@@ -225,7 +225,7 @@ class NbGraderAPI(LoggingConfigurable):
             ag_timestamps = dict(gb.db\
                 .query(Student.id, SubmittedAssignment.timestamp)\
                 .join(SubmittedAssignment)\
-                .filter(SubmittedAssignment.name == "ps1")\
+                .filter(SubmittedAssignment.name == assignment_id)\
                 .all())
             ag_students = set(ag_timestamps.keys())
 


### PR DESCRIPTION
Fixes #785 

With 1126 submissions, before autograding:

```
--
api.get_autograded_students('ps1')
0.054342s, best of 3
--
api.get_submitted_students('ps1')
0.04315s, best of 3
--
api.get_submissions('ps1')
0.558401s, best of 3
--
gb.submission_dicts('ps1')
0.014699s, best of 3
--
api.get_notebook_submissions('ps1', 'problem1')
0.011708s, best of 3
--
api.get_students()
0.072811s, best of 3
```

after autograding:

```
--
api.get_autograded_students('ps1')
0.926902s, best of 3
--
api.get_submitted_students('ps1')
0.051649s, best of 3
--
api.get_submissions('ps1')
1.04687s, best of 3
--
gb.submission_dicts('ps1')
0.28924s, best of 3
--
api.get_notebook_submissions('ps1', 'problem1')
2.141678s, best of 3
--
api.get_students()
0.25908s, best of 3
```

@lgpage would you mind testing this and see if there is improvement for you too?