### PR TITLE
Make sure relative paths to source and release dirs are correct

### DIFF
--- a/nbgrader/apps/baseapp.py
+++ b/nbgrader/apps/baseapp.py
@@ -247,6 +247,9 @@ class NbGrader(JupyterApp):
         self.coursedir = CourseDirectory(parent=self)
         super(NbGrader, self).initialize(argv)
 
+        # load config that is in the coursedir directory
+        super(JupyterApp, self).load_config_file("nbgrader_config.py", path=self.coursedir.root)
+
     def init_syspath(self):
         """Add the cwd to the sys.path ($PYTHONPATH)"""
         sys.path.insert(0, os.getcwd())
@@ -262,7 +265,6 @@ class NbGrader(JupyterApp):
         # clear the instance
         self.clear_instance()
         traitlets.log._logger = None
-
 
     def load_config_file(self, **kwargs):
         """Load the config file.

--- a/nbgrader/server_extensions/formgrader/base.py
+++ b/nbgrader/server_extensions/formgrader/base.py
@@ -19,6 +19,10 @@ class BaseHandler(IPythonHandler):
         return self.settings['nbgrader_db_url']
 
     @property
+    def url_prefix(self):
+        return self.settings['nbgrader_url_prefix']
+
+    @property
     def coursedir(self):
         return self.settings['nbgrader_coursedir']
 

--- a/nbgrader/server_extensions/formgrader/formgrader.py
+++ b/nbgrader/server_extensions/formgrader/formgrader.py
@@ -33,6 +33,7 @@ class FormgradeExtension(NbGrader):
 
         # Configure the formgrader settings
         tornado_settings = dict(
+            nbgrader_url_prefix=os.path.relpath(self.coursedir.root),
             nbgrader_coursedir=self.coursedir,
             nbgrader_exporter=HTMLExporter(config=self.config),
             nbgrader_gradebook=None,

--- a/nbgrader/server_extensions/formgrader/formgrader.py
+++ b/nbgrader/server_extensions/formgrader/formgrader.py
@@ -67,6 +67,8 @@ def load_jupyter_server_extension(nbapp):
     nbapp.log.info("Loading the formgrader nbgrader serverextension")
     webapp = nbapp.web_app
     formgrader = FormgradeExtension(parent=nbapp)
+    formgrader.log = nbapp.log
     formgrader.initialize([])
     formgrader.init_tornado_settings(webapp)
     formgrader.init_handlers(webapp)
+

--- a/nbgrader/server_extensions/formgrader/handlers.py
+++ b/nbgrader/server_extensions/formgrader/handlers.py
@@ -13,6 +13,7 @@ class ManageAssignmentsHandler(BaseHandler):
     def get(self):
         html = self.render(
             "manage_assignments.tpl",
+            url_prefix=self.url_prefix,
             base_url=self.base_url)
         self.write(html)
 
@@ -88,7 +89,6 @@ class SubmissionHandler(BaseHandler):
         indices = self.api.get_notebook_submission_indices(assignment_id, notebook_id)
         ix = indices.get(submission.id, -2)
 
-        url_prefix = os.path.relpath(self.coursedir.root)
         resources = {
             'assignment_id': assignment_id,
             'notebook_id': notebook_id,
@@ -99,7 +99,7 @@ class SubmissionHandler(BaseHandler):
             'mathjax_url': self.mathjax_url,
             'last_name': submission.student.last_name,
             'first_name': submission.student.first_name,
-            'notebook_path': url_prefix + '/' + relative_path
+            'notebook_path': self.url_prefix + '/' + relative_path
         }
 
         if not os.path.exists(filename):

--- a/nbgrader/server_extensions/formgrader/static/js/manage_assignments.js
+++ b/nbgrader/server_extensions/formgrader/static/js/manage_assignments.js
@@ -96,7 +96,7 @@ var AssignmentUI = Backbone.View.extend({
         this.$name.attr("data-order", name);
         this.$name.append($("<a/>")
             .attr("target", "_blank")
-            .attr("href", base_url + "/tree/" + this.model.get("source_path"))
+            .attr("href", base_url + "/tree/" + url_prefix + "/" + this.model.get("source_path"))
             .text(name));
 
         // duedate
@@ -140,7 +140,7 @@ var AssignmentUI = Backbone.View.extend({
         if (release_path) {
             this.$preview.append($("<a/>")
                 .attr("target", "_blank")
-                .attr("href", base_url + "/tree/" + release_path)
+                .attr("href", base_url + "/tree/" + url_prefix + "/" + release_path)
                 .append($("<span/>")
                     .addClass("glyphicon glyphicon-search")
                     .attr("aria-hidden", "true")));

--- a/nbgrader/server_extensions/formgrader/templates/manage_assignments.tpl
+++ b/nbgrader/server_extensions/formgrader/templates/manage_assignments.tpl
@@ -1,6 +1,10 @@
 {%- extends 'base.tpl' -%}
 
 {%- block head -%}
+<script>
+var url_prefix = "{{ url_prefix }}";
+</script>
+
 <script src="{{ base_url }}/formgrader/static/js/manage_assignments.js"></script>
 {%- endblock -%}
 


### PR DESCRIPTION
If the notebook is started in a different directory than the course directory, the links to the `source` and `release` folders are currently incorrect. This fixes that.