### PR TITLE
Fix issue with student dictionaries when assignments have zero points

### DIFF
--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -2318,7 +2318,8 @@ class Gradebook(object):
             A list of dictionaries, one per student
 
         """
-        if len(self.assignments) > 0:
+        total_score, = self.db.query(func.sum(Assignment.max_score)).one()
+        if len(self.assignments) > 0 and total_score > 0:
             # subquery the scores
             scores = self.db.query(
                 Student.id,
@@ -2332,7 +2333,7 @@ class Gradebook(object):
             students = self.db.query(
                 Student.id, Student.first_name, Student.last_name,
                 Student.email, _scores,
-                func.sum(GradeCell.max_score)
+                func.sum(Assignment.max_score)
             ).outerjoin(scores, Student.id == scores.c.id)\
              .group_by(
                  Student.id, Student.first_name, Student.last_name,

--- a/nbgrader/tests/api/test_gradebook.py
+++ b/nbgrader/tests/api/test_gradebook.py
@@ -728,6 +728,12 @@ def test_student_dicts(assignment):
     assert a == b
 
 
+def test_student_dicts_zero_points(gradebook):
+    gradebook.add_assignment("ps1")
+    s = gradebook.add_student("1234")
+    assert gradebook.student_dicts() == [s.to_dict()]
+
+
 def test_notebook_submission_dicts(assignment):
     assignment.add_student('hacker123')
     assignment.add_student('bitdiddle')


### PR DESCRIPTION
Fixes #857 

This fixes the issue with students not being displayed in the formgrader. The underlying issue was that `Gradebook.student_dicts()` was returning an empty list, even though the students did in fact exist in the database. This is a edgecase that only seems to occur when there are assignments in the database, but they have a combined zero points. A workaround for the issue is to make sure there is at least one assignment with nonzero points.

cc @jcsutherland