### PR TITLE
Give ExecutePreprocessor the Traitlets config during validation

### DIFF
--- a/nbgrader/validator.py
+++ b/nbgrader/validator.py
@@ -272,6 +272,10 @@ class Validator(LoggingConfigurable):
         resources = {}
         with utils.setenv(NBGRADER_VALIDATING='1'):
             for preprocessor in self.preprocessors:
+                # https://github.com/jupyter/nbgrader/pull/1075
+                # It seemes that without the self.config passed below,
+                # --ExecutePreprocessor.timeout doesn't work.  Better solution
+                # requested, unknown why this is needed.
                 pp = preprocessor(**self.config[preprocessor.__name__])
                 nb, resources = pp.preprocess(nb, resources)
         return nb

--- a/nbgrader/validator.py
+++ b/nbgrader/validator.py
@@ -272,7 +272,7 @@ class Validator(LoggingConfigurable):
         resources = {}
         with utils.setenv(NBGRADER_VALIDATING='1'):
             for preprocessor in self.preprocessors:
-                pp = preprocessor()
+                pp = preprocessor(**self.config[preprocessor.__name__])
                 nb, resources = pp.preprocess(nb, resources)
         return nb
 


### PR DESCRIPTION
Root problem: it seems that validation timeout could not be changed with `--ExecutePreprocessor.timeout`, and in fact nothing we did would adjust the validation timeout.

=====
Commit message:

- We found that preprossor config was not followed - in particular,
  the ExecutePreprocessor.timeout wasn't noticed when it was increased
  to 120.
- A instructor did some digging and suggested that this change would
  make the configuration work.
- I don't know what the root problem could be, and I don't know if
  this is even needed.  Is this patch useful, or is there a "right"
  way of making traitlets work?

=====

So I don't know if this patch is needed.  I don't know if it's the right way.  From what I can tell about Traitlets, this shouldn't be needed.  Also documentation says that `c.ExecutePreprocessor.timeout` should work even without this change.

I've wondered if I could be putting the option in the wrong config file, but I have tried several and it even didn't work from the command line.

This patch was invented by an instructor using nbgrader.

I hope that giving a possible solution can help someone explain what we are doing wrong, but otherwise, here is a patch.
