### PR TITLE
Documentation fix to add info re: timeout errors.

### DIFF
--- a/nbgrader/docs/source/user_guide/faq.rst
+++ b/nbgrader/docs/source/user_guide/faq.rst
@@ -178,7 +178,9 @@ What should I do if validation or grading of a notebook fails with a "Timeout wa
 ---------------------------------------------------------------------------------------------------------------
 This occurs because the validator or autograder is taking too long to validate or autograde your notebook. This
 can be fixed by adding the following line to nbgrader_config.py:
+
 .. code:: python
+
    # increase timeout to 60 seconds
    c.ExecutePreprocessor.timeout = 60
 

--- a/nbgrader/docs/source/user_guide/faq.rst
+++ b/nbgrader/docs/source/user_guide/faq.rst
@@ -174,6 +174,14 @@ No, nbgrader only needs to be installed for the instructor. However, students
 may optionally install the Validate extension to verify that their submission
 passes all the test cases.
 
+What should I do if validation or grading of a notebook fails with a "Timeout waiting for execute reply" error?
+---------------------------------------------------------------------------------------------------------------
+This occurs because the validator or autograder is taking too long to validate or autograde your notebook. This
+can be fixed by adding the following line to nbgrader_config.py:
+.. code:: python
+   # increase timeout to 60 seconds
+   c.ExecutePreprocessor.timeout = 60
+
 Can tests be only temporarily hidden, so that students can reveal them?
 -----------------------------------------------------------------------
 No, the tests are either present in the student version of the notebook or they


### PR DESCRIPTION
Added an entry to the FAQ that covers the common timeout errors for autograding/validation that takes too long, including a quick fix.

Fixes #931