### PR TITLE
Fix inaccurate nbextension test failures after reruns

### DIFF
--- a/nbgrader/tests/nbextensions/test_formgrader.py
+++ b/nbgrader/tests/nbextensions/test_formgrader.py
@@ -1127,7 +1127,7 @@ def test_manually_collect_assignment(browser, port, gradebook):
 
 
 @pytest.mark.nbextensions
-def test_autograde_assignment(browser, port, gradebook):
+def test_before_autograde_assignment(browser, port, gradebook):
     utils._load_gradebook_page(browser, port, "manage_submissions/ps2")
 
     # check the contents of the row before grading
@@ -1138,6 +1138,11 @@ def test_autograde_assignment(browser, port, gradebook):
     assert row.find_element_by_css_selector(".status").text == "needs autograding"
     assert row.find_element_by_css_selector(".score").text == ""
     assert utils._child_exists(row, ".autograde a")
+
+
+@pytest.mark.nbextensions
+def test_autograde_assignment1(browser, port, gradebook):
+    utils._load_gradebook_page(browser, port, "manage_submissions/ps2")
 
     # click on the autograde button
     row = browser.find_elements_by_css_selector("tbody tr")[0]
@@ -1166,6 +1171,11 @@ def test_autograde_assignment(browser, port, gradebook):
     assert row.find_element_by_css_selector(".status").text == "graded"
     assert row.find_element_by_css_selector(".score").text == "0 / 6"
     assert utils._child_exists(row, ".autograde a")
+
+
+@pytest.mark.nbextensions
+def test_autograde_assignment2(browser, port, gradebook):
+    utils._load_gradebook_page(browser, port, "manage_submissions/ps2")
 
     # overwrite the file
     source_path = join(os.path.dirname(__file__), "..", "..", "docs", "source", "user_guide", "source", "ps1", "problem1.ipynb")


### PR DESCRIPTION
The formgrader tests keep failing on travis for some reason, and then they get rerun, but then they encounter a different error because they modify state, which means we can't see what the real error is. This PR should at least makes the tests more re-runnable by splitting some of the tests up, so I can track down what's really going on.