### PR TITLE
Set env var NBGRADER_VALIDATING when validating

### DIFF
--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -266,6 +266,20 @@ def chdir(dirname):
         os.chdir(currdir)
 
 
+@contextlib.contextmanager
+def setenv(**kwargs):
+    previous_env = { }
+    for key, value in kwargs.items():
+        previous_env[key] = os.environ.get(value)
+        os.environ[key] = value
+    yield
+    for key, value in kwargs.items():
+        if previous_env[key] is None:
+            del os.environ[key]
+        else:
+            os.environ[key] = previous_env[key]
+
+
 def rmtree(path):
     # for windows, we need to go through and make sure everything
     # is writeable, otherwise rmtree will fail

--- a/nbgrader/validator.py
+++ b/nbgrader/validator.py
@@ -259,12 +259,11 @@ class Validator(LoggingConfigurable):
         return passed
 
     def _preprocess(self, nb):
-        os.environ['NBGRADER_VALIDATING'] = '1'
         resources = {}
-        for preprocessor in self.preprocessors:
-            pp = preprocessor()
-            nb, resources = pp.preprocess(nb, resources)
-        del os.environ['NBGRADER_VALIDATING']
+        with utils.setenv(NBGRADER_VALIDATING='1'):
+            for preprocessor in self.preprocessors:
+                pp = preprocessor()
+                nb, resources = pp.preprocess(nb, resources)
         return nb
 
     def validate(self, filename):

--- a/nbgrader/validator.py
+++ b/nbgrader/validator.py
@@ -259,10 +259,12 @@ class Validator(LoggingConfigurable):
         return passed
 
     def _preprocess(self, nb):
+        os.environ['NBGRADER_VALIDATING'] = '1'
         resources = {}
         for preprocessor in self.preprocessors:
             pp = preprocessor()
             nb, resources = pp.preprocess(nb, resources)
+        del os.environ['NBGRADER_VALIDATING']
         return nb
 
     def validate(self, filename):


### PR DESCRIPTION
- This allows a notebook to know when it is validating and when it is
  not.
- This was needed for a course with using major computational
  resources in each notebook.  The notebook is tell it is validating
  and go into a validation mode, using only cached data.

====

This came up as a need recently.  Actual use case is training models in the notebook and saving the models to a file, the validation can't re-do that because it takes so long.  For autograding, we can use hidden tests to change behavior, but I didn't find a way to do this when validating.

- Is there a proper way to do this, so that this change isn't needed?
- Untested.  If this is considered useful, I might be able to figure out tests myself.
- making a new context managed seems heavy-handed compared to the minimum change needed.  But I realized I needed to handle errors and slightly preferred a more proper solution.

What do you think?