### PR TITLE
Avoid extension errors when exchange is missing

### DIFF
--- a/nbgrader/apps/api.py
+++ b/nbgrader/apps/api.py
@@ -10,7 +10,7 @@ from traitlets import Instance, Enum, Unicode, observe
 
 from ..coursedir import CourseDirectory
 from ..converters import Assign, Autograde
-from ..exchange import ExchangeList, ExchangeRelease, ExchangeCollect
+from ..exchange import ExchangeList, ExchangeRelease, ExchangeCollect, ExchangeError
 from ..api import MissingEntry, Gradebook, Student, SubmittedAssignment
 from ..utils import parse_utc, temp_attrs, capture_log, as_timezone
 
@@ -66,8 +66,13 @@ class NbGraderAPI(LoggingConfigurable):
             self.coursedir = coursedir
 
         if sys.platform != 'win32':
-            lister = ExchangeList(coursedir=self.coursedir, parent=self)
-            self.course_id = lister.course_id
+            try:
+                lister = ExchangeList(coursedir=self.coursedir, parent=self)
+                lister.start()
+            except ExchangeError:
+                self.course_id = None
+            else:
+                self.course_id = lister.course_id
         else:
             self.course_id = None
 

--- a/nbgrader/nbextensions/assignment_list/main.js
+++ b/nbgrader/nbextensions/assignment_list/main.js
@@ -134,6 +134,7 @@ define([
                 .text('Assignments')
                 .click(function (e) {
                     window.history.pushState(null, null, '#assignments');
+                    course_list.load_list();
                 })
             )
         );
@@ -157,7 +158,6 @@ define([
             }
         );
         checkNbGraderVersion(base_url);
-        course_list.load_list();
     }
     return {
         load_ipython_extension: load


### PR DESCRIPTION
Fixes #820

This does two things:

1. Does not attempt to load the assignments in the assignment list until it's actually accessed.
2. Tries to use the exchange in the formgrader, and if it fails, sets the course id to none.