### PR TITLE
[WIP] Splitting of autograde in view of security issue

### DIFF
--- a/nbgrader/apps/autogradeapp.py
+++ b/nbgrader/apps/autogradeapp.py
@@ -34,6 +34,39 @@ flags.update({
         {'BaseConverter': {'force': True}},
         "Overwrite an assignment/submission if it already exists."
     ),
+    'only-sanitize': (
+        {
+            'Execute': {'enabled': False},
+            'LimitOutput': {'enabled': False},
+            'SaveAutoGrades': {'enabled': False},
+            'AssignLatePenalties': {'enabled': False},
+        },
+        "Only apply sanitizing preprocessors."
+    ),
+    'only-execute': (
+        {
+            'ClearOutput': {'enabled': False},
+            'DeduplicateIds': {'enabled': False},
+            'OverwriteKernelspec': {'enabled': False},
+            'OverwriteCells': {'enabled': False},
+            'CheckCellMetadata': {'enabled': False},
+            'LimitOutput': {'enabled': False},
+            'SaveAutoGrades': {'enabled': False},
+            'AssignLatePenalties': {'enabled': False},
+            'CheckCellMetadata': {'enabled': False}
+        },
+        "Only perform execution of notebooks."
+    ),
+    'only-record': (
+        {
+            'ClearOutput': {'enabled': False},
+            'DeduplicateIds': {'enabled': False},
+            'OverwriteKernelspec': {'enabled': False},
+            'OverwriteCells': {'enabled': False},
+            'Execute': {'enabled': False},
+        },
+        "Only record grades."
+    ),
 })
 
 


### PR DESCRIPTION
This PR is a very first attempt to split the autograde process in view of the discussion in #483. It implements the three options `--only-sanitize`, `--only-execute` (which should eventually be run in isolation), and `--only-record`. The last two steps need to be run together with the `--force` option. Running
- `nbgrader autograde --only-sanitize ps1`
- `nbgrader autograde --only-execute --force ps1`
- `nbgrader autograde --only-record --force ps1`
for the example problem set `ps1` correctly recorded the grades in the database. However, I am worried that the use of `--force` could have side effects which I have not detected so far.

Note: This PR is only meant for discussion purposes and to decide whether the solution suggested here is worth being pursued or whether the use of subcommands is a better choice. Thus, this PR is not intended to be merged.