### PR TITLE
More language support

### DIFF
--- a/nbgrader/alembic/versions/282d30a0218e_adds_lms_user_id_column_to_student_table.py
+++ b/nbgrader/alembic/versions/282d30a0218e_adds_lms_user_id_column_to_student_table.py
@@ -1,0 +1,24 @@
+"""adds lms_user_id column to student table
+
+Revision ID: 282d30a0218e
+Revises: 724cde206c17
+Create Date: 2018-10-25 20:14:56.887686
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '282d30a0218e'
+down_revision = '724cde206c17'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('student', sa.Column('lms_user_id', sa.String(128), unique=True, nullable=True))
+
+
+def downgrade():
+    op.drop_column('student', 'lms_user_id')

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -369,6 +369,10 @@ class Student(Base):
     #: of each assignment.
     max_score = None
 
+    #: The lms user ID, this is mainly for identifying students in your LMS system
+    #: and was added so teachers and TA's can easily send grades to an LMS such as CanvasLMS.
+    lms_user_id = Column(String(128), unique=True, nullable=True)
+
     def to_dict(self):
         """Convert the student object to a JSON-friendly dictionary
         representation.
@@ -380,7 +384,8 @@ class Student(Base):
             "last_name": self.last_name,
             "email": self.email,
             "score": self.score,
-            "max_score": self.max_score
+            "max_score": self.max_score,
+            "lms_user_id": self.lms_user_id
         }
 
     def __repr__(self):
@@ -803,6 +808,18 @@ class Comment(Base):
         return "Comment<{}/{}/{} for {}>".format(
             self.assignment.name, self.notebook.name, self.name, self.student.id)
 
+class CourseID(Base):
+    """Table to store the course_id, it should have only one row"""
+
+    __tablename__ = "course_id"
+    __table_args__ = (UniqueConstraint("unique_check"),)
+
+    id = Column(String(128), unique=True, primary_key=True, nullable=False)
+    # This should help to prevent having 2 rows in this table
+    unique_check = Column(Boolean, unique=False, default=True)
+
+    def __repr__(self):
+        return "CourseID<{}>".format(self.name)
 
 ## Needs manual grade
 
@@ -1027,13 +1044,16 @@ class Gradebook(object):
 
     """
 
-    def __init__(self, db_url):
+    def __init__(self, db_url, course_id=""):
         """Initialize the connection to the database.
 
         Parameters
         ----------
         db_url : string
             The URL to the database, e.g. ``sqlite:///grades.db``
+        course_id : string, optional
+            identifier of the course necessary for supporting multiple classes
+            default course_id is '' to be consistent with :class:~`nbgrader.apps.api.NbGraderAPI`
 
         """
         # create the connection to the database
@@ -1050,6 +1070,8 @@ class Gradebook(object):
             self.db.execute("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL);")
             self.db.execute("INSERT INTO alembic_version (version_num) VALUES ('{}');".format(alembic_version))
             self.db.commit()
+
+        self.set_course_id(course_id)
 
     def __enter__(self):
         return self
@@ -1068,6 +1090,47 @@ class Gradebook(object):
         """
         self.db.remove()
         self.engine.dispose()
+
+    def set_course_id(self, course_id, **kwargs):
+        """Set the course id
+
+        Parameters
+        ----------
+        course_id : string
+            The unique id of the course
+        `**kwargs` : dict
+            other keyword arguments to the :class:`~nbgrader.api.CourseID` object
+
+        Returns
+        -------
+        course_id : :class:`~nbgrader.api.CourseID`
+
+        """
+
+        try:
+            course_id_record = self.db.query(CourseID)\
+                .one()
+            if course_id: # update id only if not empty
+                course_id_record.id = course_id
+        except NoResultFound:
+            course_id_record = CourseID(id=course_id, **kwargs)
+            self.db.add(course_id_record)
+
+        try:
+            self.db.commit()
+        except (IntegrityError, FlushError) as e:
+            self.db.rollback()
+            raise InvalidEntry(*e.args)
+        return course_id_record
+
+    @property
+    def course_id(self):
+        try:
+            course_id_record = self.db.query(CourseID)\
+                .one()
+            return course_id_record.id
+        except NoResultFound:
+            raise MissingEntry("No course id")
 
     #### Students
 
@@ -1098,6 +1161,33 @@ class Gradebook(object):
         self.db.add(student)
         try:
             self.db.commit()
+            try:
+                group_name = "nbgrader-{}".format(self.course_id)
+                utils.query_jupyterhub_api(method="POST",
+                                     api_path="/groups/{name}".format(name=group_name),
+                )
+                utils.query_jupyterhub_api(method="POST",
+                                     api_path="/groups/{name}/users".format(name=group_name),
+                                     post_data = {"users":[student_id]}
+                )
+                # log.info
+                print("Student {student} added to Jupyterhub group {group_name}".format(
+                    student=student_id,
+                    group_name=group_name
+                ))
+            except (utils.JupyterhubEnvironmentError, utils.JupyterhubApiError) as e:
+                #self.log.error("Error caught: " + e) # self.log not working. Gradebook has no attribute log
+                if self.course_id: # we assume user might be using Jupyterhub but something is not working
+                    # log.error 
+                    # Note: check if log ever appears.
+                    err_msg = "Student {student} NOT added to Jupyterhub group {group_name}: ".format(
+                        student=student_id,
+                        group_name=group_name
+                    )
+                    print(err_msg + str(e))
+                    #self.log.error(err_msg)
+                print("Make sure you set a valid api_token in your config file before starting the service")
+                #self.log.error("Make sure you set a valid api_token in your config file before starting the service")
         except (IntegrityError, FlushError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)
@@ -1176,6 +1266,20 @@ class Gradebook(object):
 
         try:
             self.db.commit()
+
+            try:
+                group_name = "nbgrader-{}".format(self.course_id)
+                res = utils.query_jupyterhub_api(method="DELETE",
+                                     api_path="/groups/{name}/users".format(name=group_name),
+                                     post_data = {"users":[student.id]}
+                )
+                # log.info
+                print("Student {student} removed or was not in the Jupyterhub group {group_name}".format(student=name, group_name=group_name))
+            except (utils.JupyterhubEnvironmentError, utils.JupyterhubApiError) as e:
+                if self.course_id: # We assume user might be using Jupyterhub but something is not working
+                    # log.error
+                    print("Student {student} NOT removed from the Jupyterhub group {group_name}: ".format(student=name, group_name=group_name) + str(e))
+                #self.log.error("Error caught in remove_student(): " + e)
         except (IntegrityError, FlushError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)

--- a/nbgrader/apps/api.py
+++ b/nbgrader/apps/api.py
@@ -95,7 +95,7 @@ class NbGraderAPI(LoggingConfigurable):
         :func:`~nbgrader.api.Gradebook.close`.
 
         """
-        return Gradebook(self.coursedir.db_url)
+        return Gradebook(self.coursedir.db_url, self.course_id)
 
     def get_source_assignments(self):
         """Get the names of all assignments in the `source` directory.

--- a/nbgrader/apps/dbapp.py
+++ b/nbgrader/apps/dbapp.py
@@ -3,6 +3,7 @@
 
 import csv
 import os
+import sys
 import shutil
 
 from textwrap import dedent
@@ -11,6 +12,7 @@ from datetime import datetime
 
 from . import NbGrader
 from ..api import Gradebook, MissingEntry, Student, Assignment
+from ..exchange import ExchangeList, ExchangeError
 from .. import dbutil
 
 aliases = {
@@ -25,10 +27,21 @@ student_add_aliases.update(aliases)
 student_add_aliases.update({
     'last-name': 'DbStudentAddApp.last_name',
     'first-name': 'DbStudentAddApp.first_name',
-    'email': 'DbStudentAddApp.email'
+    'email': 'DbStudentAddApp.email',
+    'lms-user-id': 'DbStudentAddApp.lms_user_id',
 })
 
-class DbStudentAddApp(NbGrader):
+class DbBaseApp(NbGrader):
+
+    def start(self):
+        if sys.platform != 'win32':
+            lister = ExchangeList(coursedir=self.coursedir, parent=self)
+            self.course_id = lister.course_id
+        else:
+            self.course_id = ''
+        super(DbBaseApp, self).start()
+
+class DbStudentAddApp(DbBaseApp):
 
     name = u'nbgrader-db-student-add'
     description = u'Add a student to the nbgrader database'
@@ -54,6 +67,13 @@ class DbStudentAddApp(NbGrader):
         help="The email of the student"
     ).tag(config=True)
 
+    lms_user_id = Unicode(
+        None,
+        allow_none=True,
+        help="The LMS user id of the student"
+    ).tag(config=True)
+    
+
     def start(self):
         super(DbStudentAddApp, self).start()
 
@@ -64,11 +84,12 @@ class DbStudentAddApp(NbGrader):
         student = {
             "last_name": self.last_name,
             "first_name": self.first_name,
-            "email": self.email
+            "email": self.email,
+            "lms_user_id": self.lms_user_id
         }
 
         self.log.info("Creating/updating student with ID '%s': %s", student_id, student)
-        with Gradebook(self.coursedir.db_url) as gb:
+        with Gradebook(self.coursedir.db_url, self.course_id) as gb:
             gb.update_or_create_student(student_id, **student)
 
 student_remove_flags = {}
@@ -84,7 +105,7 @@ student_remove_flags.update({
     ),
 })
 
-class DbStudentRemoveApp(NbGrader):
+class DbStudentRemoveApp(DbBaseApp):
 
     name = u'nbgrader-db-student-remove'
     description = u'Remove a student from the nbgrader database'
@@ -102,7 +123,7 @@ class DbStudentRemoveApp(NbGrader):
 
         student_id = self.extra_args[0]
 
-        with Gradebook(self.coursedir.db_url) as gb:
+        with Gradebook(self.coursedir.db_url, self.course_id) as gb:
             try:
                 student = gb.find_student(student_id)
             except MissingEntry:
@@ -120,7 +141,7 @@ class DbStudentRemoveApp(NbGrader):
             gb.remove_student(student_id)
 
 
-class DbGenericImportApp(NbGrader):
+class DbGenericImportApp(DbBaseApp):
 
     aliases = aliases
     flags = flags
@@ -196,7 +217,7 @@ class DbGenericImportApp(NbGrader):
         self.log.info("Importing from: '%s'", path)
 
 
-        with Gradebook(self.coursedir.db_url) as gb:
+        with Gradebook(self.coursedir.db_url, self.course_id) as gb:
             with open(path, 'r') as fh:
                 reader = csv.DictReader(fh)
                 reader.fieldnames = self._preprocess_keys(reader.fieldnames)
@@ -258,7 +279,7 @@ class DbStudentImportApp(DbGenericImportApp):
         return "update_or_create_student"
 
 
-class DbStudentListApp(NbGrader):
+class DbStudentListApp(DbBaseApp):
 
     name = u'nbgrader-db-student-list'
     description = u'List students in the nbgrader database'
@@ -269,7 +290,7 @@ class DbStudentListApp(NbGrader):
     def start(self):
         super(DbStudentListApp, self).start()
 
-        with Gradebook(self.coursedir.db_url) as gb:
+        with Gradebook(self.coursedir.db_url, self.course_id) as gb:
             print("There are %d students in the database:" % len(gb.students))
             for student in gb.students:
                 print("%s (%s, %s) -- %s" % (student.id, student.last_name, student.first_name, student.email))
@@ -281,7 +302,7 @@ assignment_add_aliases.update({
     'duedate': 'DbAssignmentAddApp.duedate',
 })
 
-class DbAssignmentAddApp(NbGrader):
+class DbAssignmentAddApp(DbBaseApp):
 
     name = u'nbgrader-db-assignment-add'
     description = u'Add an assignment to the nbgrader database'
@@ -307,7 +328,7 @@ class DbAssignmentAddApp(NbGrader):
         }
 
         self.log.info("Creating/updating assignment with ID '%s': %s", assignment_id, assignment)
-        with Gradebook(self.coursedir.db_url) as gb:
+        with Gradebook(self.coursedir.db_url, self.course_id) as gb:
             gb.update_or_create_assignment(assignment_id, **assignment)
 
 
@@ -324,7 +345,7 @@ assignment_remove_flags.update({
     ),
 })
 
-class DbAssignmentRemoveApp(NbGrader):
+class DbAssignmentRemoveApp(DbBaseApp):
 
     name = u'nbgrader-db-assignment-remove'
     description = u'Remove an assignment from the nbgrader database'
@@ -342,7 +363,7 @@ class DbAssignmentRemoveApp(NbGrader):
 
         assignment_id = self.extra_args[0]
 
-        with Gradebook(self.coursedir.db_url) as gb:
+        with Gradebook(self.coursedir.db_url, self.course_id) as gb:
             try:
                 assignment = gb.find_assignment(assignment_id)
             except MissingEntry:
@@ -369,6 +390,25 @@ class DbAssignmentImportApp(DbGenericImportApp):
         super(DbAssignmentImportApp, self).__init__(*args, **kwargs)
         self.excluded_keys = ["id"]
 
+        with Gradebook(self.coursedir.db_url, self.course_id) as gb:
+            with open(path, 'r') as fh:
+                reader = csv.DictReader(fh)
+                for row in reader:
+                    if "name" not in row:
+                        self.fail("Malformatted CSV file: must contain a column for 'name'")
+
+                    # make sure all the keys are actually allowed in the database,
+                    # and that any empty strings are parsed as None
+                    assignment = {}
+                    for key, val in row.items():
+                        if key not in allowed_keys:
+                            continue
+                        if val == '':
+                            assignment[key] = None
+                        else:
+                            assignment[key] = val
+                    assignment_id = assignment.pop("name")
+
     @property
     def table_class(self):
         return Assignment
@@ -381,7 +421,7 @@ class DbAssignmentImportApp(DbGenericImportApp):
     def db_update_method_name(self):
         return "update_or_create_assignment"
 
-class DbAssignmentListApp(NbGrader):
+class DbAssignmentListApp(DbBaseApp):
 
     name = u'nbgrader-db-assignment-list'
     description = u'List assignments int the nbgrader database'
@@ -392,7 +432,7 @@ class DbAssignmentListApp(NbGrader):
     def start(self):
         super(DbAssignmentListApp, self).start()
 
-        with Gradebook(self.coursedir.db_url) as gb:
+        with Gradebook(self.coursedir.db_url, self.course_id) as gb:
             print("There are %d assignments in the database:" % len(gb.assignments))
             for assignment in gb.assignments:
                 print("%s (due: %s)" % (assignment.name, assignment.duedate))
@@ -400,7 +440,7 @@ class DbAssignmentListApp(NbGrader):
                     print("    - %s" % notebook.name)
 
 
-class DbStudentApp(NbGrader):
+class DbStudentApp(DbBaseApp):
 
     name = u'nbgrader-db-student'
     description = u'Modify or list students in the nbgrader database'
@@ -433,7 +473,7 @@ class DbStudentApp(NbGrader):
         super(DbStudentApp, self).start()
 
 
-class DbAssignmentApp(NbGrader):
+class DbAssignmentApp(DbBaseApp):
 
     name = u'nbgrader-db-assignment'
     description = u'Modify or list assignments in the nbgrader database'
@@ -467,7 +507,7 @@ class DbAssignmentApp(NbGrader):
         super(DbAssignmentApp, self).start()
 
 
-class DbUpgradeApp(NbGrader):
+class DbUpgradeApp(DbBaseApp):
     """Based on the `jupyterhub upgrade-db` command found in jupyterhub.app.UpgradeDB"""
 
     name = u'nbgrader-db-upgrade'
@@ -476,7 +516,7 @@ class DbUpgradeApp(NbGrader):
     def _backup_db_file(self, db_file):
         """Backup a database file"""
         if not os.path.exists(db_file):
-            with Gradebook("sqlite:///{}".format(db_file)):
+            with Gradebook("sqlite:///{}".format(db_file), self.course_id):
                 pass
 
         timestamp = datetime.now().strftime('.%Y-%m-%d-%H%M%S.%f')
@@ -496,7 +536,7 @@ class DbUpgradeApp(NbGrader):
         dbutil.upgrade(self.coursedir.db_url)
 
 
-class DbApp(NbGrader):
+class DbApp(DbBaseApp):
 
     name = u'nbgrader-db'
     description = u'Perform operations on the nbgrader database'

--- a/nbgrader/exchange/fetch.py
+++ b/nbgrader/exchange/fetch.py
@@ -14,6 +14,9 @@ class ExchangeFetch(Exchange):
     def init_src(self):
         if self.course_id == '':
             self.fail("No course id specified. Re-run with --course flag.")
+        courses = self.get_user_courses(self.coursedir.student_id)
+        if not self.course_id in courses:
+            self.fail("You do not have access to this course.")
 
         self.course_path = os.path.join(self.root, self.course_id)
         self.outbound_path = os.path.join(self.course_path, 'outbound')

--- a/nbgrader/exchange/list.py
+++ b/nbgrader/exchange/list.py
@@ -58,34 +58,37 @@ class ExchangeList(Exchange):
 
     def parse_assignments(self):
         assignments = []
-        for path in self.assignments:
-            info = self.parse_assignment(path)
-            if self.path_includes_course:
-                root = os.path.join(info['course_id'], info['assignment_id'])
-            else:
-                root = info['assignment_id']
+        if self.coursedir.student_id:
+            courses = self.get_user_courses(self.coursedir.student_id)
+            for path in self.assignments:
+                info = self.parse_assignment(path)
+                if info['course_id'] in courses:
+                    if self.path_includes_course:
+                        root = os.path.join(info['course_id'], info['assignment_id'])
+                    else:
+                        root = info['assignment_id']
 
-            if self.inbound or self.cached:
-                info['status'] = 'submitted'
-                info['path'] = path
-            elif os.path.exists(root):
-                info['status'] = 'fetched'
-                info['path'] = os.path.abspath(root)
-            else:
-                info['status'] = 'released'
-                info['path'] = path
+                    if self.inbound or self.cached:
+                        info['status'] = 'submitted'
+                        info['path'] = path
+                    elif os.path.exists(root):
+                        info['status'] = 'fetched'
+                        info['path'] = os.path.abspath(root)
+                    else:
+                        info['status'] = 'released'
+                        info['path'] = path
 
-            if self.remove:
-                info['status'] = 'removed'
+                    if self.remove:
+                        info['status'] = 'removed'
 
-            info['notebooks'] = []
-            for notebook in sorted(glob.glob(os.path.join(info['path'], '*.ipynb'))):
-                info['notebooks'].append({
-                    'notebook_id': os.path.splitext(os.path.split(notebook)[1])[0],
-                    'path': os.path.abspath(notebook)
-                })
+                    info['notebooks'] = []
+                    for notebook in sorted(glob.glob(os.path.join(info['path'], '*.ipynb'))):
+                        info['notebooks'].append({
+                            'notebook_id': os.path.splitext(os.path.split(notebook)[1])[0],
+                            'path': os.path.abspath(notebook)
+                        })
 
-            assignments.append(info)
+                    assignments.append(info)
 
         return assignments
 

--- a/nbgrader/exchange/submit.py
+++ b/nbgrader/exchange/submit.py
@@ -45,6 +45,9 @@ class ExchangeSubmit(Exchange):
     def init_dest(self):
         if self.course_id == '':
             self.fail("No course id specified. Re-run with --course flag.")
+        courses = self.get_user_courses(self.coursedir.student_id)
+        if not self.course_id in courses:
+            self.fail("You do not have access to this course.")
 
         self.inbound_path = os.path.join(self.root, self.course_id, 'inbound')
         if not os.path.isdir(self.inbound_path):

--- a/nbgrader/server_extensions/assignment_list/handlers.py
+++ b/nbgrader/server_extensions/assignment_list/handlers.py
@@ -228,7 +228,10 @@ class CourseListHandler(BaseAssignmentHandler):
 
     @web.authenticated
     def get(self):
-        self.finish(json.dumps(self.manager.list_courses()))
+        courses_list = self.manager.list_courses()
+        if courses_list['success'] and 'value' in courses_list:
+            courses_list['value'] = [course for course in courses_list['value'] if 'nbgrader-{}'.format(course) in self.current_user['groups'] or 'formgrade-{}'.format(course) in self.current_user['groups']]
+        self.finish(json.dumps(courses_list))
 
 
 class NbGraderVersionHandler(BaseAssignmentHandler):

--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -52,8 +52,29 @@ def is_locked(cell):
     else:
         return cell.metadata['nbgrader'].get('locked', False)
 
+def is_validate_error(cell, lang = None, cutoff = 100):
+    errors = []
+    if lang == 'octave'
+        for output in cell.outputs:
+            if output.output_type == "stream": 
+                if hasattr(output, "text"):
+                    if re.match("error: ", output.text): 
+                        errors.append(True)
+                        if len(errors) >= cutoff:
+                            return errors
+                    else:
+                        errors.append(False)
+    else:
+        for output in cell.outputs:
+            if output.output_type == 'error':
+                errors.append(True)
+                if len(errors) >= cutoff:
+                    return errors
+            else:
+                errors.append(False)
+    return errors
 
-def determine_grade(cell):
+def determine_grade(cell, lang = None):
     if not is_grade(cell):
         raise ValueError("cell is not a grade cell")
 
@@ -68,8 +89,7 @@ def determine_grade(cell):
             return None, max_points
 
     elif cell.cell_type == 'code':
-        for output in cell.outputs:
-            if output.output_type == 'error':
+        if any(is_validate_error(cell, lang, 1))
                 return 0, max_points
         return max_points, max_points
 

--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -8,7 +8,10 @@ import shutil
 import stat
 import logging
 import traceback
+import json
+import urllib.parse
 import contextlib
+import re # new
 
 from setuptools.archive_util import unpack_archive
 from setuptools.archive_util import unpack_tarfile
@@ -26,6 +29,56 @@ if sys.platform != 'win32':
 else:
     pwd = None
 
+class JupyterhubEnvironmentError(Exception):
+    pass
+
+class JupyterhubApiError(Exception):
+    pass
+
+def query_jupyterhub_api(method, api_path, post_data=None):
+    """Query Jupyterhub api
+
+    Detects Jupyterhub environment variables and makes a call to the Hub API
+ 
+    Parameters
+    ----------
+    method : string
+        HTTP method, e.g. GET or POST
+    api_path : string
+        relative path, for example /users/
+    post_data : dict
+        JSON arguments for the API call
+
+    Returns
+    -------
+    response : dict
+        JSON response converted to dictionary"""
+
+    import requests
+
+    if os.getenv('JUPYTERHUB_API_TOKEN'):
+        api_token = os.environ['JUPYTERHUB_API_TOKEN']
+    else:
+        raise JupyterhubEnvironmentError("JUPYTERHUB_API_TOKEN env is required to run the exchange features of nbgrader.")
+    hub_api_url = os.environ.get('JUPYTERHUB_API_URL') or 'http://127.0.0.1:8081/hub/api'
+    if os.getenv('JUPYTERHUB_USER'):
+        user = os.environ['JUPYTERHUB_USER']
+    else:
+        raise JupyterhubEnvironmentError("JUPYTERHUB_USER env is required to run the exchange features of nbgrader.")
+    auth_header = {
+            'Authorization': 'token %s' % api_token
+        }
+
+    api_path = api_path.format(authenticated_user = user)
+    req = requests.request(url=hub_api_url + api_path,
+        method=method,
+        headers=auth_header,
+        json = post_data,
+    )
+    if not req.ok:
+        raise JupyterhubApiError("Jupyterhub returned a status code of: " + str(req.status_code))
+
+    return req.json()
 
 def is_grade(cell):
     """Returns True if the cell is a grade cell."""
@@ -91,6 +144,10 @@ def determine_grade(cell, lang = None):
     elif cell.cell_type == 'code':
         if any(is_validate_error(cell, lang, 1)):
                 return 0, max_points
+            elif output.output_type == 'stream': #new
+                if hasattr(output, 'text'): #new
+                    if re.match('error: ', output.text): # new
+                        return 0, max_points #new
         return max_points, max_points
 
     else:

--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -89,7 +89,7 @@ def determine_grade(cell, lang = None):
             return None, max_points
 
     elif cell.cell_type == 'code':
-        if any(is_validate_error(cell, lang, 1))
+        if any(is_validate_error(cell, lang, 1)):
                 return 0, max_points
         return max_points, max_points
 

--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -54,7 +54,7 @@ def is_locked(cell):
 
 def is_validate_error(cell, lang = None, cutoff = 100):
     errors = []
-    if lang == 'octave'
+    if lang == 'octave':
         for output in cell.outputs:
             if output.output_type == "stream": 
                 if hasattr(output, "text"):

--- a/nbgrader/validator.py
+++ b/nbgrader/validator.py
@@ -245,10 +245,10 @@ class Validator(LoggingConfigurable):
         return cells
 
     def _get_failed_cells(self, nb):
-        return self._get_cells_op(self, nb, op.lt)
+        return self._get_cells_op(self, nb, operator.lt)
 
     def _get_passed_cells(self, nb):
-        return self._get_cells_op(self, nb, op.ge)
+        return self._get_cells_op(self, nb, operator.ge)
 
     def _preprocess(self, nb):
         resources = {}

--- a/nbgrader/validator.py
+++ b/nbgrader/validator.py
@@ -245,10 +245,10 @@ class Validator(LoggingConfigurable):
         return cells
 
     def _get_failed_cells(self, nb):
-        return self._get_cells_op(self, nb, operator.lt)
+        return self._get_cells_op(nb, operator.lt)
 
     def _get_passed_cells(self, nb):
-        return self._get_cells_op(self, nb, operator.ge)
+        return self._get_cells_op(nb, operator.ge)
 
     def _preprocess(self, nb):
         resources = {}

--- a/nbgrader/validator.py
+++ b/nbgrader/validator.py
@@ -3,6 +3,7 @@ import os
 import re
 import operator
 
+
 from traitlets.config import LoggingConfigurable
 from traitlets import List, Unicode, Integer, Bool
 from nbformat import current_nbformat, read as read_nb
@@ -109,9 +110,9 @@ class Validator(LoggingConfigurable):
                 errors = ["\n".join(o.text) for (o,f) in zip(cell.outputs, e_filter) if f ]
             else:
                 errors = ["\n".join(o.traceback) for (o,f) in zip(cell.outputs, e_filter) if f ]
+
             if len(errors) == 0:
                 errors.append("You did not provide a response.")
-
         else:
             errors.append("You did not provide a response.")
 
@@ -258,7 +259,6 @@ class Validator(LoggingConfigurable):
         return nb
 
     def validate(self, filename):
-        self.log.info("Validating '{}'".format(os.path.abspath(filename)))
         basename = os.path.basename(filename)
         dirname = os.path.dirname(filename)
         with utils.chdir(dirname):

--- a/nbgrader/validator.py
+++ b/nbgrader/validator.py
@@ -245,10 +245,10 @@ class Validator(LoggingConfigurable):
         return cells
 
     def _get_failed_cells(self, nb):
-        return _get_cells_op(self, nb, op.lt)
+        return self._get_cells_op(self, nb, op.lt)
 
     def _get_passed_cells(self, nb):
-        return _get_cells_op(self, nb, op.ge)
+        return self._get_cells_op(self, nb, op.ge)
 
     def _preprocess(self, nb):
         resources = {}

--- a/nbgrader/validator.py
+++ b/nbgrader/validator.py
@@ -232,7 +232,7 @@ class Validator(LoggingConfigurable):
             if not (utils.is_grade(cell) or utils.is_locked(cell)):
                 continue
 
-            # if it's a grade cell, the check the grade
+            # if it's a grade cell, then check the grade
             if utils.is_grade(cell):
                 score, max_score = utils.determine_grade(cell, lang)
 


### PR DESCRIPTION
# Adds octave support, refactors to less code, introduces cutoff

* Introduces utils `is_validate_error(cell, lang = None, cutoff = 100)`. This function refactors the code that was in validator._extract_error and utils.determine_grade, so now they both call this function instead of having the same code in both those places. The cutoff parameter could probably be reduced to 10.

* The optional `cutoff` parameter to is_validate_error. This should not affect grading because the determine_grade function calls is_validate_error with 1 as cutoff to give a zero or max_grade; that is the functionality of the autograder test cells, its also usually enough because the kernels usually stop giving out error messages at the first assertion error. But for example octave will give out message for every error because we are only regex matching the error text so the kernel is not stopping at an error like other kernels would.

* Using `lang = nb.metadata.get('kernelspec',{}).get("language","python")` to get the name of the kernel. Even though it says python it gets the name of the kernel. So 'octave' is returned for the octave kernel for example. This will hopefully introduce more language support. I also think it is safer to get the language then for example having the code that finds octave errors being checked for every language.

* octave kernel error matching now works, I tried some other things that might give the same error like calling display('error ') but it does not conflict. If somebody has some other ideas I could try that, otherwise I think this is a go. Edit: Okei, display('error: ') is a problem but only if they are in a autograder test cell, which are read only for the student, maybe that is safe enough.