### PR TITLE
Set nbgrader url prefix to be relative to notebook_dir

### DIFF
--- a/nbgrader/server_extensions/formgrader/formgrader.py
+++ b/nbgrader/server_extensions/formgrader/formgrader.py
@@ -33,7 +33,7 @@ class FormgradeExtension(NbGrader):
 
         # Configure the formgrader settings
         tornado_settings = dict(
-            nbgrader_url_prefix=os.path.relpath(self.coursedir.root),
+            nbgrader_url_prefix=os.path.relpath(self.coursedir.root, self.parent.notebook_dir),
             nbgrader_coursedir=self.coursedir,
             nbgrader_exporter=HTMLExporter(config=self.config),
             nbgrader_gradebook=None,


### PR DESCRIPTION
Fixes #855 

Ping @mpacer -- it was in fact this line causing the issue! I needed to change the url to be relative to the notebook directory, rather than the current directory (which defaults to the user's home directory).