### PR TITLE
Allow setting a different assignment dir for students than the root notebook directory

### DIFF
--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -31,6 +31,17 @@ class Exchange(LoggingConfigurable):
         )
     ).tag(config=True)
 
+    assignment_dir = Unicode(
+        ".",
+        help=dedent(
+            """
+            Local path for storing student assignments.  Defaults to '.'
+            which is normally Jupyter's notebook_dir.
+            """
+        )
+    ).tag(config=True)
+
+
     @validate('course_id')
     def _validate_course_id(self, proposal):
         if proposal['value'].strip() != proposal['value']:

--- a/nbgrader/exchange/fetch.py
+++ b/nbgrader/exchange/fetch.py
@@ -30,7 +30,7 @@ class ExchangeFetch(Exchange):
             root = os.path.join(self.course_id, self.coursedir.assignment_id)
         else:
             root = self.coursedir.assignment_id
-        self.dest_path = os.path.abspath(os.path.join('.', root))
+        self.dest_path = os.path.abspath(os.path.join(self.assignment_dir, root))
         if os.path.isdir(self.dest_path) and not self.replace_missing_files:
             self.fail("You already have a copy of the assignment in this directory: {}".format(root))
 

--- a/nbgrader/server_extensions/assignment_list/handlers.py
+++ b/nbgrader/server_extensions/assignment_list/handlers.py
@@ -74,9 +74,9 @@ class AssignmentList(LoggingConfigurable):
             else:
                 for assignment in assignments:
                     if assignment['status'] == 'fetched':
-                        assignment['path'] = os.path.relpath(assignment['path'], self.assignment_dir)
+                        assignment['path'] = os.path.relpath(assignment['path'], self.parent.notebook_dir)
                         for notebook in assignment['notebooks']:
-                            notebook['path'] = os.path.relpath(notebook['path'], self.assignment_dir)
+                            notebook['path'] = os.path.relpath(notebook['path'], self.parent.notebook_dir)
                 retvalue = {
                     "success": True,
                     "value": sorted(assignments, key=lambda x: (x['course_id'], x['assignment_id']))

--- a/nbgrader/server_extensions/assignment_list/handlers.py
+++ b/nbgrader/server_extensions/assignment_list/handlers.py
@@ -53,7 +53,9 @@ class AssignmentList(LoggingConfigurable):
         # first get the exchange assignment directory
         with chdir(self.parent.notebook_dir):
             config = self.load_config()
-            assignment_dir = config.Exchange.assignment_dir
+
+        lister = ExchangeList(config=config)
+        assignment_dir = lister.assignment_dir
 
         # now cd to the full assignment directory and load the config again
         with chdir(assignment_dir):

--- a/nbgrader/server_extensions/assignment_list/handlers.py
+++ b/nbgrader/server_extensions/assignment_list/handlers.py
@@ -33,7 +33,7 @@ def chdir(dirname):
 
 class AssignmentList(LoggingConfigurable):
 
-    assignment_dir = Unicode('', help='Directory where the nbgrader commands should be run')
+    assignment_dir = Unicode('', help='Directory where the nbgrader commands should be run').tag(config=True)
     @default("assignment_dir")
     def _assignment_dir_default(self):
         return self.parent.notebook_dir

--- a/nbgrader/server_extensions/assignment_list/handlers.py
+++ b/nbgrader/server_extensions/assignment_list/handlers.py
@@ -33,11 +33,6 @@ def chdir(dirname):
 
 class AssignmentList(LoggingConfigurable):
 
-    assignment_dir = Unicode('', help='Directory where the nbgrader commands should be run').tag(config=True)
-    @default("assignment_dir")
-    def _assignment_dir_default(self):
-        return self.parent.notebook_dir
-
     def load_config(self):
         paths = jupyter_config_path()
         paths.insert(0, os.getcwd())
@@ -53,10 +48,22 @@ class AssignmentList(LoggingConfigurable):
 
         return full_config
 
+    @contextlib.contextmanager
+    def get_assignment_dir_config(self):
+        # first get the exchange assignment directory
+        with chdir(self.parent.notebook_dir):
+            config = self.load_config()
+            assignment_dir = config.Exchange.assignment_dir
+
+        # now cd to the full assignment directory and load the config again
+        with chdir(assignment_dir):
+            for new_config in NbGrader._load_config_files("nbgrader_config", path=[os.getcwd()], log=self.log):
+                config.merge(new_config)
+            yield config
+
     def list_released_assignments(self, course_id=None):
-        with chdir(self.assignment_dir):
+        with self.get_assignment_dir_config() as config:
             try:
-                config = self.load_config()
                 if course_id:
                     config.Exchange.course_id = course_id
 
@@ -85,9 +92,8 @@ class AssignmentList(LoggingConfigurable):
         return retvalue
 
     def list_submitted_assignments(self, course_id=None):
-        with chdir(self.assignment_dir):
+        with self.get_assignment_dir_config() as config:
             try:
-                config = self.load_config()
                 config.ExchangeList.cached = True
                 if course_id:
                     config.Exchange.course_id = course_id
@@ -140,9 +146,8 @@ class AssignmentList(LoggingConfigurable):
         return retvalue
 
     def fetch_assignment(self, course_id, assignment_id):
-        with chdir(self.assignment_dir):
+        with self.get_assignment_dir_config() as config:
             try:
-                config = self.load_config()
                 config.Exchange.course_id = course_id
                 config.CourseDirectory.assignment_id = assignment_id
 
@@ -165,9 +170,8 @@ class AssignmentList(LoggingConfigurable):
         return retvalue
 
     def submit_assignment(self, course_id, assignment_id):
-        with chdir(self.assignment_dir):
+        with self.get_assignment_dir_config() as config:
             try:
-                config = self.load_config()
                 config.Exchange.course_id = course_id
                 config.CourseDirectory.assignment_id = assignment_id
 


### PR DESCRIPTION
Currently, nbgrader assumes that fetching assignments via the web UI will always put them in `notebook_dir` - so that `notebook_dir`/`default_url` can't be used.  This PR seem to minimally fix that - at least I could do one manual test and it worked.  It will need serious examination from others, in addition to tests and documentation.

Please let me know what you think: is this on the right track?  What should be done to make it useful?

---
I'm not sure if the `.tag(config=True)` is needed.

The current config needs `c.Exchange.assignment_dir = "/notebooks/` in `nbgrader_config.py` and `c.AssignmentList.assignment_dir` in `jupyter_notebook_config.py`.