### PR TITLE
Prevent assignments from being created with invalid names

### DIFF
--- a/nbgrader/coursedir.py
+++ b/nbgrader/coursedir.py
@@ -4,7 +4,7 @@ import re
 from textwrap import dedent
 
 from traitlets.config import LoggingConfigurable
-from traitlets import Unicode, List, default
+from traitlets import Unicode, List, default, validate, TraitError
 
 from .utils import full_split, parse_utc
 
@@ -41,6 +41,12 @@ class CourseDirectory(LoggingConfigurable):
             """
         )
     ).tag(config=True)
+
+    @validate('assignment_id')
+    def _validate_assignment_id(self, proposal):
+        if '+' in proposal['value']:
+            raise TraitError('Assignment names should not contain the following characters: +')
+        return proposal['value']
 
     notebook_id = Unicode(
         "*",

--- a/nbgrader/server_extensions/formgrader/static/js/manage_assignments.js
+++ b/nbgrader/server_extensions/formgrader/static/js/manage_assignments.js
@@ -395,7 +395,7 @@ var createAssignmentModal = function () {
             modal.modal('hide');
             return;
         }
-        if (name.includes("+")) {
+        if (name.indexOf("+") != -1) {
             var err = $("#create-error");
             err.text("Assignment names may not include the '+' character.");
             err.show();

--- a/nbgrader/server_extensions/formgrader/static/js/manage_assignments.js
+++ b/nbgrader/server_extensions/formgrader/static/js/manage_assignments.js
@@ -395,6 +395,15 @@ var createAssignmentModal = function () {
             modal.modal('hide');
             return;
         }
+        if (name.includes("+")) {
+            var err = $("#create-error");
+            err.text("Assignment names may not include the '+' character.");
+            err.show();
+            return;
+        } else {
+            var err = $("#create-error");
+            err.hide();
+        }
 
         var model = new Assignment({
             "name": name,
@@ -417,19 +426,22 @@ var createAssignmentModal = function () {
         modal.modal('hide');
     };
 
-    var body = $("<table/>").addClass("table table-striped form-table");
+    var body = $("<p/>")
+    body.append($("<p id='create-error' class='alert alert-danger' style='display: none'/>"));
+    var table = $("<table/>").addClass("table table-striped form-table");
+    body.append(table)
     var name = $("<tr/>");
-    body.append(name);
+    table.append(name);
     name.append($("<td/>").addClass("align-middle").text("Name"));
     name.append($("<td/>").append($("<input/>").addClass("name").attr("type", "text").attr("size", "31")));
 
     var duedate = $("<tr/>");
-    body.append(duedate);
+    table.append(duedate);
     duedate.append($("<td/>").addClass("align-middle").text("Due date (optional)"));
     duedate.append($("<td/>").append($("<input/>").addClass("duedate").attr("type", "datetime-local")));
 
     var timezone = $("<tr/>");
-    body.append(timezone);
+    table.append(timezone);
     timezone.append($("<td/>").addClass("align-middle").text("Timezone as UTC offset (optional)"));
     timezone.append($("<td/>").append($("<input/>").addClass("timezone").attr("type", "text")));
 

--- a/nbgrader/tests/apps/test_nbgrader_assign.py
+++ b/nbgrader/tests/apps/test_nbgrader_assign.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import pytest
+import traitlets
 
 from os.path import join
 from sqlalchemy.exc import InvalidRequestError
@@ -43,6 +44,13 @@ class TestNbGraderAssign(BaseTestApp):
             fh.write("""c.CourseDirectory.db_assignments = [dict(name="ps1")]\n""")
         run_nbgrader(["assign", "ps1"])
         assert os.path.isfile(join(course_dir, "release", "ps1", "foo.ipynb"))
+
+    def test_single_file_bad_assignment_name(self, course_dir, temp_cwd):
+        """Test that an error is thrown when the assignment name is invalid."""
+        self._empty_notebook(join(course_dir, 'source', 'foo+bar', 'foo.ipynb'))
+        with pytest.raises(traitlets.TraitError):
+            run_nbgrader(["assign", "foo+bar", "--create"])
+        assert not os.path.isfile(join(course_dir, "release", "foo+bar", "foo.ipynb"))
 
     def test_multiple_files(self, course_dir):
         """Can multiple files be assigned?"""

--- a/nbgrader/tests/nbextensions/test_formgrader.py
+++ b/nbgrader/tests/nbextensions/test_formgrader.py
@@ -825,13 +825,23 @@ def test_add_new_assignment(browser, port, gradebook):
     # set the name and dudedate
     elem = browser.find_element_by_css_selector("#add-assignment-modal .name")
     elem.click()
-    elem.send_keys("ps2")
+    elem.send_keys("ps2+a")
     elem = browser.find_element_by_css_selector("#add-assignment-modal .duedate")
     elem.click()
     elem.send_keys("2017-07-05T17:00")
     elem = browser.find_element_by_css_selector("#add-assignment-modal .timezone")
     elem.click()
     elem.send_keys("UTC")
+
+    # click save and wait for the error message to appear
+    utils._click_element(browser, "#add-assignment-modal .save")
+    WebDriverWait(browser, 10).until(EC.visibility_of_element_located((By.CSS_SELECTOR, "#create-error")))
+
+    # set a valid name
+    elem = browser.find_element_by_css_selector("#add-assignment-modal .name")
+    elem.clear()
+    elem.click()
+    elem.send_keys("ps2")
 
     # click save and wait for the modal to close
     utils._click_element(browser, "#add-assignment-modal .save")


### PR DESCRIPTION
This both checks that assignment ids do not contain '+' when validating the traitlet value for assignment_id, and also prevents assignments with '+' from being created in the formgrader interface.

Fixes #928