### PR TITLE
Use mathjax macro for formgrader

### DIFF
--- a/nbgrader/server_extensions/formgrader/templates/formgrade.tpl
+++ b/nbgrader/server_extensions/formgrader/templates/formgrade.tpl
@@ -15,7 +15,7 @@
 {% endfor %}
 
 <!-- Loading mathjax macro -->
-{{ mathjax() }}
+{{ mathjax( resources.base_url + '/' + resources.mathjax_url + '?config=TeX-AMS-MML_HTMLorMML-full') }}
 
 <link rel="stylesheet" href="{{ resources.base_url }}/formgrader/static/css/formgrade.css" />
 

--- a/nbgrader/server_extensions/formgrader/templates/formgrade.tpl
+++ b/nbgrader/server_extensions/formgrader/templates/formgrade.tpl
@@ -1,5 +1,6 @@
 {%- extends 'basic.tpl' -%}
 {% from 'formgrade_macros.tpl' import nav, header %}
+{% from 'mathjax.tpl' import mathjax %}
 
 {%- block header -%}
 <!DOCTYPE html>
@@ -13,26 +14,8 @@
     </style>
 {% endfor %}
 
-<!-- MathJax -->
-<script type="text/javascript">
-window.MathJax = {
-    tex2jax: {
-        inlineMath: [ ['$','$'], ["\\(","\\)"] ],
-        displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
-        processEscapes: true,
-        processEnvironments: true
-    },
-    // Center justify equations in code and markdown cells. Elsewhere
-    // we use CSS to left justify single line equations in code cells.
-    displayAlign: 'center',
-    "HTML-CSS": {
-        styles: {'.MathJax_Display': {"margin": 0}},
-        linebreaks: { automatic: true }
-    }
-};
-</script>
-
-<script type="text/javascript" src="{{ resources.base_url }}/{{ resources.mathjax_url }}?config=TeX-AMS-MML_HTMLorMML-full"></script>
+<!-- Loading mathjax macro -->
+{{ mathjax() }}
 
 <link rel="stylesheet" href="{{ resources.base_url }}/formgrader/static/css/formgrade.css" />
 


### PR DESCRIPTION
Currently, LaTeX oversets are rendered weird in the [formgrader](https://homepages.upb.de/jbobolz/nbgraderRenderExample/badRender.html) (i.e. while grading a submission), to the point where some submissions become unreadable. 
In the notebook and the [feedback](https://homepages.upb.de/jbobolz/nbgraderRenderExample/feedback.html), everything is rendered fine.
An example notebook to reproduce the problem can be found [here](https://homepages.upb.de/jbobolz/nbgraderRenderExample/formattest.ipynb)

This pull request changes the way mathjax is included on formgrader pages to be consistent with the include on the feedback page (where everything works fine). It also makes sense to me that the formatting should be the same for the formgrader and the feedback.

I have this change running productively for some time now and it seems to work fine. However, I am not familiar with nbgrader's development, so no guarantees that this is not a stupid fix.

edit: as it turns out this was not the fix for my rendering problem. The pull request now provides a minor code quality improvement, I guess :)