### PR TITLE
Switch from PhamtomJS to Firefox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ python:
   - 3.5
   - 3.6
 env:
+  global:
+    - MOZ_HEADLESS=1
   matrix:
     - GROUP=docs
     - GROUP=nbextensions
@@ -15,14 +17,15 @@ addons:
     packages:
     - pandoc
     - enchant
+  firefox: latest
 before_install:
   - pip install -U pip wheel setuptools
   - pip install invoke
 install:
-  - mkdir travis-phantomjs
-  - wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-14.04.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-14.04.tar.bz2
-  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-14.04.tar.bz2 -C $PWD/travis-phantomjs
-  - export PATH=$PWD/travis-phantomjs:$PATH
+  - wget https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-linux64.tar.gz
+  - mkdir geckodriver
+  - tar -xzf geckodriver-v0.19.1-linux64.tar.gz -C geckodriver
+  - export PATH=$PATH:$PWD/geckodriver
   - invoke install --group="$GROUP"
 script:
   - invoke tests --group="$GROUP"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,9 @@ before_install:
   - pip install -U pip wheel setuptools
   - pip install invoke
 install:
-  - wget https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-linux64.tar.gz
+  - wget https://github.com/mozilla/geckodriver/releases/download/v0.20.1/geckodriver-v0.20.1-linux64.tar.gz
   - mkdir geckodriver
-  - tar -xzf geckodriver-v0.19.1-linux64.tar.gz -C geckodriver
+  - tar -xzf geckodriver-v0.20.1-linux64.tar.gz -C geckodriver
   - export PATH=$PATH:$PWD/geckodriver
   - invoke install --group="$GROUP"
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,9 +46,6 @@ install:
 build: off
 
 test_script:
-  - cmd: npm install phantomjs-prebuilt
-  - cmd: set "PATH=%CD%\\node_modules\\phantomjs-prebuilt\\lib\\phantom\\bin;%PATH%"
-
   - cmd: invoke tests --group=python
   - cmd: invoke tests --group=nbextensions
 

--- a/nbgrader/docs/source/contributor_guide/installation_developer.rst
+++ b/nbgrader/docs/source/contributor_guide/installation_developer.rst
@@ -47,27 +47,6 @@ To work properly, the *assignment list* and *formgrader* extensions require
 both the nbextension and serverextension. The *create assignment* extension
 only has an nbextension part.
 
-Installing Phantomjs
---------------------
-To run tests while developing nbgrader and its documentation, Phantomjs must
-be installed.
-
-Install using npm
-~~~~~~~~~~~~~~~~~
-If you have npm installed, you can install phantomjs using::
-
-    npm install phantomjs
-
-Install using other package managers
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-If you do not have npm installed, you can still install phantomjs.
-
-On OS X::
-
-    brew update
-    brew install phantomjs
-
-On Linux::
-
-    apt-get update
-    apt-get install phantomjs
+Installing Firefox Headless WebDriver
+-------------------------------------
+To run tests while developing nbgrader and its documentation, the Firefox headless webdriver must be installed. Please `follow the Mozilla installation instructions <https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/WebDriver>`_ to get Firefox properly setup on your system.

--- a/nbgrader/server_extensions/formgrader/static/js/formgrade.js
+++ b/nbgrader/server_extensions/formgrader/static/js/formgrade.js
@@ -12,6 +12,8 @@ function FormGrader (base_url, submission_id) {
     this.comment_uis;
 
     this.keyboard_manager;
+
+    this.loaded = false;
 }
 
 FormGrader.prototype.init = function () {
@@ -71,6 +73,8 @@ FormGrader.prototype.init = function () {
         "keybinding": "control-shift-f",
         "help": "Flag the submission"
     });
+
+    this.loaded = true;
 };
 
 FormGrader.prototype.loadGrades = function () {

--- a/nbgrader/tests/nbextensions/conftest.py
+++ b/nbgrader/tests/nbextensions/conftest.py
@@ -176,12 +176,9 @@ def _make_browser(tempdir):
     selenium_logger = logging.getLogger('selenium.webdriver.remote.remote_connection')
     selenium_logger.setLevel(logging.WARNING)
 
-    capabilities = DesiredCapabilities.PHANTOMJS
-    capabilities['loggingPrefs'] = {'browser': 'ALL'}
-    browser = webdriver.PhantomJS(
-        service_args=['--cookies-file=/dev/null', '--proxy-type=none'],
-        desired_capabilities=capabilities,
-        service_log_path=os.path.devnull)
+    options = webdriver.firefox.options.Options()
+    options.add_argument('-headless')
+    browser = webdriver.Firefox(firefox_options=options)
     browser.set_page_load_timeout(30)
     browser.set_script_timeout(30)
 
@@ -189,13 +186,8 @@ def _make_browser(tempdir):
 
 
 def _close_browser(browser):
-    console_messages = browser.get_log('browser')
-    if len(console_messages) > 0:
-        print("\n<-- CAPTURED JAVASCRIPT CONSOLE MESSAGES -->")
-        for message in console_messages:
-            print(message)
-        print("<------------------------------------------>")
     browser.save_screenshot(os.path.join(os.path.dirname(__file__), 'selenium.screenshot.png'))
+    browser.close()
     browser.service.process.send_signal(signal.SIGTERM)
     browser.quit()
 

--- a/nbgrader/tests/nbextensions/conftest.py
+++ b/nbgrader/tests/nbextensions/conftest.py
@@ -10,7 +10,10 @@ import signal
 import glob
 
 from selenium import webdriver
-from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import NoAlertPresentException
 from textwrap import dedent
 
 from .. import copy_coverage_files, get_free_ports
@@ -187,6 +190,16 @@ def _make_browser(tempdir):
 
 def _close_browser(browser):
     browser.save_screenshot(os.path.join(os.path.dirname(__file__), 'selenium.screenshot.png'))
+    browser.get("about:blank")
+
+    try:
+        alert = browser.switch_to_alert()
+    except NoAlertPresentException:
+        pass
+    else:
+        print("Warning: dismissing unexpected alert ({})".format(alert.text))
+        alert.accept()
+
     browser.quit()
 
 

--- a/nbgrader/tests/nbextensions/conftest.py
+++ b/nbgrader/tests/nbextensions/conftest.py
@@ -187,8 +187,6 @@ def _make_browser(tempdir):
 
 def _close_browser(browser):
     browser.save_screenshot(os.path.join(os.path.dirname(__file__), 'selenium.screenshot.png'))
-    browser.close()
-    browser.service.process.send_signal(signal.SIGTERM)
     browser.quit()
 
 

--- a/nbgrader/tests/nbextensions/formgrade_utils.py
+++ b/nbgrader/tests/nbextensions/formgrade_utils.py
@@ -5,7 +5,7 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
-from selenium.common.exceptions import TimeoutException, NoSuchElementException
+from selenium.common.exceptions import TimeoutException, NoSuchElementException, NoAlertPresentException
 
 
 
@@ -85,6 +85,14 @@ def _get(browser, url, retries=5):
         else:
             print("Failed to load '{}', trying again...".format(url))
             _get(browser, url, retries=retries - 1)
+
+    try:
+        alert = browser.switch_to_alert()
+    except NoAlertPresentException:
+        pass
+    else:
+        print("Warning: dismissing unexpected alert ({})".format(alert.text))
+        alert.accept()
 
 
 def _load_gradebook_page(browser, port, url):

--- a/nbgrader/tests/nbextensions/formgrade_utils.py
+++ b/nbgrader/tests/nbextensions/formgrade_utils.py
@@ -22,7 +22,8 @@ def _tree_url(port, url=""):
 def _check_url(browser, port, url):
     if not url.startswith("http"):
         url = _formgrade_url(port, url)
-    assert unquote(browser.current_url).rstrip("/") == url
+    url_matches = lambda browser: unquote(browser.current_url).rstrip("/") == url
+    WebDriverWait(browser, 10).until(url_matches)
 
 
 def _check_breadcrumbs(browser, *breadcrumbs):
@@ -37,8 +38,12 @@ def _check_breadcrumbs(browser, *breadcrumbs):
 
 def _click_link(browser, link_text, partial=False):
     if partial:
+        WebDriverWait(browser, 10).until(
+            EC.presence_of_element_located((By.PARTIAL_LINK_TEXT, link_text)))
         element = browser.find_element_by_partial_link_text(link_text)
     else:
+        WebDriverWait(browser, 10).until(
+            EC.presence_of_element_located((By.LINK_TEXT, link_text)))
         element = browser.find_element_by_link_text(link_text)
     element.click()
 
@@ -60,6 +65,12 @@ def _wait_for_gradebook_page(browser, port, url):
         """return typeof models !== "undefined" && models !== undefined && models.loaded === true;""")
     WebDriverWait(browser, 10).until(page_loaded)
     _check_url(browser, port, url)
+
+
+def _switch_to_window(browser, index):
+    handle_exists = lambda browser: index < len(browser.window_handles)
+    WebDriverWait(browser, 10).until(handle_exists)
+    browser.switch_to_window(browser.window_handles[index])
 
 
 def _get(browser, url, retries=5):

--- a/nbgrader/tests/nbextensions/formgrade_utils.py
+++ b/nbgrader/tests/nbextensions/formgrade_utils.py
@@ -154,6 +154,7 @@ def _click_element(browser, name):
 
 
 def _send_keys_to_body(browser, *keys):
+    browser.execute_script("$('body').focus();")
     body = browser.find_element_by_tag_name("body")
     body.send_keys(*keys)
 

--- a/nbgrader/tests/nbextensions/formgrade_utils.py
+++ b/nbgrader/tests/nbextensions/formgrade_utils.py
@@ -1,3 +1,5 @@
+import os
+
 from six.moves.urllib.parse import urljoin, unquote
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
@@ -107,7 +109,7 @@ def _wait_for_formgrader(browser, port, url, retries=5):
             return false;
         }
 
-        if (!(typeof formgrader !== "undefined" && formgrader !== undefined)) {
+        if (!(typeof formgrader !== "undefined" && formgrader !== undefined && formgrader.loaded)) {
             return false;
         }
 
@@ -120,6 +122,14 @@ def _wait_for_formgrader(browser, port, url, retries=5):
         }
 
         if (!(typeof autosize !== "undefined" && autosize !== undefined)) {
+            return false;
+        }
+
+        if (!(typeof $ !== "undefined" && $ !== undefined)) {
+            return false;
+        }
+
+        if ($("body")[0] === undefined) {
             return false;
         }
 
@@ -216,3 +226,7 @@ def _child_exists(elem, selector):
         return False
     else:
         return True
+
+
+def _save_screenshot(browser):
+    browser.save_screenshot(os.path.join(os.path.dirname(__file__), "selenium.screenshot.png"))

--- a/nbgrader/tests/nbextensions/test_assignment_list.py
+++ b/nbgrader/tests/nbextensions/test_assignment_list.py
@@ -31,7 +31,7 @@ def nbserver(request, port, tempdir, jupyter_config_dir, jupyter_data_dir, excha
     return server
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def browser(request, tempdir, nbserver):
     browser = _make_browser(tempdir)
 
@@ -107,7 +107,7 @@ def _load_assignments_list(browser, port, retries=5):
 
 
 def _expand(browser, list_id, assignment):
-    browser.find_element_by_link_text(assignment).click()
+    browser.find_element_by_id("fetched_assignments_list").find_element_by_link_text(assignment).click()
     rows = browser.find_elements_by_css_selector("{} .list_item".format(list_id))
     for i in range(1, len(rows)):
         _wait(browser).until(lambda browser: browser.find_elements_by_css_selector("{} .list_item".format(list_id))[i].is_displayed())

--- a/nbgrader/tests/nbextensions/test_create_assignment.py
+++ b/nbgrader/tests/nbextensions/test_create_assignment.py
@@ -24,7 +24,7 @@ def nbserver(request, port, tempdir, jupyter_config_dir, jupyter_data_dir, excha
     return server
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def browser(request, tempdir, nbserver):
     browser = _make_browser(tempdir)
 

--- a/nbgrader/tests/nbextensions/test_create_assignment.py
+++ b/nbgrader/tests/nbextensions/test_create_assignment.py
@@ -64,6 +64,7 @@ def _load_notebook(browser, port, retries=5, name="blank"):
             """
             return (typeof Jupyter !== "undefined" &&
                     Jupyter.page !== undefined &&
+                    Jupyter.notebook !== undefined &&
                     $("#notebook_name").text() === "{}");
             """.format(name))
 

--- a/nbgrader/tests/nbextensions/test_create_assignment.py
+++ b/nbgrader/tests/nbextensions/test_create_assignment.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 from selenium.webdriver.common.by import By
@@ -216,6 +217,10 @@ def _dismiss_modal(browser):
             return True
         return False
     _wait(browser).until(modal_gone)
+
+
+def _save_screenshot(browser):
+    browser.save_screenshot(os.path.join(os.path.dirname(__file__), "selenium.screenshot.png"))
 
 
 @pytest.mark.nbextensions
@@ -482,7 +487,12 @@ def test_tabbing(browser, port):
 
     # click the id field
     element = browser.find_element_by_css_selector(".nbgrader-points-input")
+    # There is a bug where sometimes the click doesn't register, so we also press enter
+    # here which for some reason seems to help. It's not clear here what's happening
+    # to cause this bug but see https://github.com/mozilla/geckodriver/issues/322 for
+    # reference. It only seemed to be a problem on Linux, not Mac or Windows.
     element.click()
+    element.send_keys(Keys.RETURN)
     _wait(browser).until(active_element_is("nbgrader-points-input"))
 
     # press tab and check that the active element is correct
@@ -495,6 +505,7 @@ def test_tabbing(browser, port):
     # click the id field
     element = browser.find_element_by_css_selector(".nbgrader-points-input")
     element.click()
+    element.send_keys(Keys.RETURN)
     _wait(browser).until(active_element_is("nbgrader-points-input"))
 
     # press tab and check that the active element is correct

--- a/nbgrader/tests/nbextensions/test_formgrader.py
+++ b/nbgrader/tests/nbextensions/test_formgrader.py
@@ -353,6 +353,7 @@ def test_load_live_notebook(browser, port, gradebook):
                     port, "autograded/{}/Problem Set 1/{}.ipynb".format(submission.student.id, problem.name)))
             browser.close()
             utils._switch_to_window(browser, 0)
+            utils._wait_for_formgrader(browser, port, "submissions/{}/?index=0".format(submission.id))
 
 
 @pytest.mark.nbextensions

--- a/nbgrader/tests/nbextensions/test_formgrader.py
+++ b/nbgrader/tests/nbextensions/test_formgrader.py
@@ -36,7 +36,10 @@ def nbserver(request, port, tempdir, jupyter_config_dir, jupyter_data_dir, excha
     return server
 
 
-@pytest.fixture(scope="module")
+# Firefox does not seem to release memory, and so will easily eat up
+# almost 1GB if we do not close the browser after each test :-/
+# This causes tests to time out on travis.
+@pytest.fixture(scope="function")
 def browser(request, tempdir, nbserver):
     browser = _make_browser(tempdir)
 

--- a/nbgrader/tests/nbextensions/test_formgrader.py
+++ b/nbgrader/tests/nbextensions/test_formgrader.py
@@ -2,7 +2,9 @@ import pytest
 import os
 import shutil
 import sys
+import time
 import glob
+import itertools
 
 from os.path import join
 
@@ -335,25 +337,27 @@ def test_formgrade_view_breadcrumbs(browser, port, gradebook):
 
 
 @pytest.mark.nbextensions
-def test_load_live_notebook(browser, port, gradebook):
-    for problem in gradebook.find_assignment("Problem Set 1").notebooks:
-        submissions = problem.submissions
-        submissions.sort(key=lambda x: x.id)
+@pytest.mark.parametrize("iproblem,isubmission", itertools.product(range(2), range(2)))
+def test_load_live_notebook(browser, port, gradebook, iproblem, isubmission):
+    problem = gradebook.find_assignment("Problem Set 1").notebooks[iproblem]
+    submissions = problem.submissions
+    submissions.sort(key=lambda x: x.id)
+    submission = submissions[isubmission]
 
-        for i, submission in enumerate(submissions):
-            utils._get(browser, utils._formgrade_url(port, "submissions/{}".format(submission.id)))
-            utils._wait_for_formgrader(browser, port, "submissions/{}/?index=0".format(submission.id))
+    utils._get(browser, utils._formgrade_url(port, "submissions/{}".format(submission.id)))
+    utils._wait_for_formgrader(browser, port, "submissions/{}/?index=0".format(submission.id))
 
-            # check the live notebook link
-            utils._click_link(browser, "Submission #{}".format(i + 1))
-            utils._switch_to_window(browser, 1)
-            utils._wait_for_notebook_page(
-                browser, port,
-                utils._notebook_url(
-                    port, "autograded/{}/Problem Set 1/{}.ipynb".format(submission.student.id, problem.name)))
-            browser.close()
-            utils._switch_to_window(browser, 0)
-            utils._wait_for_formgrader(browser, port, "submissions/{}/?index=0".format(submission.id))
+    # check the live notebook link
+    utils._click_link(browser, "Submission #{}".format(isubmission + 1))
+    utils._switch_to_window(browser, 1)
+    utils._wait_for_notebook_page(
+        browser, port,
+        utils._notebook_url(
+            port, "autograded/{}/Problem Set 1/{}.ipynb".format(submission.student.id, problem.name)))
+
+    utils._get(browser, utils._formgrade_url(port, "submissions/{}".format(submission.id)))
+    browser.close()
+    utils._switch_to_window(browser, 0)
 
 
 @pytest.mark.nbextensions
@@ -400,10 +404,12 @@ def test_next_prev_assignments(browser, port, gradebook):
         utils._wait_for_formgrader(browser, port, "submissions/{}/?index=0".format(submissions[0].id))
 
         # Move to the next submission
+        time.sleep(0.5)
         next_function()
         utils._wait_for_formgrader(browser, port, "submissions/{}/?index=0".format(submissions[1].id))
 
         # Move to the next submission (should return to notebook list)
+        time.sleep(0.5)
         next_function()
         utils._wait_for_gradebook_page(browser, port, "gradebook/Problem Set 1/Problem 1")
 
@@ -412,10 +418,12 @@ def test_next_prev_assignments(browser, port, gradebook):
         utils._wait_for_formgrader(browser, port, "submissions/{}/?index=0".format(submissions[1].id))
 
         # Move to the previous submission
+        time.sleep(0.5)
         prev_function()
         utils._wait_for_formgrader(browser, port, "submissions/{}/?index=0".format(submissions[0].id))
 
         # Move to the previous submission (should return to the notebook list)
+        time.sleep(0.5)
         prev_function()
         utils._wait_for_gradebook_page(browser, port, "gradebook/Problem Set 1/Problem 1")
 
@@ -440,6 +448,7 @@ def test_next_prev_failed_assignments(browser, port, gradebook):
 
     if submissions[0].failed_tests:
         # Go to the next failed submission (should return to the notebook list)
+        time.sleep(0.5)
         utils._send_keys_to_body(browser, Keys.CONTROL, Keys.SHIFT, ".")
         utils._wait_for_gradebook_page(browser, port, "gradebook/Problem Set 1/Problem 1")
 
@@ -448,6 +457,7 @@ def test_next_prev_failed_assignments(browser, port, gradebook):
         utils._wait_for_formgrader(browser, port, "submissions/{}/?index=0".format(submissions[0].id))
 
         # Go to the previous failed submission (should return to the notebook list)
+        time.sleep(0.5)
         utils._send_keys_to_body(browser, Keys.CONTROL, Keys.SHIFT, ",")
         utils._wait_for_gradebook_page(browser, port, "gradebook/Problem Set 1/Problem 1")
 
@@ -456,10 +466,12 @@ def test_next_prev_failed_assignments(browser, port, gradebook):
         utils._wait_for_formgrader(browser, port, "submissions/{}/?index=0".format(submissions[0].id))
 
         # Go to the other notebook
+        time.sleep(0.5)
         utils._send_keys_to_body(browser, Keys.CONTROL, ".")
         utils._wait_for_formgrader(browser, port, "submissions/{}/?index=0".format(submissions[1].id))
 
         # Go to the next failed submission (should return to the notebook list)
+        time.sleep(0.5)
         utils._send_keys_to_body(browser, Keys.CONTROL, Keys.SHIFT, ".")
         utils._wait_for_gradebook_page(browser, port, "gradebook/Problem Set 1/Problem 1")
 
@@ -468,11 +480,13 @@ def test_next_prev_failed_assignments(browser, port, gradebook):
         utils._wait_for_formgrader(browser, port, "submissions/{}/?index=0".format(submissions[1].id))
 
         # Go to the previous failed submission
+        time.sleep(0.5)
         utils._send_keys_to_body(browser, Keys.CONTROL, Keys.SHIFT, ",")
         utils._wait_for_formgrader(browser, port, "submissions/{}/?index=0".format(submissions[0].id))
 
     else:
         # Go to the next failed submission
+        time.sleep(0.5)
         utils._send_keys_to_body(browser, Keys.CONTROL, Keys.SHIFT, ".")
         utils._wait_for_formgrader(browser, port, "submissions/{}/?index=0".format(submissions[1].id))
 
@@ -481,6 +495,7 @@ def test_next_prev_failed_assignments(browser, port, gradebook):
         utils._wait_for_formgrader(browser, port, "submissions/{}/?index=0".format(submissions[0].id))
 
         # Go to the previous failed submission (should return to the notebook list)
+        time.sleep(0.5)
         utils._send_keys_to_body(browser, Keys.CONTROL, Keys.SHIFT, ",")
         utils._wait_for_gradebook_page(browser, port, "gradebook/Problem Set 1/Problem 1")
 
@@ -489,10 +504,12 @@ def test_next_prev_failed_assignments(browser, port, gradebook):
         utils._wait_for_formgrader(browser, port, "submissions/{}/?index=0".format(submissions[0].id))
 
         # Go to the other notebook
+        time.sleep(0.5)
         utils._send_keys_to_body(browser, Keys.CONTROL, ".")
         utils._wait_for_formgrader(browser, port, "submissions/{}/?index=0".format(submissions[1].id))
 
         # Go to the next failed submission (should return to the notebook list)
+        time.sleep(0.5)
         utils._send_keys_to_body(browser, Keys.CONTROL, Keys.SHIFT, ".")
         utils._wait_for_gradebook_page(browser, port, "gradebook/Problem Set 1/Problem 1")
 

--- a/nbgrader/tests/nbextensions/test_validate_assignment.py
+++ b/nbgrader/tests/nbextensions/test_validate_assignment.py
@@ -36,7 +36,7 @@ def _wait(browser):
 
 def _load_notebook(browser, port, notebook, retries=5):
     # go to the correct page
-    url = "http://localhost:{}/notebooks/{}".format(port, notebook)
+    url = "http://localhost:{}/notebooks/{}.ipynb".format(port, notebook)
     browser.get(url)
 
     alert = ''
@@ -49,14 +49,16 @@ def _load_notebook(browser, port, notebook, retries=5):
         except NoAlertPresentException:
             alert = None
         else:
-            alert.dismiss()
-            browser.get(url)
-
-    assert browser.current_url == url
+            print("Warning: dismissing unexpected alert ({})".format(alert.text))
+            alert.accept()
 
     def page_loaded(browser):
         return browser.execute_script(
-            'return typeof Jupyter !== "undefined" && Jupyter.page !== undefined;')
+            """
+            return (typeof Jupyter !== "undefined" &&
+                    Jupyter.page !== undefined &&
+                    $("#notebook_name").text() === "{}");
+            """.format(notebook))
 
     # wait for the page to load
     try:
@@ -65,14 +67,20 @@ def _load_notebook(browser, port, notebook, retries=5):
         if retries > 0:
             print("Retrying page load...")
             # page timeout, but sometimes this happens, so try refreshing?
-            _load_notebook(browser, port, retries=retries - 1)
+            _load_notebook(browser, port, retries=retries - 1, notebook=notebook)
         else:
             print("Failed to load the page too many times")
             raise
 
 
 def _wait_for_validate_button(browser):
-    _wait(browser).until(EC.presence_of_all_elements_located((By.CSS_SELECTOR, "button.validate")))
+    def validate_exists(browser):
+        try:
+            browser.find_element_by_css_selector("button.validate")
+        except NoSuchElementException:
+            return False
+        return True
+    _wait(browser).until(validate_exists)
 
 
 def _wait_for_modal(browser):
@@ -94,7 +102,7 @@ def _dismiss_modal(browser):
 
 @pytest.mark.nbextensions
 def test_validate_ok(browser, port):
-    _load_notebook(browser, port, "submitted-changed.ipynb")
+    _load_notebook(browser, port, "submitted-changed")
     _wait_for_validate_button(browser)
 
     # click the "validate" button
@@ -112,7 +120,7 @@ def test_validate_ok(browser, port):
 
 @pytest.mark.nbextensions
 def test_validate_failure(browser, port):
-    _load_notebook(browser, port, "submitted-unchanged.ipynb")
+    _load_notebook(browser, port, "submitted-unchanged")
     _wait_for_validate_button(browser)
 
     # click the "validate" button
@@ -130,7 +138,7 @@ def test_validate_failure(browser, port):
 
 @pytest.mark.nbextensions
 def test_validate_grade_cell_changed(browser, port):
-    _load_notebook(browser, port, "submitted-grade-cell-changed.ipynb")
+    _load_notebook(browser, port, "submitted-grade-cell-changed")
     _wait_for_validate_button(browser)
 
     # click the "validate" button
@@ -148,7 +156,7 @@ def test_validate_grade_cell_changed(browser, port):
 
 @pytest.mark.nbextensions
 def test_validate_locked_cell_changed(browser, port):
-    _load_notebook(browser, port, "submitted-locked-cell-changed.ipynb")
+    _load_notebook(browser, port, "submitted-locked-cell-changed")
     _wait_for_validate_button(browser)
 
     # click the "validate" button
@@ -166,7 +174,7 @@ def test_validate_locked_cell_changed(browser, port):
 
 @pytest.mark.nbextensions
 def test_validate_open_relative_file(browser, port):
-    _load_notebook(browser, port, "open_relative_file.ipynb")
+    _load_notebook(browser, port, "open_relative_file")
     _wait_for_validate_button(browser)
 
     # click the "validate" button
@@ -184,7 +192,7 @@ def test_validate_open_relative_file(browser, port):
 
 @pytest.mark.nbextensions
 def test_validate_grade_cell_type_changed(browser, port):
-    _load_notebook(browser, port, "submitted-grade-cell-type-changed.ipynb")
+    _load_notebook(browser, port, "submitted-grade-cell-type-changed")
     _wait_for_validate_button(browser)
 
     # click the "validate" button
@@ -202,7 +210,7 @@ def test_validate_grade_cell_type_changed(browser, port):
 
 @pytest.mark.nbextensions
 def test_validate_answer_cell_type_changed(browser, port):
-    _load_notebook(browser, port, "submitted-answer-cell-type-changed.ipynb")
+    _load_notebook(browser, port, "submitted-answer-cell-type-changed")
     _wait_for_validate_button(browser)
 
     # click the "validate" button
@@ -216,3 +224,15 @@ def test_validate_answer_cell_type_changed(browser, port):
 
     # close the modal dialog
     _dismiss_modal(browser)
+
+
+################################################################################
+####### DO NOT ADD TESTS BELOW THIS LINE #######################################
+################################################################################
+
+@pytest.mark.nbextensions
+def test_final(browser, port):
+    """This is a final test to be run so that the browser doesn't hang, see
+    https://github.com/mozilla/geckodriver/issues/1151
+    """
+    _load_notebook(browser, port, "blank")

--- a/nbgrader/tests/nbextensions/test_validate_assignment.py
+++ b/nbgrader/tests/nbextensions/test_validate_assignment.py
@@ -57,6 +57,7 @@ def _load_notebook(browser, port, notebook, retries=5):
             """
             return (typeof Jupyter !== "undefined" &&
                     Jupyter.page !== undefined &&
+                    Jupyter.notebook !== undefined &&
                     $("#notebook_name").text() === "{}");
             """.format(notebook))
 


### PR DESCRIPTION
Fixes #935

Note that unfortunately, the Firefox webdriver does not support capturing logs from javascript. This is annoying, but not a dealbreaker.

In making this change I uncovered a bunch of race conditions in the javascript tests, which is good I guess!