### PR TITLE
Allow instructors to share files via shared group id

### DIFF
--- a/nbgrader/converters/base.py
+++ b/nbgrader/converters/base.py
@@ -264,7 +264,8 @@ class BaseConverter(LoggingConfigurable):
             if self.groupshared and os.stat(dirname).st_uid == os.getuid():
                 #for subdirname in subdirnames:
                 #    subdirname = os.path.join(dirname, subdirname)
-                os.chmod(dirname, (os.stat(dirname).st_mode|0o2770) & 0o2777)
+                try:   os.chmod(dirname, (os.stat(dirname).st_mode|0o2770) & 0o2777)
+                except PermissionError: pass
         # If groupshared, set write permissions on directories.  Directories
         # are created within ipython_genutils.path.ensure_dir_exists via
         # nbconvert.writer, (unless there are supplementary files) with a
@@ -273,9 +274,10 @@ class BaseConverter(LoggingConfigurable):
         if self.groupshared:
             # Root may be created in this step, and is not included above.
             rootdir = self.coursedir.format_path(self._output_directory, '.', '.')
-            if os.stat(rootdir).st_uid == os.getuid():
-                # Add 2770 to existing dir permissions (don't unconditionally override)
-                os.chmod(rootdir, (os.stat(rootdir).st_mode|0o2770) & 0o2777)
+            # Add 2770 to existing dir permissions (don't unconditionally override)
+            try:   os.chmod(rootdir, (os.stat(rootdir).st_mode|0o2770) & 0o2777)
+            except PermissionError: pass
+
 
     def convert_single_notebook(self, notebook_filename):
         """Convert a single notebook.

--- a/nbgrader/converters/base.py
+++ b/nbgrader/converters/base.py
@@ -264,8 +264,10 @@ class BaseConverter(LoggingConfigurable):
             if self.groupshared and os.stat(dirname).st_uid == os.getuid():
                 #for subdirname in subdirnames:
                 #    subdirname = os.path.join(dirname, subdirname)
-                try:   os.chmod(dirname, (os.stat(dirname).st_mode|0o2770) & 0o2777)
-                except PermissionError: pass
+                try:
+                    os.chmod(dirname, (os.stat(dirname).st_mode|0o2770) & 0o2777)
+                except PermissionError:
+                    pass
         # If groupshared, set write permissions on directories.  Directories
         # are created within ipython_genutils.path.ensure_dir_exists via
         # nbconvert.writer, (unless there are supplementary files) with a
@@ -275,8 +277,10 @@ class BaseConverter(LoggingConfigurable):
             # Root may be created in this step, and is not included above.
             rootdir = self.coursedir.format_path(self._output_directory, '.', '.')
             # Add 2770 to existing dir permissions (don't unconditionally override)
-            try:   os.chmod(rootdir, (os.stat(rootdir).st_mode|0o2770) & 0o2777)
-            except PermissionError: pass
+            try:
+                os.chmod(rootdir, (os.stat(rootdir).st_mode|0o2770) & 0o2777)
+            except PermissionError:
+                pass
 
 
     def convert_single_notebook(self, notebook_filename):

--- a/nbgrader/converters/base.py
+++ b/nbgrader/converters/base.py
@@ -44,20 +44,9 @@ class BaseConverter(LoggingConfigurable):
         )
     ).tag(config=True)
 
-    groupshared = Bool(
-        False,
-        help=dedent(
-            """
-            Be less strict about user permissions (instructor files are by
-            default group writeable.  Requires that admins ensure that primary
-            groups are correct!
-            """
-        )
-    ).tag(config=True)
-
     @default("permissions")
     def _permissions_default(self):
-        return 664 if self.groupshared else 444
+        return 664 if self.coursedir.groupshared else 444
 
     coursedir = Instance(CourseDirectory, allow_none=True)
 
@@ -261,7 +250,7 @@ class BaseConverter(LoggingConfigurable):
             for filename in filenames:
                 os.chmod(os.path.join(dirname, filename), permissions)
             # If groupshared, set dir permissions - see comment below.
-            if self.groupshared and os.stat(dirname).st_uid == os.getuid():
+            if self.coursedir.groupshared and os.stat(dirname).st_uid == os.getuid():
                 #for subdirname in subdirnames:
                 #    subdirname = os.path.join(dirname, subdirname)
                 try:
@@ -273,7 +262,7 @@ class BaseConverter(LoggingConfigurable):
         # nbconvert.writer, (unless there are supplementary files) with a
         # default mode of 755 and there is no way to pass the mode arguments
         # all the way to there!  So we have to walk and fix.
-        if self.groupshared:
+        if self.coursedir.groupshared:
             # Root may be created in this step, and is not included above.
             rootdir = self.coursedir.format_path(self._output_directory, '.', '.')
             # Add 2770 to existing dir permissions (don't unconditionally override)

--- a/nbgrader/converters/base.py
+++ b/nbgrader/converters/base.py
@@ -44,6 +44,17 @@ class BaseConverter(LoggingConfigurable):
         )
     ).tag(config=True)
 
+    groupshared = Bool(
+        False,
+        help=dedent(
+            """
+            Be less strict about user permissions (instructor files are by
+            default group writeable.  Requires that admins ensure that primary
+            groups are correct!
+            """
+        )
+    ).tag(config=True)
+
     @default("permissions")
     def _permissions_default(self):
         return 444

--- a/nbgrader/converters/base.py
+++ b/nbgrader/converters/base.py
@@ -264,7 +264,7 @@ class BaseConverter(LoggingConfigurable):
             if self.groupshared and os.stat(dirname).st_uid == os.getuid():
                 #for subdirname in subdirnames:
                 #    subdirname = os.path.join(dirname, subdirname)
-                os.chmod(dirname, (os.stat(dirname).st_mode|0o770) & 0o777)
+                os.chmod(dirname, (os.stat(dirname).st_mode|0o2770) & 0o2777)
         # If groupshared, set write permissions on directories.  Directories
         # are created within ipython_genutils.path.ensure_dir_exists via
         # nbconvert.writer, (unless there are supplementary files) with a
@@ -274,8 +274,8 @@ class BaseConverter(LoggingConfigurable):
             # Root may be created in this step, and is not included above.
             rootdir = self.coursedir.format_path(self._output_directory, '.', '.')
             if os.stat(rootdir).st_uid == os.getuid():
-                # Add 770 to existing dir permissions (don't unconditionally override)
-                os.chmod(rootdir, (os.stat(rootdir).st_mode|0o770) & 0o777)
+                # Add 2770 to existing dir permissions (don't unconditionally override)
+                os.chmod(rootdir, (os.stat(rootdir).st_mode|0o2770) & 0o2777)
 
     def convert_single_notebook(self, notebook_filename):
         """Convert a single notebook.

--- a/nbgrader/converters/base.py
+++ b/nbgrader/converters/base.py
@@ -57,7 +57,7 @@ class BaseConverter(LoggingConfigurable):
 
     @default("permissions")
     def _permissions_default(self):
-        return 444
+        return 664 if self.groupshared else 444
 
     coursedir = Instance(CourseDirectory, allow_none=True)
 

--- a/nbgrader/converters/base.py
+++ b/nbgrader/converters/base.py
@@ -251,8 +251,6 @@ class BaseConverter(LoggingConfigurable):
                 os.chmod(os.path.join(dirname, filename), permissions)
             # If groupshared, set dir permissions - see comment below.
             if self.coursedir.groupshared and os.stat(dirname).st_uid == os.getuid():
-                #for subdirname in subdirnames:
-                #    subdirname = os.path.join(dirname, subdirname)
                 try:
                     os.chmod(dirname, (os.stat(dirname).st_mode|0o2770) & 0o2777)
                 except PermissionError:

--- a/nbgrader/converters/generate_assignment.py
+++ b/nbgrader/converters/generate_assignment.py
@@ -42,7 +42,7 @@ class GenerateAssignment(BaseConverter):
 
     @default("permissions")
     def _permissions_default(self):
-        return 644
+        return 664 if self.groupshared else 644
 
     @property
     def _input_directory(self):

--- a/nbgrader/converters/generate_assignment.py
+++ b/nbgrader/converters/generate_assignment.py
@@ -42,7 +42,7 @@ class GenerateAssignment(BaseConverter):
 
     @default("permissions")
     def _permissions_default(self):
-        return 664 if self.groupshared else 644
+        return 664 if self.coursedir.groupshared else 644
 
     @property
     def _input_directory(self):

--- a/nbgrader/converters/generate_feedback.py
+++ b/nbgrader/converters/generate_feedback.py
@@ -36,7 +36,7 @@ class GenerateFeedback(BaseConverter):
 
     @default("permissions")
     def _permissions_default(self):
-        return 644
+        return 664 if self.coursedir.groupshared else 644
 
     def _load_config(self, cfg, **kwargs):
         if 'Feedback' in cfg:

--- a/nbgrader/coursedir.py
+++ b/nbgrader/coursedir.py
@@ -227,7 +227,9 @@ class CourseDirectory(LoggingConfigurable):
             and exchange directories group readable/writeable (g+rws, default
             g=nothing only ) by default.  This should only be used if you
             carefully set the primary groups of your notebook servers and fully
-            understand the unix permission model.
+            understand the unix permission model.  This changes the default
+            permissions from 444 (unwriteable) to 664 (writeable), so that
+            other instructors are able to delete/overwrite files.
             """
         )
     ).tag(config=True)

--- a/nbgrader/coursedir.py
+++ b/nbgrader/coursedir.py
@@ -4,7 +4,7 @@ import re
 from textwrap import dedent
 
 from traitlets.config import LoggingConfigurable
-from traitlets import Integer, Unicode, List, default, validate, TraitError
+from traitlets import Integer, Bool, Unicode, List, default, validate, TraitError
 
 from .utils import full_split, parse_utc
 
@@ -215,6 +215,17 @@ class CourseDirectory(LoggingConfigurable):
             The root directory for the course files (that includes the `source`,
             `release`, `submitted`, `autograded`, etc. directories). Defaults to
             the current working directory.
+            """
+        )
+    ).tag(config=True)
+
+    groupshared = Bool(
+        False,
+        help=dedent(
+            """
+            Be less strict about user permissions (instructor files are by
+            default group writeable.  Requires that admins ensure that primary
+            groups are correct!
             """
         )
     ).tag(config=True)

--- a/nbgrader/coursedir.py
+++ b/nbgrader/coursedir.py
@@ -223,9 +223,11 @@ class CourseDirectory(LoggingConfigurable):
         False,
         help=dedent(
             """
-            Be less strict about user permissions (instructor files are by
-            default group writeable.  Requires that admins ensure that primary
-            groups are correct!
+            Make all instructor files group writeable (g+ws, default g+r only)
+            and exchange directories group readable/writeable (g+rws, default
+            g=nothing only ) by default.  This should only be used if you
+            carefully set the primary groups of your notebook servers and fully
+            understand the unix permission model.
             """
         )
     ).tag(config=True)

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -142,12 +142,12 @@ class Exchange(LoggingConfigurable):
         if self.groupshared:
             for dirname, _, filenames in os.walk(dest):
                 # dirs become ug+rwx
-                if os.stat(dirname).st_uid == os.getuid():
-                    os.chmod(dirname, (os.stat(dirname).st_mode|0o2770) & 0o2777)
+                try:   os.chmod(dirname, (os.stat(dirname).st_mode|0o2770) & 0o2777)
+                except PermissionError: pass
                 for filename in filenames:
                     filename = os.path.join(dirname, filename)
-                    if os.stat(filename).st_uid == os.getuid():
-                        os.chmod(filename, (os.stat(filename).st_mode|0o660) & 0o777)
+                    try:    os.chmod(filename, (os.stat(filename).st_mode|0o660) & 0o777)
+                    except PermissionError: pass
 
     def start(self):
         if sys.platform == 'win32':

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -68,17 +68,6 @@ class Exchange(LoggingConfigurable):
         )
     ).tag(config=True)
 
-    groupshared = Bool(
-        False,
-        help=dedent(
-            """
-            Be less strict about user permissions (instructor files are by
-            default group writeable.  Requires that admins ensure that primary
-            groups are correct!
-            """
-        )
-    ).tag(config=True)
-
     coursedir = Instance(CourseDirectory, allow_none=True)
     authenticator = Instance(Authenticator, allow_none=True)
 
@@ -139,7 +128,7 @@ class Exchange(LoggingConfigurable):
                                                log=self.log))
         # copytree copies access mode too - so we must add go+rw back to it if
         # we are in groupshared.
-        if self.groupshared:
+        if self.coursedir.groupshared:
             for dirname, _, filenames in os.walk(dest):
                 # dirs become ug+rwx
                 try:
@@ -157,7 +146,7 @@ class Exchange(LoggingConfigurable):
         if sys.platform == 'win32':
             self.fail("Sorry, the exchange is not available on Windows.")
 
-        if not self.groupshared:
+        if not self.coursedir.groupshared:
             # This just makes sure that directory is o+rwx.  In group shared
             # case, it is up to admins to ensure that instructors can write
             # there.
@@ -191,5 +180,5 @@ class Exchange(LoggingConfigurable):
             # so we have to create and then chmod.
             os.chmod(path, mode)
         else:
-            if not self.groupshared and not self_owned(path):
+            if not self.coursedir.groupshared and not self_owned(path):
                 self.fail("You don't own the directory: {}".format(path))

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -137,6 +137,17 @@ class Exchange(LoggingConfigurable):
                                                include=self.coursedir.include,
                                                max_file_size=self.coursedir.max_file_size,
                                                log=self.log))
+        # copytree copies access mode too - so we must add go+rw back to it if
+        # we are in groupshared.
+        if self.groupshared:
+            for dirname, _, filenames in os.walk(dest):
+                # dirs become ug+rwx
+                if os.stat(dirname).st_uid == os.getuid():
+                    os.chmod(dirname, (os.stat(dirname).st_mode|0o770) & 0o777)
+                for filename in filenames:
+                    filename = os.path.join(dirname, filename)
+                    if os.stat(filename).st_uid == os.getuid():
+                        os.chmod(filename, (os.stat(filename).st_mode|0o660) & 0o777)
 
     def start(self):
         if sys.platform == 'win32':

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -172,5 +172,5 @@ class Exchange(LoggingConfigurable):
             # so we have to create and then chmod.
             os.chmod(path, mode)
         else:
-            if not self_owned(path):
+            if not self.groupshared and not self_owned(path):
                 self.fail("You don't own the directory: {}".format(path))

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -142,7 +142,11 @@ class Exchange(LoggingConfigurable):
         if sys.platform == 'win32':
             self.fail("Sorry, the exchange is not available on Windows.")
 
-        self.ensure_root()
+        if not self.groupshared:
+            # This just makes sure that directory is o+rwx.  In group shared
+            # case, it is up to admins to ensure that instructors can write
+            # there.
+            self.ensure_root()
         self.set_timestamp()
 
         self.init_src()

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -131,16 +131,21 @@ class Exchange(LoggingConfigurable):
         if self.coursedir.groupshared:
             for dirname, _, filenames in os.walk(dest):
                 # dirs become ug+rwx
-                try:
-                    os.chmod(dirname, (os.stat(dirname).st_mode|0o2770) & 0o2777)
-                except PermissionError:
-                    pass
+                st_mode = os.stat(dirname).st_mode
+                if st_mode & 0o2770 != 0o2770:
+                    try:
+                        os.chmod(dirname, (st_mode|0o2770) & 0o2777)
+                    except PermissionError:
+                        self.log.warning("Could not update permissions of %s to make it groupshared", dirname)
+
                 for filename in filenames:
                     filename = os.path.join(dirname, filename)
-                    try:
-                        os.chmod(filename, (os.stat(filename).st_mode|0o660) & 0o777)
-                    except PermissionError:
-                        pass
+                    st_mode = os.stat(filename).st_mode
+                    if st_mode & 0o660 != 0o660:
+                        try:
+                            os.chmod(filename, (st_mode|0o660) & 0o777)
+                        except PermissionError:
+                            self.log.warning("Could not update permissions of %s to make it groupshared", filename)
 
     def start(self):
         if sys.platform == 'win32':

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -142,12 +142,16 @@ class Exchange(LoggingConfigurable):
         if self.groupshared:
             for dirname, _, filenames in os.walk(dest):
                 # dirs become ug+rwx
-                try:   os.chmod(dirname, (os.stat(dirname).st_mode|0o2770) & 0o2777)
-                except PermissionError: pass
+                try:
+                    os.chmod(dirname, (os.stat(dirname).st_mode|0o2770) & 0o2777)
+                except PermissionError:
+                    pass
                 for filename in filenames:
                     filename = os.path.join(dirname, filename)
-                    try:    os.chmod(filename, (os.stat(filename).st_mode|0o660) & 0o777)
-                    except PermissionError: pass
+                    try:
+                        os.chmod(filename, (os.stat(filename).st_mode|0o660) & 0o777)
+                    except PermissionError:
+                        pass
 
     def start(self):
         if sys.platform == 'win32':

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -143,7 +143,7 @@ class Exchange(LoggingConfigurable):
             for dirname, _, filenames in os.walk(dest):
                 # dirs become ug+rwx
                 if os.stat(dirname).st_uid == os.getuid():
-                    os.chmod(dirname, (os.stat(dirname).st_mode|0o770) & 0o777)
+                    os.chmod(dirname, (os.stat(dirname).st_mode|0o2770) & 0o2777)
                 for filename in filenames:
                     filename = os.path.join(dirname, filename)
                     if os.stat(filename).st_uid == os.getuid():

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -68,6 +68,17 @@ class Exchange(LoggingConfigurable):
         )
     ).tag(config=True)
 
+    groupshared = Bool(
+        False,
+        help=dedent(
+            """
+            Be less strict about user permissions (instructor files are by
+            default group writeable.  Requires that admins ensure that primary
+            groups are correct!
+            """
+        )
+    ).tag(config=True)
+
     coursedir = Instance(CourseDirectory, allow_none=True)
     authenticator = Instance(Authenticator, allow_none=True)
 

--- a/nbgrader/exchange/release_assignment.py
+++ b/nbgrader/exchange/release_assignment.py
@@ -32,7 +32,7 @@ class ExchangeReleaseAssignment(Exchange):
         super(ExchangeReleaseAssignment, self)._load_config(cfg, **kwargs)
 
     def ensure_root(self):
-        perms = S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IWGRP|S_IXGRP|S_IROTH|S_IWOTH|S_IXOTH|((S_IWGRP|S_ISGID) if self.groupshared else 0)
+        perms = S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IWGRP|S_IXGRP|S_IROTH|S_IWOTH|S_IXOTH|((S_IWGRP|S_ISGID) if self.coursedir.groupshared else 0)
 
         # if root doesn't exist, create it and set permissions
         if not os.path.exists(self.root):
@@ -80,19 +80,19 @@ class ExchangeReleaseAssignment(Exchange):
         # groupshared: +2040
         self.ensure_directory(
             self.course_path,
-            S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH|((S_ISGID|S_IWGRP) if self.groupshared else 0)
+            S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH|((S_ISGID|S_IWGRP) if self.coursedir.groupshared else 0)
         )
         # 0755
         # groupshared: +2040
         self.ensure_directory(
             self.outbound_path,
-            S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH|((S_ISGID|S_IWGRP) if self.groupshared else 0)
+            S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH|((S_ISGID|S_IWGRP) if self.coursedir.groupshared else 0)
         )
         # 0733 with set GID so student submission will have the instructors group
         # groupshared: +0040
         self.ensure_directory(
             self.inbound_path,
-            S_ISGID|S_IRUSR|S_IWUSR|S_IXUSR|S_IWGRP|S_IXGRP|S_IWOTH|S_IXOTH|(S_IRGRP if self.groupshared else 0)
+            S_ISGID|S_IRUSR|S_IWUSR|S_IXUSR|S_IWGRP|S_IXGRP|S_IWOTH|S_IXOTH|(S_IRGRP if self.coursedir.groupshared else 0)
         )
 
     def copy_files(self):
@@ -111,6 +111,6 @@ class ExchangeReleaseAssignment(Exchange):
         self.do_copy(self.src_path, self.dest_path)
         self.set_perms(
             self.dest_path,
-            fileperms=(S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH|(S_IWGRP if self.groupshared else 0)),
-            dirperms=(S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH|((S_ISGID|S_IWGRP) if self.groupshared else 0)))
+            fileperms=(S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH|(S_IWGRP if self.coursedir.groupshared else 0)),
+            dirperms=(S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH|((S_ISGID|S_IWGRP) if self.coursedir.groupshared else 0)))
         self.log.info("Released as: {} {}".format(self.coursedir.course_id, self.coursedir.assignment_id))

--- a/nbgrader/exchange/release_assignment.py
+++ b/nbgrader/exchange/release_assignment.py
@@ -77,19 +77,22 @@ class ExchangeReleaseAssignment(Exchange):
         self.inbound_path = os.path.join(self.course_path, 'inbound')
         self.dest_path = os.path.join(self.outbound_path, self.coursedir.assignment_id)
         # 0755
+        # groupshared: +2040
         self.ensure_directory(
             self.course_path,
-            S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH
+            S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH|((S_ISGID|S_IWGRP) if self.groupshared else 0)
         )
         # 0755
+        # groupshared: +2040
         self.ensure_directory(
             self.outbound_path,
-            S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH
+            S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH|((S_ISGID|S_IWGRP) if self.groupshared else 0)
         )
         # 0733 with set GID so student submission will have the instructors group
+        # groupshared: +0040
         self.ensure_directory(
             self.inbound_path,
-            S_ISGID|S_IRUSR|S_IWUSR|S_IXUSR|S_IWGRP|S_IXGRP|S_IWOTH|S_IXOTH
+            S_ISGID|S_IRUSR|S_IWUSR|S_IXUSR|S_IWGRP|S_IXGRP|S_IWOTH|S_IXOTH|(S_IRGRP if self.groupshared else 0)
         )
 
     def copy_files(self):
@@ -108,6 +111,6 @@ class ExchangeReleaseAssignment(Exchange):
         self.do_copy(self.src_path, self.dest_path)
         self.set_perms(
             self.dest_path,
-            fileperms=(S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH),
-            dirperms=(S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH))
+            fileperms=(S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH|(S_IWGRP if self.groupshared else 0)),
+            dirperms=(S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH|((S_ISGID|S_IWGRP) if self.groupshared else 0)))
         self.log.info("Released as: {} {}".format(self.coursedir.course_id, self.coursedir.assignment_id))

--- a/nbgrader/exchange/release_assignment.py
+++ b/nbgrader/exchange/release_assignment.py
@@ -32,7 +32,7 @@ class ExchangeReleaseAssignment(Exchange):
         super(ExchangeReleaseAssignment, self)._load_config(cfg, **kwargs)
 
     def ensure_root(self):
-        perms = S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IWGRP|S_IXGRP|S_IROTH|S_IWOTH|S_IXOTH
+        perms = S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IWGRP|S_IXGRP|S_IROTH|S_IWOTH|S_IXOTH|((S_IWGRP|S_ISGID) if self.groupshared else 0)
 
         # if root doesn't exist, create it and set permissions
         if not os.path.exists(self.root):

--- a/nbgrader/exchange/release_feedback.py
+++ b/nbgrader/exchange/release_feedback.py
@@ -1,7 +1,7 @@
 import os
 import shutil
 import glob
-from stat import S_IRUSR, S_IWUSR, S_IXUSR, S_IXGRP, S_IXOTH
+from stat import S_IRUSR, S_IWUSR, S_IXUSR, S_IRGRP, S_IWGRP, S_IXGRP, S_IXOTH, S_ISGID
 
 from .exchange import Exchange
 from ..utils import notebook_hash
@@ -22,7 +22,7 @@ class ExchangeReleaseFeedback(Exchange):
         # 0755
         self.ensure_directory(
             self.outbound_feedback_path,
-            S_IRUSR | S_IWUSR | S_IXUSR | S_IXGRP | S_IXOTH
+            S_IRUSR | S_IWUSR | S_IXUSR | S_IXGRP | S_IXOTH | ((S_IRGRP|S_IWGRP|S_ISGID) if self.coursedir.groupshared else 0)
         )
 
     def copy_files(self):

--- a/nbgrader/tests/apps/base.py
+++ b/nbgrader/tests/apps/base.py
@@ -59,7 +59,11 @@ class BaseTestApp(object):
             fh.write(contents)
 
     def _get_permissions(self, filename):
-        return oct(os.stat(filename).st_mode)[-3:]
+        st_mode = os.stat(filename).st_mode
+        # If setgid is true, return four bytes.  For testing CourseDirectory.groupshared.
+        if st_mode & 0o2000:
+            return oct(st_mode)[-4:]
+        return oct(st_mode)[-3:]
 
     def _file_contents(self, path):
         with open(path, "r") as fh:


### PR DESCRIPTION
Hi,

I have been working on a setup where I wanted instructors to be able to share releasing files, collecting, and so on.nbgrader says that it doesn't support this, but I tried anyway.  This PR contains the changes needed to make this work, which have been mostly minimal.  Things are not perfect, and some of these changes may be not needed.  I'm still testing locally and this is mainly to get some more expert opinions.

This adds a new option `groupshared` which enables the behavior.  By default, no behavior should change.

These changes assume that the following are set by the environment (admins).  They are satisfied in my setup because we run via kubespawner and I carefully control these:
- instructors have a unique-per-course primary gid which students do not have.  Alternatively, the setgid bit could be set (in practice I do both).  If using setgid, you have to set that up yourself.
- umasks are 0007
- shared course and exchange directories, like normal.
- Instructors won't do something wrong with permissions which breaks the security.

We expect these behaviors to happen when `groupshared = True`:
- All info in the course directory is `g+rw`.  Instructors can all edit files.
- Multiple instructors can release and collect files from the exchange.  Basically, when releasing, group permissions mirror user, not other.  Because the submitted folder is set g+rwx, other instructors can also collect.
- Don't insist on non-group writability in some places.

It actually seems to mostly work (though I am still doing internal tests) Remaining problems (I will keep updating this as I find more):
- [x] The `groupshared` set in two places.  Set it only once.  (I didn't see a common base class...)
- [x] when the `release/` and `release/{assignment_id}` directories are created, it is `g-w`.  Haven't been able to figure out why yet - it is not the umask, and I can't figure out where in the code the dirs are created. (help requested!)
- [x] sqlite3 hardcodes a create mode of 644.  I hacked around this by touching `gradebook.db` and setting a proper mode first.
- [x] tests
- [x] Study 664 vs 444 as default permissions for autograde. (rkdarst)
- [x] Study what the problem with ensure_root was (rkdarst)

For now I am trying to just make *something* that will work, then I can work on improving it more.  What do you think?  Is this something that I should work on to merge upstream?