### PR TITLE
Remove underscores from task names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,4 @@ install:
 script:
   - invoke tests --group="$GROUP"
 after_success:
-  - invoke after_success --group="$GROUP"
+  - invoke aftersuccess --group="$GROUP"

--- a/tasks.py
+++ b/tasks.py
@@ -48,7 +48,7 @@ def docs(ctx):
 
 
 @task
-def clean_docs(ctx):
+def cleandocs(ctx):
     run(ctx, 'python nbgrader/docs/source/clear_docs.py')
 
 
@@ -123,7 +123,7 @@ def tests(ctx, group='all', skip=None, junitxml=None):
 
 
 @task
-def after_success(ctx, group):
+def aftersuccess(ctx, group):
     if group in ('python', 'nbextensions'):
         run(ctx, 'codecov')
     else:
@@ -152,8 +152,8 @@ def install(ctx, group):
 
 
 ns = collection.Collection(
-    after_success,
-    clean_docs,
+    aftersuccess,
+    cleandocs,
     docs,
     install,
     js,


### PR DESCRIPTION
Apparently something changed with invoke so that it no longer recognizes tasks with underscores in their names.