### PR TITLE
Add nbval for non-Windows tests/CI

### DIFF
--- a/dev-requirements-windows.txt
+++ b/dev-requirements-windows.txt
@@ -7,3 +7,4 @@ invoke
 sphinx
 codecov
 cov-core
+nbval

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,4 @@
 pyenchant
 sphinxcontrib-spelling
 sphinx_rtd_theme
+nbval

--- a/nbgrader/docs/source/user_guide/autograded/bitdiddle/ps1/problem1.ipynb
+++ b/nbgrader/docs/source/user_guide/autograded/bitdiddle/ps1/problem1.ipynb
@@ -123,7 +123,10 @@
      "points": 1.0,
      "schema_version": 1,
      "solution": false
-    }
+    },
+    "tags": [
+     "raises-exception"
+    ]
    },
    "outputs": [
     {
@@ -255,7 +258,10 @@
      "points": 0.5,
      "schema_version": 1,
      "solution": false
-    }
+    },
+    "tags": [
+     "raises-exception"
+    ]
    },
    "outputs": [
     {
@@ -359,7 +365,10 @@
      "points": 2.0,
      "schema_version": 1,
      "solution": true
-    }
+    },
+    "tags": [
+     "raises-exception"
+    ]
    },
    "outputs": [
     {

--- a/nbgrader/docs/source/user_guide/release/ps1/problem1.ipynb
+++ b/nbgrader/docs/source/user_guide/release/ps1/problem1.ipynb
@@ -91,7 +91,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
    "outputs": [],
    "source": [
     "squares(10)"
@@ -111,7 +115,10 @@
      "points": 1.0,
      "schema_version": 1,
      "solution": false
-    }
+    },
+    "tags": [
+     "raises-exception"
+    ]
    },
    "outputs": [],
    "source": [
@@ -136,7 +143,10 @@
      "points": 1.0,
      "schema_version": 1,
      "solution": false
-    }
+    },
+    "tags": [
+     "raises-exception"
+    ]
    },
    "outputs": [],
    "source": [
@@ -199,7 +209,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
    "outputs": [],
    "source": [
     "sum_of_squares(10)"
@@ -219,7 +233,10 @@
      "points": 0.5,
      "schema_version": 1,
      "solution": false
-    }
+    },
+    "tags": [
+     "raises-exception"
+    ]
    },
    "outputs": [],
    "source": [
@@ -244,7 +261,10 @@
      "points": 0.5,
      "schema_version": 1,
      "solution": false
-    }
+    },
+    "tags": [
+     "raises-exception"
+    ]
    },
    "outputs": [],
    "source": [
@@ -312,7 +332,10 @@
      "points": 2.0,
      "schema_version": 1,
      "solution": true
-    }
+    },
+    "tags": [
+     "raises-exception"
+    ]
    },
    "outputs": [],
    "source": [

--- a/nbgrader/docs/source/user_guide/submitted/bitdiddle/ps1/problem1.ipynb
+++ b/nbgrader/docs/source/user_guide/submitted/bitdiddle/ps1/problem1.ipynb
@@ -217,7 +217,10 @@
      "points": 0.5,
      "schema_version": 1,
      "solution": false
-    }
+    },
+    "tags": [
+     "raises-exception"
+    ]
    },
    "outputs": [],
    "source": [
@@ -311,7 +314,10 @@
      "points": 2.0,
      "schema_version": 1,
      "solution": true
-    }
+    },
+    "tags": [
+     "raises-exception"
+    ]
    },
    "outputs": [],
    "source": [

--- a/tasks.py
+++ b/tasks.py
@@ -39,6 +39,8 @@ except ImportError:
 
 @task
 def docs(ctx):
+    if not WINDOWS:
+        run(ctx, 'py.test --nbval-lax --current-env nbgrader/docs/source')
     run(ctx, 'python nbgrader/docs/source/build_docs.py')
     run(ctx, 'make -C nbgrader/docs html')
     run(ctx, 'make -C nbgrader/docs linkcheck')


### PR DESCRIPTION
Use nbval to test documentation notebooks. Tests are not run on Windows, as at least one example notebook requires a linux filesystem.

Part of sprints at EuroSciPy 2017.