### PR TITLE
Fix NbGraderAPI.timezone handling

### DIFF
--- a/nbgrader/apps/api.py
+++ b/nbgrader/apps/api.py
@@ -12,7 +12,7 @@ from ..coursedir import CourseDirectory
 from ..converters import Assign, Autograde
 from ..exchange import ExchangeList, ExchangeRelease, ExchangeCollect, ExchangeError
 from ..api import MissingEntry, Gradebook, Student, SubmittedAssignment
-from ..utils import parse_utc, temp_attrs, capture_log, as_timezone
+from ..utils import parse_utc, temp_attrs, capture_log, as_timezone, to_numeric_tz
 
 
 class NbGraderAPI(LoggingConfigurable):
@@ -306,7 +306,7 @@ class NbGraderAPI(LoggingConfigurable):
                 else:
                     assignment["display_duedate"] = None
                     assignment["duedate_notimezone"] = None
-                assignment["duedate_timezone"] = self.timezone
+                assignment["duedate_timezone"] = to_numeric_tz(self.timezone)
                 assignment["average_score"] = gb.average_assignment_score(assignment_id)
                 assignment["average_code_score"] = gb.average_assignment_code_score(assignment_id)
                 assignment["average_written_score"] = gb.average_assignment_written_score(assignment_id)
@@ -318,7 +318,7 @@ class NbGraderAPI(LoggingConfigurable):
                 "duedate": None,
                 "display_duedate": None,
                 "duedate_notimezone": None,
-                "duedate_timezone": self.timezone,
+                "duedate_timezone": to_numeric_tz(self.timezone),
                 "average_score": 0,
                 "average_code_score": 0,
                 "average_written_score": 0,

--- a/nbgrader/server_extensions/formgrader/static/js/manage_assignments.js
+++ b/nbgrader/server_extensions/formgrader/static/js/manage_assignments.js
@@ -52,7 +52,7 @@ var AssignmentUI = Backbone.View.extend({
 
         var timezone = $("<tr/>");
         body.append(timezone);
-        timezone.append($("<td/>").addClass("align-middle").text("Timezone (optional)"));
+        timezone.append($("<td/>").addClass("align-middle").text("Timezone as UTC offset (optional)"));
         timezone.append($("<td/>").append($("<input/>").addClass("modal-timezone").attr("type", "text")));
 
         var footer = $("<div/>");
@@ -430,7 +430,7 @@ var createAssignmentModal = function () {
 
     var timezone = $("<tr/>");
     body.append(timezone);
-    timezone.append($("<td/>").addClass("align-middle").text("Timezone (optional)"));
+    timezone.append($("<td/>").addClass("align-middle").text("Timezone as UTC offset (optional)"));
     timezone.append($("<td/>").append($("<input/>").addClass("timezone").attr("type", "text")));
 
     var footer = $("<div/>");

--- a/nbgrader/tests/apps/test_api.py
+++ b/nbgrader/tests/apps/test_api.py
@@ -134,7 +134,7 @@ class TestNbGraderAPI(BaseTestApp):
             "average_written_score": 0,
             "duedate": None,
             "display_duedate": None,
-            "duedate_timezone": "UTC",
+            "duedate_timezone": "+0000",
             "duedate_notimezone": None,
             "name": "ps1",
             "num_submissions": 0,

--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -15,6 +15,7 @@ from setuptools.archive_util import unpack_zipfile
 from contextlib import contextmanager
 from tornado.log import LogFormatter
 from dateutil.tz import gettz
+from datetime import datetime
 
 
 # pwd is for unix passwords only, so we shouldn't import it on
@@ -117,6 +118,11 @@ def parse_utc(ts):
     if ts.tzinfo is not None:
         ts = (ts - ts.utcoffset()).replace(tzinfo=None)
     return ts
+
+
+def to_numeric_tz(timezone):
+    """Converts a timezone to a format which can be read by parse_utc."""
+    return as_timezone(datetime.utcnow(), timezone).strftime('%z')
 
 
 def as_timezone(ts, timezone):


### PR DESCRIPTION
**Before this patch**

Currently, the user may specify, e.g.

```
c = get_config()
c.NbGraderAPI.timezone = 'America/Sao_Paulo' 
```

Then it would correctly convert all timestamps to `'America/Sao_Paulo'`. However, it would also be displayed in the formgrader when the user sets the assignment's due date:

![Timezone displayed in the formgrader before this patch](https://user-images.githubusercontent.com/262047/29498276-967fad22-85ce-11e7-8339-9592ccb40b68.png)

When the user sends this form, the timezone string is concatenated to the time and passed to `utils.parse_utc`, which cannot handle this string format.

**After this patch**

This patch converts `NbGraderAPI.timezone` to a format readable by `parse_utc` before displaying it to the user in the formgrader. This way the user does not need to change the default value presented in the Timezone field: it will just use the configured timezone out-of-the-box.

![Timezone displayed in the formgrader after this patch](https://user-images.githubusercontent.com/262047/29498306-61fc8074-85cf-11e7-8596-e4e39d588827.png)

**Note**

The `dateutil.tz.gettz` function does not support reading a timezone in the numeric format (e.g. `-0300` or `UTC-3`), therefore it is not possible to use the numeric format to configure `NbGraderAPI.timezone`.

In other words, this patch is the only way to get the timezones working correctly in the Web UI. It also takes into account that the timezone offset might change during the course due to daylight savings.