### PR TITLE
Validate all cells

### DIFF
--- a/nbgrader/validator.py
+++ b/nbgrader/validator.py
@@ -87,6 +87,11 @@ class Validator(LoggingConfigurable):
         help="Warning to display when a cell passes (when invert=True)"
     ).tag(config=True)
 
+    validate_all = Bool(
+        False,
+        help="Validate all cells, not just the graded tests cells."
+    ).tag(config=True)
+
     stream = sys.stdout
 
     def _indent(self, val):
@@ -225,8 +230,8 @@ class Validator(LoggingConfigurable):
     def _get_failed_cells(self, nb):
         failed = []
         for cell in nb.cells:
-            #if not (utils.is_grade(cell) or utils.is_locked(cell)):
-            #    continue
+            if not (self.validate_all or utils.is_grade(cell) or utils.is_locked(cell)):
+                continue
 
             # if it's a grade cell, the check the grade
             if utils.is_grade(cell):
@@ -237,7 +242,7 @@ class Validator(LoggingConfigurable):
                     pass
                 elif score < max_score:
                     failed.append(cell)
-            elif cell.cell_type == 'code':
+            elif self.validate_all and cell.cell_type == 'code':
                 for output in cell.outputs:
                     if output.output_type == 'error':
                         failed.append(cell)

--- a/nbgrader/validator.py
+++ b/nbgrader/validator.py
@@ -225,8 +225,8 @@ class Validator(LoggingConfigurable):
     def _get_failed_cells(self, nb):
         failed = []
         for cell in nb.cells:
-            if not (utils.is_grade(cell) or utils.is_locked(cell)):
-                continue
+            #if not (utils.is_grade(cell) or utils.is_locked(cell)):
+            #    continue
 
             # if it's a grade cell, the check the grade
             if utils.is_grade(cell):

--- a/nbgrader/validator.py
+++ b/nbgrader/validator.py
@@ -237,6 +237,11 @@ class Validator(LoggingConfigurable):
                     pass
                 elif score < max_score:
                     failed.append(cell)
+            elif cell.cell_type == 'code':
+                for output in cell.outputs:
+                    if output.output_type == 'error':
+                        failed.append(cell)
+                        break
 
         return failed
 


### PR DESCRIPTION
An instructor asked why the "validate" interface didn't present errors in all cells (instead of just those that were graded).  It seems it was designed this way.

We took a look and figured out how to make it validate everything: we added a `validate_all` option, which makes the validation interface show all errors.  There's no difference in what's actually computed, it just doesn't hide the errors from non-graded cells.

This is currently without tests, though we've been using it for some time.  I can look at tests if the reception is positive.