### PR TITLE
Restrict access for students to different courses

### DIFF
--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1430,19 +1430,19 @@ class Gradebook(object):
                 print("Jupyterhub group: {group_name} created.".format(group_name=group_name) )
             utils.query_jupyterhub_api(method="POST",
                                  api_path="/groups/{name}/users".format(name=group_name),
-                                 post_data = {"users":[student_id]}
+                                 post_data = {"users":[student.id]}
             )
             # Saying student could be already here is because the post request returns 200 even if the student_id was already in the group
             print("Student {student} added or was already in the Jupyterhub group: {group_name}".format(
-                student=student_id,
+                student=student.id,
                 group_name=group_name
             ))
         except utils.JupyterhubEnvironmentError as e:
-            print("Not running on Jupyterhub, not adding {student} user to the Jupyterhub group {group_name}".format(student=student_id, group_name=group_name))
+            print("Not running on Jupyterhub, not adding {student} user to the Jupyterhub group {group_name}".format(student=student.id, group_name=group_name))
         except utils.JupyterhubApiError as e:
             if self.course_id: # We assume user might be using Jupyterhub but something is not working
                 err_msg = "Student {student} NOT added to the Jupyterhub group {group_name}: ".format(
-                    student=student_id,
+                    student=student.id,
                     group_name=group_name
                 )
             print(err_msg + str(e))

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1389,6 +1389,15 @@ class Gradebook(object):
             raise InvalidEntry(*e.args)
         return course_id_record
 
+    @property
+    def course_id(self):
+        try:
+            course_id_record = self.db.query(CourseID)\
+                .one()
+            return course_id_record.id
+        except NoResultFound:
+            raise MissingEntry("No course id")
+
     #### Students
 
     @property

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1532,7 +1532,7 @@ class Gradebook(object):
                 group_name = "nbgrader-{}".format(self.course_id)
                 utils.query_jupyterhub_api(method="DELETE",
                                      api_path="/groups/{name}/users".format(name=group_name),
-                                     post_data = {"users":[student_id]}
+                                     post_data = {"users":[student.id]}
                 )
                 # log.info
                 print("Student {student} removed from the Jupyterhub group {group_name}".format(student=name, group_name=group_name))

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1446,7 +1446,7 @@ class Gradebook(object):
                     group_name=group_name
                 )
             print(err_msg + str(e))
-            print("Make sure you set a valid api_token in your config file before starting the service")
+            print("Make sure you set a valid admin_user 'api_token' in your config file before starting the service")
 
     def add_student(self, student_id, **kwargs):
         """Add a new student to the database.

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -961,7 +961,20 @@ class Comment(Base):
         return "Comment<{}/{}/{} for {}>".format(
             self.assignment.name, self.notebook.name, self.name, self.student.id)
 
-# Needs manual grade
+class CourseID(Base):
+    """Table to store the course_id, it should have only one row"""
+
+    __tablename__ = "course_id"
+    __table_args__ = (UniqueConstraint("unique_check"),)
+
+    id = Column(String(128), unique=True, primary_key=True, nullable=False)
+    # This should help to prevent having 2 rows in this table
+    unique_check = Column(Boolean, unique=False, default=True)
+
+    def __repr__(self):
+        return "CourseID<{}>".format(self.name)
+
+## Needs manual grade
 
 SubmittedNotebook.needs_manual_grade = column_property(
     exists().where(and_(
@@ -1297,13 +1310,16 @@ class Gradebook(object):
 
     """
 
-    def __init__(self, db_url):
+    def __init__(self, db_url, course_id=""):
         """Initialize the connection to the database.
 
         Parameters
         ----------
         db_url : string
             The URL to the database, e.g. ``sqlite:///grades.db``
+        course_id : string, optional
+            identifier of the course necessary for supporting multiple classes
+            default course_id is '' to be consistent with :class:~`nbgrader.apps.api.NbGraderAPI`
 
         """
         # create the connection to the database
@@ -1320,6 +1336,8 @@ class Gradebook(object):
             self.db.execute("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL);")
             self.db.execute("INSERT INTO alembic_version (version_num) VALUES ('{}');".format(alembic_version))
             self.db.commit()
+
+        self.set_course_id(course_id)
 
     def __enter__(self):
         return self
@@ -1339,7 +1357,38 @@ class Gradebook(object):
         self.db.remove()
         self.engine.dispose()
 
-    # Students
+    def set_course_id(self, course_id, **kwargs):
+        """Set the course id
+
+        Parameters
+        ----------
+        course_id : string
+            The unique id of the course
+        `**kwargs` : dict
+            other keyword arguments to the :class:`~nbgrader.api.CourseID` object
+
+        Returns
+        -------
+        course_id : :class:`~nbgrader.api.CourseID`
+
+        """
+
+        try:
+            course_id_record = self.db.query(CourseID)\
+                .one()
+            course_id_record.id = course_id
+        except NoResultFound:
+            course_id_record = CourseID(id=course_id, **kwargs)
+            self.db.add(course_id_record)
+
+        try:
+            self.db.commit()
+        except (IntegrityError, FlushError) as e:
+            self.db.rollback()
+            raise InvalidEntry(*e.args)
+        return course_id_record
+
+    #### Students
 
     @property
     def students(self):

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1536,13 +1536,14 @@ class Gradebook(object):
                                      api_path="/groups/{name}/users".format(name=group_name),
                                      post_data = {"users":[student.id]}
                 )
-                # log.info
-                print("Student {student} removed or was not in the Jupyterhub group {group_name}".format(student=name, group_name=group_name))
-            except (utils.JupyterhubEnvironmentError, utils.JupyterhubApiError) as e:
-                if self.course_id: # We assume user might be using Jupyterhub but something is not working
-                    # log.error
-                    print("Student {student} NOT removed from the Jupyterhub group {group_name}: ".format(student=name, group_name=group_name) + str(e))
+                print("Student {student} was removed or was already not in the Jupyterhub group {group_name}".format(student=name, group_name=group_name))
+            except utils.JupyterhubEnvironmentError as e:
+                print("Not running on Jupyterhub so {student} was NOT removed from the Jupyterhub group {group_name}: ".format(student=name, group_name=group_name), str(e))
                 #self.log.error("Error caught in remove_student(): " + e)
+            except utils.JupyterhubApiError as e:
+                if self.course_id:
+                    print("Student {student} was NOT removed from the Jupyterhub group {group_name}: ".format(student=name, group_name=group_name), str(e))
+                    print("Make sure you start your service with a valid 'api_token' in your Jupyterhub config")
         except (IntegrityError, FlushError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1432,11 +1432,12 @@ class Gradebook(object):
                 jup_groups = utils.query_jupyterhub_api(method="GET",
                                      api_path="/groups",
                 )
-                if group_name not in [x['name'] for x in jup_groups]
+                if group_name not in [x['name'] for x in jup_groups]:
                     # This could result in a bad request(JupyterhubApiError) if there is already a group so first we check above if there is a group
                     utils.query_jupyterhub_api(method="POST",
                                          api_path="/groups/{name}".format(name=group_name),
                     )
+                    print("Jupyterhub group: {group_name} created.".format(group_name=group_name) )
                 utils.query_jupyterhub_api(method="POST",
                                      api_path="/groups/{name}/users".format(name=group_name),
                                      post_data = {"users":[student_id]}

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1442,7 +1442,7 @@ class Gradebook(object):
                     group_name=group_name
                 ))
             except (utils.JupyterhubEnvironmentError, utils.JupyterhubApiError) as e:
-                self.log.error("Error caught: " + e)
+                #self.log.error("Error caught: " + e) # self.log not working. Gradebook has no attribute log
                 if self.course_id: # we assume user might be using Jupyterhub but something is not working
                     # log.error 
                     # Note: check if log ever appears.
@@ -1450,10 +1450,10 @@ class Gradebook(object):
                         student=student_id,
                         group_name=group_name
                     )
-                    print(err_msg + e)
-                    self.log.error(err_msg)
+                    print(err_msg + str(e))
+                    #self.log.error(err_msg)
                 print("Make sure you set a valid api_token in your config file before starting the service")
-                self.log.error("Make sure you set a valid api_token in your config file before starting the service")
+                #self.log.error("Make sure you set a valid api_token in your config file before starting the service")
         except (IntegrityError, FlushError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)
@@ -1535,17 +1535,17 @@ class Gradebook(object):
 
             try:
                 group_name = "nbgrader-{}".format(self.course_id)
-                utils.query_jupyterhub_api(method="DELETE",
+                res = utils.query_jupyterhub_api(method="DELETE",
                                      api_path="/groups/{name}/users".format(name=group_name),
                                      post_data = {"users":[student.id]}
                 )
                 # log.info
-                print("Student {student} removed from the Jupyterhub group {group_name}".format(student=name, group_name=group_name))
+                print("Student {student} removed or was not in the Jupyterhub group {group_name}".format(student=name, group_name=group_name))
             except (utils.JupyterhubEnvironmentError, utils.JupyterhubApiError) as e:
                 if self.course_id: # we assume user might be using Jupyterhub but something is not working
                     # log.error
                     print("Student {student} NOT removed from the Jupyterhub group {group_name}: ".format(student=name, group_name=group_name) + str(e))
-                self.log.error("Error caught in remove_student(): " + e)
+                #self.log.error("Error caught in remove_student(): " + e)
         except (IntegrityError, FlushError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1429,14 +1429,18 @@ class Gradebook(object):
             self.db.commit()
             try:
                 group_name = "nbgrader-{}".format(self.course_id)
-                utils.query_jupyterhub_api(method="POST",
-                                     api_path="/groups/{name}".format(name=group_name),
+                jup_groups = utils.query_jupyterhub_api(method="GET",
+                                     api_path="/groups",
                 )
+                if group_name not in [x['name'] for x in jup_groups]
+                    # This could result in a bad request(JupyterhubApiError) if there is already a group so first we check above if there is a group
+                    utils.query_jupyterhub_api(method="POST",
+                                         api_path="/groups/{name}".format(name=group_name),
+                    )
                 utils.query_jupyterhub_api(method="POST",
                                      api_path="/groups/{name}/users".format(name=group_name),
                                      post_data = {"users":[student_id]}
                 )
-                # log.info
                 print("Student {student} added to Jupyterhub group {group_name}".format(
                     student=student_id,
                     group_name=group_name

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1541,11 +1541,11 @@ class Gradebook(object):
                 )
                 # log.info
                 print("Student {student} removed from the Jupyterhub group {group_name}".format(student=name, group_name=group_name))
-            except utils.JupyterhubEnvironmentError as e:
+            except (utils.JupyterhubEnvironmentError, utils.JupyterhubApiError) as e:
                 if self.course_id: # we assume user might be using Jupyterhub but something is not working
                     # log.error
                     print("Student {student} NOT removed from the Jupyterhub group {group_name}: ".format(student=name, group_name=group_name) + str(e))
-
+                self.log.error("Error caught in remove_student(): " + e)
         except (IntegrityError, FlushError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1441,19 +1441,16 @@ class Gradebook(object):
                     student=student_id,
                     group_name=group_name
                 ))
-            except (utils.JupyterhubEnvironmentError, utils.JupyterhubApiError) as e:
-                #self.log.error("Error caught: " + e) # self.log not working. Gradebook has no attribute log
-                if self.course_id: # we assume user might be using Jupyterhub but something is not working
-                    # log.error 
-                    # Note: check if log ever appears.
+            except utils.JupyterhubEnvironmentError as e:
+                print("Not running on Jupyterhub, not adding {student} user to Jupyterhub group {group_name}".format(student=student_id, group_name=group_name))
+            except utils.JupyterhubApiError as e:
+                if self.course_id: # We assume user might be using Jupyterhub but something is not working
                     err_msg = "Student {student} NOT added to Jupyterhub group {group_name}: ".format(
                         student=student_id,
                         group_name=group_name
                     )
-                    print(err_msg + str(e))
-                    #self.log.error(err_msg)
+                print(err_msg + str(e))
                 print("Make sure you set a valid api_token in your config file before starting the service")
-                #self.log.error("Make sure you set a valid api_token in your config file before starting the service")
         except (IntegrityError, FlushError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -965,11 +965,8 @@ class CourseID(Base):
     """Table to store the course_id, it should have only one row"""
 
     __tablename__ = "course_id"
-    __table_args__ = (UniqueConstraint("unique_check"),)
 
     id = Column(String(128), unique=True, primary_key=True, nullable=False)
-    # This should help to prevent having 2 rows in this table
-    unique_check = Column(Boolean, unique=False, default=True)
 
     def __repr__(self):
         return "CourseID<{}>".format(self.name)

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1542,7 +1542,7 @@ class Gradebook(object):
                 # log.info
                 print("Student {student} removed or was not in the Jupyterhub group {group_name}".format(student=name, group_name=group_name))
             except (utils.JupyterhubEnvironmentError, utils.JupyterhubApiError) as e:
-                if self.course_id: # we assume user might be using Jupyterhub but something is not working
+                if self.course_id: # We assume user might be using Jupyterhub but something is not working
                     # log.error
                     print("Student {student} NOT removed from the Jupyterhub group {group_name}: ".format(student=name, group_name=group_name) + str(e))
                 #self.log.error("Error caught in remove_student(): " + e)

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1432,6 +1432,7 @@ class Gradebook(object):
                 jup_groups = utils.query_jupyterhub_api(method="GET",
                                      api_path="/groups",
                 )
+                self.log.info([x['name'] for x in jup_groups])
                 if group_name not in [x['name'] for x in jup_groups]:
                     # This could result in a bad request(JupyterhubApiError) if there is already a group so first we check above if there is a group
                     utils.query_jupyterhub_api(method="POST",
@@ -1442,15 +1443,15 @@ class Gradebook(object):
                                      api_path="/groups/{name}/users".format(name=group_name),
                                      post_data = {"users":[student_id]}
                 )
-                print("Student {student} added to Jupyterhub group {group_name}".format(
+                print("Student {student} added to the Jupyterhub group {group_name}".format(
                     student=student_id,
                     group_name=group_name
                 ))
             except utils.JupyterhubEnvironmentError as e:
-                print("Not running on Jupyterhub, not adding {student} user to Jupyterhub group {group_name}".format(student=student_id, group_name=group_name))
+                print("Not running on Jupyterhub, not adding {student} user to the Jupyterhub group {group_name}".format(student=student_id, group_name=group_name))
             except utils.JupyterhubApiError as e:
                 if self.course_id: # We assume user might be using Jupyterhub but something is not working
-                    err_msg = "Student {student} NOT added to Jupyterhub group {group_name}: ".format(
+                    err_msg = "Student {student} NOT added to the Jupyterhub group {group_name}: ".format(
                         student=student_id,
                         group_name=group_name
                     )

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1544,7 +1544,6 @@ class Gradebook(object):
                 print("Student {student} was removed or was already not in the Jupyterhub group {group_name}".format(student=name, group_name=group_name))
             except utils.JupyterhubEnvironmentError as e:
                 print("Not running on Jupyterhub so {student} was NOT removed from the Jupyterhub group {group_name}:".format(student=name, group_name=group_name), str(e))
-                #self.log.error("Error caught in remove_student(): " + e)
             except utils.JupyterhubApiError as e:
                 if self.course_id:
                     print("Student {student} was NOT removed from the Jupyterhub group {group_name}:".format(student=name, group_name=group_name), str(e))

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1547,7 +1547,7 @@ class Gradebook(object):
             except utils.JupyterhubApiError as e:
                 if self.course_id:
                     print("Student {student} was NOT removed from the Jupyterhub group {group_name}:".format(student=name, group_name=group_name), str(e))
-                    print("Make sure you start your service with a valid 'api_token' in your Jupyterhub config")
+                    print("Make sure you start your service with a valid admin_user 'api_token' in your Jupyterhub config")
         except (IntegrityError, FlushError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1427,6 +1427,20 @@ class Gradebook(object):
         self.db.add(student)
         try:
             self.db.commit()
+            try:
+                group_name = "nbgrader-{}".format(self.course_id)
+                utils.query_jupyterhub_api(method="POST",
+                                     api_path="/groups/{name}".format(name=group_name),
+                )
+                utils.query_jupyterhub_api(method="POST",
+                                     api_path="/groups/{name}/users".format(name=group_name),
+                                     post_data = {"users":[student_id]}
+                )
+            except utils.JupyterhubEnvironmentError as e:
+                if self.course_id: # we assume user might be using Jupyterhub but something is not working
+                    #FIXME how do we access the logger from here?
+                    print("Student {student} not added to the Jupyterhub group, error: ".format(name) + str(e))
+
         except (IntegrityError, FlushError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)
@@ -1505,6 +1519,18 @@ class Gradebook(object):
 
         try:
             self.db.commit()
+
+            try:
+                group_name = "nbgrader-{}".format(self.course_id)
+                utils.query_jupyterhub_api(method="DELETE",
+                                     api_path="/groups/{name}/users".format(name=group_name),
+                                     post_data = {"users":[student_id]}
+                )
+            except utils.JupyterhubEnvironmentError as e:
+                if self.course_id: # we assume user might be using Jupyterhub but something is not working
+                    #FIXME how do we access the logger from here?
+                    print("Student {student} not removed to the Jupyterhub group, error: ".format(name) + str(e))
+
         except (IntegrityError, FlushError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1432,7 +1432,6 @@ class Gradebook(object):
                 jup_groups = utils.query_jupyterhub_api(method="GET",
                                      api_path="/groups",
                 )
-                self.log.info([x['name'] for x in jup_groups])
                 if group_name not in [x['name'] for x in jup_groups]:
                     # This could result in a bad request(JupyterhubApiError) if there is already a group so first we check above if there is a group
                     utils.query_jupyterhub_api(method="POST",

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1376,7 +1376,8 @@ class Gradebook(object):
         try:
             course_id_record = self.db.query(CourseID)\
                 .one()
-            course_id_record.id = course_id
+            if course_id: # update id only if not empty
+                course_id_record.id = course_id
         except NoResultFound:
             course_id_record = CourseID(id=course_id, **kwargs)
             self.db.add(course_id_record)

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1444,11 +1444,15 @@ class Gradebook(object):
             except (utils.JupyterhubEnvironmentError, utils.JupyterhubApiError) as e:
                 self.log.error("Error caught: " + e)
                 if self.course_id: # we assume user might be using Jupyterhub but something is not working
-                    # log.error
-                    self.log.error("Student {student} NOT added to Jupyterhub group {group_name}: ".format(
+                    # log.error 
+                    # Note: check if log ever appears.
+                    err_msg = "Student {student} NOT added to Jupyterhub group {group_name}: ".format(
                         student=student_id,
                         group_name=group_name
-                    ))
+                    )
+                    print(err_msg + e)
+                    self.log.error(err_msg)
+                print("Make sure you set a valid api_token in your config file before starting the service")
                 self.log.error("Make sure you set a valid api_token in your config file before starting the service")
         except (IntegrityError, FlushError) as e:
             self.db.rollback()

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1468,7 +1468,7 @@ class Gradebook(object):
         self.db.add(student)
         try:
             self.db.commit()
-            add_student_to_group(student)
+            self.add_student_to_group(student)
                 
         except (IntegrityError, FlushError) as e:
             self.db.rollback()
@@ -1524,7 +1524,7 @@ class Gradebook(object):
                 setattr(student, attr, kwargs[attr])
             try:
                 self.db.commit()
-                add_student_to_group(student)
+                self.add_student_to_group(student)
             except (IntegrityError, FlushError) as e:
                 self.db.rollback()
                 raise InvalidEntry(*e.args)

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1436,10 +1436,18 @@ class Gradebook(object):
                                      api_path="/groups/{name}/users".format(name=group_name),
                                      post_data = {"users":[student_id]}
                 )
+                # log.info
+                print("Student {student} added to Jupyterhub group {group_name}".format(
+                    student=student_id,
+                    group_name=group_name
+                ))
             except utils.JupyterhubEnvironmentError as e:
                 if self.course_id: # we assume user might be using Jupyterhub but something is not working
-                    #FIXME how do we access the logger from here?
-                    print("Student {student} not added to the Jupyterhub group, error: ".format(name) + str(e))
+                    # log.error
+                    print("Student {student} NOT added to Jupyterhub group {group_name}: ".format(
+                        student=student_id,
+                        group_name=group_name
+                    ) + str(e))
 
         except (IntegrityError, FlushError) as e:
             self.db.rollback()
@@ -1526,10 +1534,12 @@ class Gradebook(object):
                                      api_path="/groups/{name}/users".format(name=group_name),
                                      post_data = {"users":[student_id]}
                 )
+                # log.info
+                print("Student {student} removed from the Jupyterhub group {group_name}".format(student=name, group_name=group_name))
             except utils.JupyterhubEnvironmentError as e:
                 if self.course_id: # we assume user might be using Jupyterhub but something is not working
-                    #FIXME how do we access the logger from here?
-                    print("Student {student} not removed to the Jupyterhub group, error: ".format(name) + str(e))
+                    # log.error
+                    print("Student {student} NOT removed from the Jupyterhub group {group_name}: ".format(student=name, group_name=group_name) + str(e))
 
         except (IntegrityError, FlushError) as e:
             self.db.rollback()

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -961,7 +961,7 @@ class Comment(Base):
         return "Comment<{}/{}/{} for {}>".format(
             self.assignment.name, self.notebook.name, self.name, self.student.id)
 
-class CourseID(Base):
+class Course(Base):
     """Table to store the course_id, it should have only one row"""
 
     __tablename__ = "course_id"
@@ -969,7 +969,7 @@ class CourseID(Base):
     id = Column(String(128), unique=True, primary_key=True, nullable=False)
 
     def __repr__(self):
-        return "CourseID<{}>".format(self.name)
+        return "Course<{}>".format(self.name)
 
 ## Needs manual grade
 
@@ -1362,21 +1362,21 @@ class Gradebook(object):
         course_id : string
             The unique id of the course
         `**kwargs` : dict
-            other keyword arguments to the :class:`~nbgrader.api.CourseID` object
+            other keyword arguments to the :class:`~nbgrader.api.Course` object
 
         Returns
         -------
-        course_id : :class:`~nbgrader.api.CourseID`
+        course_id : :class:`~nbgrader.api.Course`
 
         """
 
         try:
-            course_id_record = self.db.query(CourseID)\
+            course_id_record = self.db.query(Course)\
                 .one()
             if course_id: # update id only if not empty
                 course_id_record.id = course_id
         except NoResultFound:
-            course_id_record = CourseID(id=course_id, **kwargs)
+            course_id_record = Course(id=course_id, **kwargs)
             self.db.add(course_id_record)
 
         try:
@@ -1389,7 +1389,7 @@ class Gradebook(object):
     @property
     def course_id(self):
         try:
-            course_id_record = self.db.query(CourseID)\
+            course_id_record = self.db.query(Course)\
                 .one()
             return course_id_record.id
         except NoResultFound:

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1543,11 +1543,11 @@ class Gradebook(object):
                 )
                 print("Student {student} was removed or was already not in the Jupyterhub group {group_name}".format(student=name, group_name=group_name))
             except utils.JupyterhubEnvironmentError as e:
-                print("Not running on Jupyterhub so {student} was NOT removed from the Jupyterhub group {group_name}: ".format(student=name, group_name=group_name), str(e))
+                print("Not running on Jupyterhub so {student} was NOT removed from the Jupyterhub group {group_name}:".format(student=name, group_name=group_name), str(e))
                 #self.log.error("Error caught in remove_student(): " + e)
             except utils.JupyterhubApiError as e:
                 if self.course_id:
-                    print("Student {student} was NOT removed from the Jupyterhub group {group_name}: ".format(student=name, group_name=group_name), str(e))
+                    print("Student {student} was NOT removed from the Jupyterhub group {group_name}:".format(student=name, group_name=group_name), str(e))
                     print("Make sure you start your service with a valid 'api_token' in your Jupyterhub config")
         except (IntegrityError, FlushError) as e:
             self.db.rollback()

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1442,13 +1442,13 @@ class Gradebook(object):
                     group_name=group_name
                 ))
             except (utils.JupyterhubEnvironmentError, utils.JupyterhubApiError) as e:
-
+                self.log.error("Error caught: " + e)
                 if self.course_id: # we assume user might be using Jupyterhub but something is not working
                     # log.error
                     self.log.error("Student {student} NOT added to Jupyterhub group {group_name}: ".format(
                         student=student_id,
                         group_name=group_name
-                    ) + str(e))
+                    ))
                 self.log.error("Make sure you set a valid api_token in your config file before starting the service")
         except (IntegrityError, FlushError) as e:
             self.db.rollback()

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1441,14 +1441,15 @@ class Gradebook(object):
                     student=student_id,
                     group_name=group_name
                 ))
-            except utils.JupyterhubEnvironmentError as e:
+            except (utils.JupyterhubEnvironmentError, utils.JupyterhubApiError) as e:
+
                 if self.course_id: # we assume user might be using Jupyterhub but something is not working
                     # log.error
-                    print("Student {student} NOT added to Jupyterhub group {group_name}: ".format(
+                    self.log.error("Student {student} NOT added to Jupyterhub group {group_name}: ".format(
                         student=student_id,
                         group_name=group_name
                     ) + str(e))
-
+                self.log.error("Make sure you set a valid api_token in your config file before starting the service")
         except (IntegrityError, FlushError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)

--- a/nbgrader/apps/api.py
+++ b/nbgrader/apps/api.py
@@ -95,7 +95,7 @@ class NbGraderAPI(LoggingConfigurable):
         :func:`~nbgrader.api.Gradebook.close`.
 
         """
-        return Gradebook(self.coursedir.db_url)
+        return Gradebook(self.coursedir.db_url, self.course_id)
 
     def get_source_assignments(self):
         """Get the names of all assignments in the `source` directory.

--- a/nbgrader/apps/dbapp.py
+++ b/nbgrader/apps/dbapp.py
@@ -381,24 +381,6 @@ class DbAssignmentImportApp(DbGenericImportApp):
         super(DbAssignmentImportApp, self).__init__(*args, **kwargs)
         self.excluded_keys = ["id"]
 
-    with Gradebook(self.coursedir.db_url, self.course_id) as gb:
-        with open(path, 'r') as fh:
-            reader = csv.DictReader(fh)
-            for row in reader:
-                if "name" not in row:
-                    self.fail("Malformatted CSV file: must contain a column for 'name'")
-
-                # make sure all the keys are actually allowed in the database,
-                # and that any empty strings are parsed as None
-                assignment = {}
-                for key, val in row.items():
-                    if key not in allowed_keys:
-                        continue
-                    if val == '':
-                        assignment[key] = None
-                    else:
-                        assignment[key] = val
-                assignment_id = assignment.pop("name")
     @property
     def table_class(self):
         return Assignment

--- a/nbgrader/apps/dbapp.py
+++ b/nbgrader/apps/dbapp.py
@@ -3,6 +3,7 @@
 
 import csv
 import os
+import sys
 import shutil
 
 from textwrap import dedent
@@ -11,6 +12,7 @@ from datetime import datetime
 
 from . import NbGrader
 from ..api import Gradebook, MissingEntry, Student, Assignment
+from ..exchange import ExchangeList, ExchangeError
 from .. import dbutil
 
 aliases = {
@@ -28,7 +30,17 @@ student_add_aliases.update({
     'email': 'DbStudentAddApp.email'
 })
 
-class DbStudentAddApp(NbGrader):
+class DbBaseApp(NbGrader):
+
+    def start(self):
+        if sys.platform != 'win32':
+            lister = ExchangeList(coursedir=self.coursedir, parent=self)
+            self.course_id = lister.course_id
+        else:
+            self.course_id = ''
+        super(DbBaseApp, self).start()
+
+class DbStudentAddApp(DbBaseApp):
 
     name = u'nbgrader-db-student-add'
     description = u'Add a student to the nbgrader database'
@@ -68,7 +80,7 @@ class DbStudentAddApp(NbGrader):
         }
 
         self.log.info("Creating/updating student with ID '%s': %s", student_id, student)
-        with Gradebook(self.coursedir.db_url) as gb:
+        with Gradebook(self.coursedir.db_url, self.course_id) as gb:
             gb.update_or_create_student(student_id, **student)
 
 student_remove_flags = {}
@@ -84,7 +96,7 @@ student_remove_flags.update({
     ),
 })
 
-class DbStudentRemoveApp(NbGrader):
+class DbStudentRemoveApp(DbBaseApp):
 
     name = u'nbgrader-db-student-remove'
     description = u'Remove a student from the nbgrader database'
@@ -102,7 +114,7 @@ class DbStudentRemoveApp(NbGrader):
 
         student_id = self.extra_args[0]
 
-        with Gradebook(self.coursedir.db_url) as gb:
+        with Gradebook(self.coursedir.db_url, self.course_id) as gb:
             try:
                 student = gb.find_student(student_id)
             except MissingEntry:
@@ -120,7 +132,7 @@ class DbStudentRemoveApp(NbGrader):
             gb.remove_student(student_id)
 
 
-class DbGenericImportApp(NbGrader):
+class DbGenericImportApp(DbBaseApp):
 
     aliases = aliases
     flags = flags
@@ -196,7 +208,7 @@ class DbGenericImportApp(NbGrader):
         self.log.info("Importing from: '%s'", path)
 
 
-        with Gradebook(self.coursedir.db_url) as gb:
+        with Gradebook(self.coursedir.db_url, self.course_id) as gb:
             with open(path, 'r') as fh:
                 reader = csv.DictReader(fh)
                 reader.fieldnames = self._preprocess_keys(reader.fieldnames)
@@ -258,7 +270,7 @@ class DbStudentImportApp(DbGenericImportApp):
         return "update_or_create_student"
 
 
-class DbStudentListApp(NbGrader):
+class DbStudentListApp(DbBaseApp):
 
     name = u'nbgrader-db-student-list'
     description = u'List students in the nbgrader database'
@@ -269,7 +281,7 @@ class DbStudentListApp(NbGrader):
     def start(self):
         super(DbStudentListApp, self).start()
 
-        with Gradebook(self.coursedir.db_url) as gb:
+        with Gradebook(self.coursedir.db_url, self.course_id) as gb:
             print("There are %d students in the database:" % len(gb.students))
             for student in gb.students:
                 print("%s (%s, %s) -- %s" % (student.id, student.last_name, student.first_name, student.email))
@@ -281,7 +293,7 @@ assignment_add_aliases.update({
     'duedate': 'DbAssignmentAddApp.duedate',
 })
 
-class DbAssignmentAddApp(NbGrader):
+class DbAssignmentAddApp(DbBaseApp):
 
     name = u'nbgrader-db-assignment-add'
     description = u'Add an assignment to the nbgrader database'
@@ -307,7 +319,7 @@ class DbAssignmentAddApp(NbGrader):
         }
 
         self.log.info("Creating/updating assignment with ID '%s': %s", assignment_id, assignment)
-        with Gradebook(self.coursedir.db_url) as gb:
+        with Gradebook(self.coursedir.db_url, self.course_id) as gb:
             gb.update_or_create_assignment(assignment_id, **assignment)
 
 
@@ -324,7 +336,7 @@ assignment_remove_flags.update({
     ),
 })
 
-class DbAssignmentRemoveApp(NbGrader):
+class DbAssignmentRemoveApp(DbBaseApp):
 
     name = u'nbgrader-db-assignment-remove'
     description = u'Remove an assignment from the nbgrader database'
@@ -342,7 +354,7 @@ class DbAssignmentRemoveApp(NbGrader):
 
         assignment_id = self.extra_args[0]
 
-        with Gradebook(self.coursedir.db_url) as gb:
+        with Gradebook(self.coursedir.db_url, self.course_id) as gb:
             try:
                 assignment = gb.find_assignment(assignment_id)
             except MissingEntry:
@@ -369,6 +381,24 @@ class DbAssignmentImportApp(DbGenericImportApp):
         super(DbAssignmentImportApp, self).__init__(*args, **kwargs)
         self.excluded_keys = ["id"]
 
+    with Gradebook(self.coursedir.db_url, self.course_id) as gb:
+        with open(path, 'r') as fh:
+            reader = csv.DictReader(fh)
+            for row in reader:
+                if "name" not in row:
+                    self.fail("Malformatted CSV file: must contain a column for 'name'")
+
+                # make sure all the keys are actually allowed in the database,
+                # and that any empty strings are parsed as None
+                assignment = {}
+                for key, val in row.items():
+                    if key not in allowed_keys:
+                        continue
+                    if val == '':
+                        assignment[key] = None
+                    else:
+                        assignment[key] = val
+                assignment_id = assignment.pop("name")
     @property
     def table_class(self):
         return Assignment
@@ -381,7 +411,7 @@ class DbAssignmentImportApp(DbGenericImportApp):
     def db_update_method_name(self):
         return "update_or_create_assignment"
 
-class DbAssignmentListApp(NbGrader):
+class DbAssignmentListApp(DbBaseApp):
 
     name = u'nbgrader-db-assignment-list'
     description = u'List assignments int the nbgrader database'
@@ -392,7 +422,7 @@ class DbAssignmentListApp(NbGrader):
     def start(self):
         super(DbAssignmentListApp, self).start()
 
-        with Gradebook(self.coursedir.db_url) as gb:
+        with Gradebook(self.coursedir.db_url, self.course_id) as gb:
             print("There are %d assignments in the database:" % len(gb.assignments))
             for assignment in gb.assignments:
                 print("%s (due: %s)" % (assignment.name, assignment.duedate))
@@ -400,7 +430,7 @@ class DbAssignmentListApp(NbGrader):
                     print("    - %s" % notebook.name)
 
 
-class DbStudentApp(NbGrader):
+class DbStudentApp(DbBaseApp):
 
     name = u'nbgrader-db-student'
     description = u'Modify or list students in the nbgrader database'
@@ -433,7 +463,7 @@ class DbStudentApp(NbGrader):
         super(DbStudentApp, self).start()
 
 
-class DbAssignmentApp(NbGrader):
+class DbAssignmentApp(DbBaseApp):
 
     name = u'nbgrader-db-assignment'
     description = u'Modify or list assignments in the nbgrader database'
@@ -467,7 +497,7 @@ class DbAssignmentApp(NbGrader):
         super(DbAssignmentApp, self).start()
 
 
-class DbUpgradeApp(NbGrader):
+class DbUpgradeApp(DbBaseApp):
     """Based on the `jupyterhub upgrade-db` command found in jupyterhub.app.UpgradeDB"""
 
     name = u'nbgrader-db-upgrade'
@@ -476,7 +506,7 @@ class DbUpgradeApp(NbGrader):
     def _backup_db_file(self, db_file):
         """Backup a database file"""
         if not os.path.exists(db_file):
-            with Gradebook("sqlite:///{}".format(db_file)):
+            with Gradebook("sqlite:///{}".format(db_file), self.course_id):
                 pass
 
         timestamp = datetime.now().strftime('.%Y-%m-%d-%H%M%S.%f')
@@ -496,7 +526,7 @@ class DbUpgradeApp(NbGrader):
         dbutil.upgrade(self.coursedir.db_url)
 
 
-class DbApp(NbGrader):
+class DbApp(DbBaseApp):
 
     name = u'nbgrader-db'
     description = u'Perform operations on the nbgrader database'

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -149,7 +149,7 @@ class Exchange(LoggingConfigurable):
 
     def get_current_user_courses(self):
         """Check if student is enrolled in course"""
-        groups = call_jupyterhub_api('GET', '/users/%s' % user)['groups']
+        groups = query_jupyterhub_api('GET', '/users/%s' % user)['groups']
         courses = set()
         for group in groups:
             if group.startswith('nbgrader-') or group.startswith('formgrade-'):

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -3,6 +3,7 @@ import datetime
 import sys
 import shutil
 import glob
+import json
 
 from textwrap import dedent
 
@@ -161,7 +162,6 @@ class Exchange(LoggingConfigurable):
             user = os.environ['JUPYTERHUB_USER']
         else:
             sys.exit("JUPYTERHUB_USER env is required to run the exchange features of nbgrader.")
-        import json
         auth_header = {
                 'Authorization': 'token %s' % api_token
             }

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -176,5 +176,5 @@ class Exchange(LoggingConfigurable):
         courses = set()
         for group in groups:
             if group.startswith('nbgrader-') or group.startswith('formgrade-'):
-                courses.add('-'.join(group.split('-')[1:]))
+                courses.add(group.split('-', 1)[1])
         return list(courses)

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -150,32 +150,23 @@ class Exchange(LoggingConfigurable):
 
     def get_current_user_courses(self):
         """Check if student is enrolled in course"""
-        from jupyterhub.services.auth import HubOAuth
         from tornado.httpclient import HTTPClient, HTTPRequest
 
         if os.getenv('JUPYTERHUB_API_TOKEN'):
             api_token = os.environ['JUPYTERHUB_API_TOKEN']
-        if not api_token:
-            self.exit("JUPYTERHUB_API_TOKEN env is required to run nbgrader. Did you launch it manually?")
+        else:
+            self.exit("JUPYTERHUB_API_TOKEN env is required to run the exchange features of nbgrader.")
         hub_api_url = os.environ.get('JUPYTERHUB_API_URL') or 'http://127.0.0.1:8081/hub/api'
-        base_url = os.environ.get('JUPYTERHUB_SERVICE_PREFIX') or '/'
-        hub_prefix = base_url + "hub/"
-        self.hub_auth = HubOAuth(
-            parent=self,
-            api_token=api_token,
-            api_url=hub_api_url,
-            hub_prefix=hub_prefix,
-            base_url=base_url,
-        )
+        if os.getenv('JUPYTERHUB_USER'):
+            user = os.environ['JUPYTERHUB_USER']
+        else:
+            self.exit("JUPYTERHUB_USER env is required to run the exchange features of nbgrader.")
         import json
-        # smoke check
-        if not self.hub_auth.oauth_client_id:
-            raise ValueError("Missing OAuth client ID")
         auth_header = {
                 'Authorization': 'token %s' % api_token
             }
         client = HTTPClient()
-        req = HTTPRequest(url=hub_api_url + '/users/%s' % self.hub_auth.oauth_client_id.replace('user-', ''),
+        req = HTTPRequest(url=hub_api_url + '/users/%s' % user,
             method='GET',
             headers=auth_header,
         )

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -155,12 +155,12 @@ class Exchange(LoggingConfigurable):
         if os.getenv('JUPYTERHUB_API_TOKEN'):
             api_token = os.environ['JUPYTERHUB_API_TOKEN']
         else:
-            self.exit("JUPYTERHUB_API_TOKEN env is required to run the exchange features of nbgrader.")
+            sys.exit("JUPYTERHUB_API_TOKEN env is required to run the exchange features of nbgrader.")
         hub_api_url = os.environ.get('JUPYTERHUB_API_URL') or 'http://127.0.0.1:8081/hub/api'
         if os.getenv('JUPYTERHUB_USER'):
             user = os.environ['JUPYTERHUB_USER']
         else:
-            self.exit("JUPYTERHUB_USER env is required to run the exchange features of nbgrader.")
+            sys.exit("JUPYTERHUB_USER env is required to run the exchange features of nbgrader.")
         import json
         auth_header = {
                 'Authorization': 'token %s' % api_token

--- a/nbgrader/exchange/fetch.py
+++ b/nbgrader/exchange/fetch.py
@@ -14,7 +14,7 @@ class ExchangeFetch(Exchange):
     def init_src(self):
         if self.course_id == '':
             self.fail("No course id specified. Re-run with --course flag.")
-        courses = self.get_current_user_courses()
+        courses = self.get_user_courses(self.coursedir.student_id)
         if not self.course_id in courses:
             self.fail("You do not have access to this course.")
 

--- a/nbgrader/exchange/fetch.py
+++ b/nbgrader/exchange/fetch.py
@@ -14,6 +14,9 @@ class ExchangeFetch(Exchange):
     def init_src(self):
         if self.course_id == '':
             self.fail("No course id specified. Re-run with --course flag.")
+        courses = self.get_current_user_courses()
+        if not self.course_id in courses:
+            self.fail("You do not have access to this course.")
 
         self.course_path = os.path.join(self.root, self.course_id)
         self.outbound_path = os.path.join(self.course_path, 'outbound')

--- a/nbgrader/exchange/list.py
+++ b/nbgrader/exchange/list.py
@@ -58,36 +58,37 @@ class ExchangeList(Exchange):
 
     def parse_assignments(self):
         assignments = []
-        courses = self.get_current_user_courses()
-        for path in self.assignments:
-            info = self.parse_assignment(path)
-            if info['course_id'] in courses:
-                if self.path_includes_course:
-                    root = os.path.join(info['course_id'], info['assignment_id'])
-                else:
-                    root = info['assignment_id']
+        if self.coursedir.student_id:
+            courses = self.get_user_courses(self.coursedir.student_id)
+            for path in self.assignments:
+                info = self.parse_assignment(path)
+                if info['course_id'] in courses:
+                    if self.path_includes_course:
+                        root = os.path.join(info['course_id'], info['assignment_id'])
+                    else:
+                        root = info['assignment_id']
 
-                if self.inbound or self.cached:
-                    info['status'] = 'submitted'
-                    info['path'] = path
-                elif os.path.exists(root):
-                    info['status'] = 'fetched'
-                    info['path'] = os.path.abspath(root)
-                else:
-                    info['status'] = 'released'
-                    info['path'] = path
+                    if self.inbound or self.cached:
+                        info['status'] = 'submitted'
+                        info['path'] = path
+                    elif os.path.exists(root):
+                        info['status'] = 'fetched'
+                        info['path'] = os.path.abspath(root)
+                    else:
+                        info['status'] = 'released'
+                        info['path'] = path
 
-                if self.remove:
-                    info['status'] = 'removed'
+                    if self.remove:
+                        info['status'] = 'removed'
 
-                info['notebooks'] = []
-                for notebook in sorted(glob.glob(os.path.join(info['path'], '*.ipynb'))):
-                    info['notebooks'].append({
-                        'notebook_id': os.path.splitext(os.path.split(notebook)[1])[0],
-                        'path': os.path.abspath(notebook)
-                    })
+                    info['notebooks'] = []
+                    for notebook in sorted(glob.glob(os.path.join(info['path'], '*.ipynb'))):
+                        info['notebooks'].append({
+                            'notebook_id': os.path.splitext(os.path.split(notebook)[1])[0],
+                            'path': os.path.abspath(notebook)
+                        })
 
-                assignments.append(info)
+                    assignments.append(info)
 
         return assignments
 

--- a/nbgrader/exchange/list.py
+++ b/nbgrader/exchange/list.py
@@ -58,34 +58,36 @@ class ExchangeList(Exchange):
 
     def parse_assignments(self):
         assignments = []
+        courses = self.get_current_user_courses()
         for path in self.assignments:
             info = self.parse_assignment(path)
-            if self.path_includes_course:
-                root = os.path.join(info['course_id'], info['assignment_id'])
-            else:
-                root = info['assignment_id']
+            if info['course_id'] in courses:
+                if self.path_includes_course:
+                    root = os.path.join(info['course_id'], info['assignment_id'])
+                else:
+                    root = info['assignment_id']
 
-            if self.inbound or self.cached:
-                info['status'] = 'submitted'
-                info['path'] = path
-            elif os.path.exists(root):
-                info['status'] = 'fetched'
-                info['path'] = os.path.abspath(root)
-            else:
-                info['status'] = 'released'
-                info['path'] = path
+                if self.inbound or self.cached:
+                    info['status'] = 'submitted'
+                    info['path'] = path
+                elif os.path.exists(root):
+                    info['status'] = 'fetched'
+                    info['path'] = os.path.abspath(root)
+                else:
+                    info['status'] = 'released'
+                    info['path'] = path
 
-            if self.remove:
-                info['status'] = 'removed'
+                if self.remove:
+                    info['status'] = 'removed'
 
-            info['notebooks'] = []
-            for notebook in sorted(glob.glob(os.path.join(info['path'], '*.ipynb'))):
-                info['notebooks'].append({
-                    'notebook_id': os.path.splitext(os.path.split(notebook)[1])[0],
-                    'path': os.path.abspath(notebook)
-                })
+                info['notebooks'] = []
+                for notebook in sorted(glob.glob(os.path.join(info['path'], '*.ipynb'))):
+                    info['notebooks'].append({
+                        'notebook_id': os.path.splitext(os.path.split(notebook)[1])[0],
+                        'path': os.path.abspath(notebook)
+                    })
 
-            assignments.append(info)
+                assignments.append(info)
 
         return assignments
 

--- a/nbgrader/exchange/submit.py
+++ b/nbgrader/exchange/submit.py
@@ -45,6 +45,9 @@ class ExchangeSubmit(Exchange):
     def init_dest(self):
         if self.course_id == '':
             self.fail("No course id specified. Re-run with --course flag.")
+        courses = self.get_current_user_courses()
+        if not self.course_id in courses:
+            self.fail("You do not have access to this course.")
 
         self.inbound_path = os.path.join(self.root, self.course_id, 'inbound')
         if not os.path.isdir(self.inbound_path):

--- a/nbgrader/exchange/submit.py
+++ b/nbgrader/exchange/submit.py
@@ -45,7 +45,7 @@ class ExchangeSubmit(Exchange):
     def init_dest(self):
         if self.course_id == '':
             self.fail("No course id specified. Re-run with --course flag.")
-        courses = self.get_current_user_courses()
+        courses = self.get_user_courses(self.coursedir.student_id)
         if not self.course_id in courses:
             self.fail("You do not have access to this course.")
 

--- a/nbgrader/server_extensions/assignment_list/handlers.py
+++ b/nbgrader/server_extensions/assignment_list/handlers.py
@@ -229,7 +229,7 @@ class CourseListHandler(BaseAssignmentHandler):
     @web.authenticated
     def get(self):
         courses_list = self.manager.list_courses()
-        if 'value' in courses_list:
+        if courses_list['success'] and 'value' in courses_list:
             courses_list['value'] = [course for course in courses_list['value'] if 'nbgrader-{}'.format(course) in self.current_user['groups']]
         self.finish(json.dumps(courses_list))
 

--- a/nbgrader/server_extensions/assignment_list/handlers.py
+++ b/nbgrader/server_extensions/assignment_list/handlers.py
@@ -230,7 +230,7 @@ class CourseListHandler(BaseAssignmentHandler):
     def get(self):
         courses_list = self.manager.list_courses()
         if courses_list['success'] and 'value' in courses_list:
-            courses_list['value'] = [course for course in courses_list['value'] if 'nbgrader-{}'.format(course) in self.current_user['groups']]
+            courses_list['value'] = [course for course in courses_list['value'] if 'nbgrader-{}'.format(course) in self.current_user['groups'] or 'formgrade-{}'.format(course) in self.current_user['groups']]
         self.finish(json.dumps(courses_list))
 
 

--- a/nbgrader/server_extensions/assignment_list/handlers.py
+++ b/nbgrader/server_extensions/assignment_list/handlers.py
@@ -228,7 +228,10 @@ class CourseListHandler(BaseAssignmentHandler):
 
     @web.authenticated
     def get(self):
-        self.finish(json.dumps(self.manager.list_courses()))
+        courses_list = self.manager.list_courses()
+        if 'value' in courses_list:
+            courses_list['value'] = [course for course in courses_list['value'] if 'nbgrader-{}'.format(course) in self.current_user['groups']]
+        self.finish(json.dumps(courses_list))
 
 
 class NbGraderVersionHandler(BaseAssignmentHandler):

--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -32,6 +32,9 @@ else:
 class JupyterhubEnvironmentError(Exception):
     pass
 
+class JupyterhubApiError(Exception):
+    pass
+
 def query_jupyterhub_api(method, api_path, post_data=None):
     """Query Jupyterhub api
 
@@ -72,6 +75,8 @@ def query_jupyterhub_api(method, api_path, post_data=None):
         headers=auth_header,
         json = post_data,
     )
+    if not req.ok:
+        raise JupyterhubApiError("Jupyterhub returned a status code of: " + req.status_code)
 
     return req.json()
 

--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -76,7 +76,7 @@ def query_jupyterhub_api(method, api_path, post_data=None):
         json = post_data,
     )
     if not req.ok:
-        raise JupyterhubApiError("JupyterhubAPI returned a status code of: " + str(req.status_code) + "for api_path: " + api_path)
+        raise JupyterhubApiError("JupyterhubAPI returned a status code of: " + str(req.status_code) + " for api_path: " + api_path)
 
     return req.json()
 

--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -76,7 +76,7 @@ def query_jupyterhub_api(method, api_path, post_data=None):
         json = post_data,
     )
     if not req.ok:
-        raise JupyterhubApiError("JupyterhubAPI returned a status code of: " + str(req.status_code))
+        raise JupyterhubApiError("JupyterhubAPI returned a status code of: " + str(req.status_code) + "for api_path: " + api_path)
 
     return req.json()
 

--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -76,7 +76,7 @@ def query_jupyterhub_api(method, api_path, post_data=None):
         json = post_data,
     )
     if not req.ok:
-        raise JupyterhubApiError("Jupyterhub returned a status code of: " + str(req.status_code))
+        raise JupyterhubApiError("JupyterhubAPI returned a status code of: " + str(req.status_code))
 
     return req.json()
 

--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -9,6 +9,9 @@ import stat
 import logging
 import traceback
 import contextlib
+import json
+import urllib.parse
+
 
 from setuptools.archive_util import unpack_archive
 from setuptools.archive_util import unpack_tarfile
@@ -26,6 +29,50 @@ if sys.platform != 'win32':
 else:
     pwd = None
 
+class JupyterhubEnvironmentError(Exception):
+    pass
+
+def query_jupyterhub_api(method, api_path, post_data=None):
+    """Query Jupyterhub api
+
+    Detects Jupyterhub environment variables and makes a call to the Hub API
+ 
+    Parameters
+    ----------
+    method : string
+        HTTP method, e.g. GET or POST
+    api_path : string
+        relative path, for example /users/
+    post_data : dict
+        JSON arguments for the API call
+
+    Returns
+    -------
+    response : dict
+        JSON response converted to dictionary"""
+
+    import requests
+
+    if os.getenv('JUPYTERHUB_API_TOKEN'):
+        api_token = os.environ['JUPYTERHUB_API_TOKEN']
+    else:
+        raise JupyterhubEnvironmentError("JUPYTERHUB_API_TOKEN env is required to run the exchange features of nbgrader.")
+    hub_api_url = os.environ.get('JUPYTERHUB_API_URL') or 'http://127.0.0.1:8081/hub/api'
+    if os.getenv('JUPYTERHUB_USER'):
+        user = os.environ['JUPYTERHUB_USER']
+    else:
+        raise JupyterhubEnvironmentError("JUPYTERHUB_USER env is required to run the exchange features of nbgrader.")
+    auth_header = {
+            'Authorization': 'token %s' % api_token
+        }
+
+    req = requests.request(url=hub_api_url + api_path,
+        method=method,
+        headers=auth_header,
+        json = post_data,
+    )
+
+    return req.json()
 
 def is_task(cell):
     """Returns True if the cell is a task cell."""

--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -10,7 +10,6 @@ import logging
 import traceback
 import contextlib
 import json
-import urllib.parse
 
 
 from setuptools.archive_util import unpack_archive

--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -76,7 +76,7 @@ def query_jupyterhub_api(method, api_path, post_data=None):
         json = post_data,
     )
     if not req.ok:
-        raise JupyterhubApiError("Jupyterhub returned a status code of: " + req.status_code)
+        raise JupyterhubApiError("Jupyterhub returned a status code of: " + str(req.status_code))
 
     return req.json()
 

--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -66,6 +66,7 @@ def query_jupyterhub_api(method, api_path, post_data=None):
             'Authorization': 'token %s' % api_token
         }
 
+    api_path = api_path.format(authenticated_user = user)
     req = requests.request(url=hub_api_url + api_path,
         method=method,
         headers=auth_header,


### PR DESCRIPTION
# Multiple courses
This is a more finalised version of #893 with [permission](https://github.com/zonca/nbgrader/pull/1) from zonca to post this with his code here as a new PR. 

## Add to documentation:

* Only api_tokens made for users in the admin_users list will work.

* You must generate an `'api_token'` with with the command `jupyterhub token <some admin user>`. The default api token that is created even if the user that you are using nbgrader in is in the admin_users list does not work, so generate it manually with that command wherever your jupyterhub.sqlite file cd nbis.
* For teachers/TA's have `'formgrade-<course-id>'` as the name of your group. 
* For the students have `'nbgrader-<course-id>'` as the name, you can also ommit this because it is made for you when adding a student if they are not already in Jupyterhub config when the server is started.

Here is an example how to put both the `'api_token'` and the `'formgrade-<course-id>'`group in when you create the service.

```
c.Jupyterhub.load_groups = {
     'formgrade-gagr':['sigurdurb', 'gagr'],
     'nbgrader-gagr':[],
}
c.JupyterHub.services = [{'name':'gagr20181',
                          'url':'http://127.0.0.1:9993',
                          'api_token':'4d60feb9df9f480db1eb8b77a4ef81ad',
'command':['jupyterhub-singleuser',
           '--group=formgrade-gagr',
           '--debug',
          ],
        'user':'gagr',
        'cwd':'/home/gagr',
}]
```

Note: I only tested this on Jupyterhub 0.8.1 on Ubuntu 16.04, still have to test this without Jupyterhub.
But I think it is fairly safe to say that for those who need they can run this with Jupyterhub now.
