### PR TITLE
Raise error when executed task fails

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -11,7 +11,7 @@ def echo(msg):
 
 def run(cmd):
     echo(cmd)
-    return sp.call(cmd, shell=True)
+    return sp.check_call(cmd, shell=True)
 
 try:
     from nbformat import read


### PR DESCRIPTION
Currently, if the tests fail then an error won't be raised because the underlying command to `subprocess.call` does not raise errors. This changes it to `check_call` which should raise an error.