### PR TITLE
Add random string to submission filenames for better hiding

### DIFF
--- a/nbgrader/exchange/collect.py
+++ b/nbgrader/exchange/collect.py
@@ -26,8 +26,8 @@ class ExchangeCollect(Exchange):
     def _path_to_record(self, path):
         filename = os.path.split(path)[1]
         # Only split twice on +, giving three components. This allows usernames with +.
-        filename_list = filename.rsplit('+', 2)
-        if len(filename_list) != 3:
+        filename_list = filename.rsplit('+', 3)
+        if len(filename_list) < 3:
             self.fail("Invalid filename: {}".format(filename))
         username = filename_list[0]
         timestamp = parse_utc(filename_list[2])

--- a/nbgrader/exchange/submit.py
+++ b/nbgrader/exchange/submit.py
@@ -110,7 +110,7 @@ class ExchangeSubmit(Exchange):
         self.init_release()
 
         dest_path = os.path.join(self.inbound_path, self.assignment_filename)
-        cache_path = os.path.join(self.cache_path, self.assignment_filename)
+        cache_path = os.path.join(self.cache_path, self.assignment_filename.rsplit('+', 1)[0])
 
         self.log.info("Source: {}".format(self.src_path))
         self.log.info("Destination: {}".format(dest_path))

--- a/nbgrader/exchange/submit.py
+++ b/nbgrader/exchange/submit.py
@@ -1,3 +1,4 @@
+import base64
 import os
 from stat import (
     S_IRUSR, S_IWUSR, S_IXUSR,
@@ -45,7 +46,9 @@ class ExchangeSubmit(Exchange):
             self.fail("You don't have write permissions to the directory: {}".format(self.inbound_path))
 
         self.cache_path = os.path.join(self.cache, self.course_id)
-        self.assignment_filename = '{}+{}+{}'.format(get_username(), self.coursedir.assignment_id, self.timestamp)
+        random_str = base64.urlsafe_b64encode(os.urandom(9)).decode('ascii')
+        self.assignment_filename = '{}+{}+{}+{}'.format(
+            get_username(), self.coursedir.assignment_id, self.timestamp, random_str)
 
     def init_release(self):
         if self.course_id == '':


### PR DESCRIPTION
- Previously, the exchange was writeable by all users, readable by all
  users, but only listable by the instructors.  Non-guessability of
  the filename is the method of security.  However, filenames are a
  function of (username, assignment_id, and microsecond timestamp).  A
  microsecond timestamp alone is not immediately guessable, but not
  perfect either.
- This patch introduces a random string to the submission filename.
- This is backwards compatible, except if there is a "+" in a username
  and the instructor uses new nbgrader and students submit with old
  nbgrader.  This is because "+" is used to split the path components,
  but is also a valid character for usernames.  It was split with
  .rsplit("+", 2) before, now it is .rsplit("+", 3).
- Related: #978
- Closes: #978

---

The non-extension tests work locally, let's see what travis says for the rest...