### PR TITLE
Change to notebook directory when validating (repeat of #880)

### DIFF
--- a/nbgrader/tests/apps/files/data.txt
+++ b/nbgrader/tests/apps/files/data.txt
@@ -1,0 +1,4 @@
+line 1
+line 2
+line 3
+line 4

--- a/nbgrader/tests/apps/files/open_relative_file.ipynb
+++ b/nbgrader/tests/apps/files/open_relative_file.ipynb
@@ -1,0 +1,37 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true,
+    "nbgrader": {
+     "grade": true,
+     "grade_id": "open_file",
+     "locked": true,
+     "points": 10,
+     "schema_version": 2,
+     "solution": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "with open(\"data.txt\", \"r\") as f:\n",
+    "    data = f.read()\n",
+    "    \n",
+    "assert len(data.split(\"\\n\")) == 4"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python",
+   "language": "python",
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/nbgrader/tests/apps/test_nbgrader_validate.py
+++ b/nbgrader/tests/apps/test_nbgrader_validate.py
@@ -22,6 +22,13 @@ class TestNbGraderValidate(BaseTestApp):
         output = run_nbgrader(["validate", "submitted-changed.ipynb"], stdout=True)
         assert output.strip() == "Success! Your notebook passes all the tests."
 
+    def test_validate_subdir(self):
+        """Does the validation fail on an unchanged notebook?"""
+        self._copy_file(join("files", "open_relative_file.ipynb"), "my_subdir/open_relative_file.ipynb")
+        self._copy_file(join("files", "data.txt"), "my_subdir/data.txt")
+        output = run_nbgrader(["validate", "my_subdir/open_relative_file.ipynb"], stdout=True)
+        assert output.strip() == "Success! Your notebook passes all the tests."
+
     def test_invert_validate_unchanged(self):
         """Does the inverted validation pass on an unchanged notebook?"""
         self._copy_file(join("files", "submitted-unchanged.ipynb"), "submitted-unchanged.ipynb")

--- a/nbgrader/validator.py
+++ b/nbgrader/validator.py
@@ -282,7 +282,8 @@ class Validator(LoggingConfigurable):
             } for cell in type_changed]
             return results
 
-        nb = self._preprocess(nb)
+        with utils.chdir(dirname):
+            nb = self._preprocess(nb)
         changed = self._get_changed_cells(nb)
         passed = self._get_passed_cells(nb)
         failed = self._get_failed_cells(nb)


### PR DESCRIPTION
- This was fixed in #880, but a refactoring to split reading from
  preprocessing has removed the wrapper around the preprocess step.

There is in fact a test for this, but perhaps pytest chdirs to the ipynb's directory so that the test can't fail.

I'm still making my final tests but this seems to work.