### PR TITLE
JOSE paper bib updates

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -5,11 +5,12 @@ year = {2018}
 }
 
 @inproceedings{kluyver2016jupyter,
-  title={Jupyter Notebooks-a publishing format for reproducible computational workflows.},
+  title={Jupyter Notebooks: A publishing format for reproducible computational workflows},
   author={Kluyver, Thomas and Ragan-Kelley, Benjamin and P{\'e}rez, Fernando and Granger, Brian E and Bussonnier, Matthias and Frederic, Jonathan and Kelley, Kyle and Hamrick, Jessica B and Grout, Jason and Corlay, Sylvain and others},
   booktitle={ELPUB},
   pages={87--90},
-  year={2016}
+  year={2016},
+  doi={10.3233/978-1-61499-649-1-87},
 }
 
 @article{Cortina2007,
@@ -32,7 +33,8 @@ number = {2},
 pages = {248--253},
 title = {{Motivation and non-majors in computer science: Identifying discrete audiences for introductory courses}},
 volume = {48},
-year = {2005}
+year = {2005},
+doi={10.1109/TE.2004.842924},
 }
 
 @article{Guzdial2005,
@@ -93,7 +95,7 @@ year = {2005}
 
 @misc{Hamrick2016,
   author       = {Hamrick, Jessica B. and Jupyter Development Team},
-  title        = {2016 Jupyter Education Survey},
+  title        = {2016 {Jupyter} Education Survey},
   month        = may,
   year         = 2016,
   doi          = {10.5281/zenodo.51701},
@@ -137,10 +139,11 @@ year = {2014}
 @article{wing2008computational,
   title={Computational thinking and thinking about computing},
   author={Wing, Jeannette M},
-  journal={Philosophical transactions of the royal society of London A: mathematical, physical and engineering sciences},
+  journal={Philosophical Transactions of the Royal Society of London A: Mathematical, Physical and Engineering Sciences},
   volume={366},
   number={1881},
   pages={3717--3725},
   year={2008},
-  publisher={The Royal Society}
+  publisher={The Royal Society},
+  doi={10.1098/rsta.2008.0118}
 }


### PR DESCRIPTION
Capitalization fixes and add missing DOI.

Does the JupyterHub reference have a URL or DOI?

Cc: https://github.com/openjournals/jose-reviews/issues/32