### PR TITLE
Produce warnings if the exchange isn't set up correctly

### DIFF
--- a/nbgrader/server_extensions/formgrader/handlers.py
+++ b/nbgrader/server_extensions/formgrader/handlers.py
@@ -1,5 +1,6 @@
 import os
 import re
+import sys
 
 from tornado import web
 
@@ -14,7 +15,11 @@ class ManageAssignmentsHandler(BaseHandler):
         html = self.render(
             "manage_assignments.tpl",
             url_prefix=self.url_prefix,
-            base_url=self.base_url)
+            base_url=self.base_url,
+            windows=(sys.prefix == 'win32'),
+            course_id=self.api.course_id,
+            exchange=self.api.exchange,
+            exchange_missing=self.api.exchange_missing)
         self.write(html)
 
 

--- a/nbgrader/server_extensions/formgrader/templates/manage_assignments.tpl
+++ b/nbgrader/server_extensions/formgrader/templates/manage_assignments.tpl
@@ -55,6 +55,27 @@ Manage Assignments
     </div>
   </div>
 </div>
+{% if windows %}
+<div class="alert alert-warning" id="warning-windows">
+Windows operating system detected. Please note that the "release" and "collect"
+functionality will not be available.
+</div>
+{% elif exchange_missing %}
+<div class="alert alert-warning" id="warning-exchange">
+The exchange directory at <code>{{ exchange }}</code> does not exist and could
+not be created. The "release" and "collect" functionality will not be available.
+Please see the documentation on
+<a href="http://nbgrader.readthedocs.io/en/stable/user_guide/managing_assignment_files.html#setting-up-the-exchange">Setting Up The Exchange</a>
+for instructions.
+</div>
+{% elif not course_id %}
+<div class="alert alert-warning" id="warning-course-id">
+The course id has not been set in <code>nbgrader_config.py</code>. The "release"
+and "collect" functionality will not be available. Please see the documentation on
+<a href="http://nbgrader.readthedocs.io/en/stable/user_guide/managing_assignment_files.html#setting-up-the-exchange">Setting Up The Exchange</a>
+for instructions.
+</div>
+{% endif %}
 {%- endblock -%}
 
 {%- block table_header -%}


### PR DESCRIPTION
This will add warnings if the exchange isn't available. This can happen if any of the following are true:

* The OS is windows
* The exchange can't be created
* The course_id isn't set in nbgrader_config.py