### PR TITLE
Fix miscellaneous bugs

### DIFF
--- a/nbgrader/tests/nbextensions/files/blank.ipynb
+++ b/nbgrader/tests/nbextensions/files/blank.ipynb
@@ -22,7 +22,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python",
    "language": "python",
    "name": "python2"
   }

--- a/nbgrader/tests/nbextensions/files/blank.ipynb
+++ b/nbgrader/tests/nbextensions/files/blank.ipynb
@@ -3,9 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -24,9 +22,9 @@
   "kernelspec": {
    "display_name": "Python",
    "language": "python",
-   "name": "python2"
+   "name": "python"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/nbgrader/tests/nbextensions/files/old-schema.ipynb
+++ b/nbgrader/tests/nbextensions/files/old-schema.ipynb
@@ -4,7 +4,6 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": false,
     "nbgrader": {
      "cell_type": "code",
      "grade": false,
@@ -31,9 +30,9 @@
   "kernelspec": {
    "display_name": "Python",
    "language": "python",
-   "name": "python2"
+   "name": "python"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/nbgrader/tests/nbextensions/files/open_relative_file.ipynb
+++ b/nbgrader/tests/nbextensions/files/open_relative_file.ipynb
@@ -29,9 +29,9 @@
   "kernelspec": {
    "display_name": "Python",
    "language": "python",
-   "name": "python2"
+   "name": "python"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/nbgrader/tests/nbextensions/files/submitted-answer-cell-type-changed.ipynb
+++ b/nbgrader/tests/nbextensions/files/submitted-answer-cell-type-changed.ipynb
@@ -147,9 +147,9 @@
   "kernelspec": {
    "display_name": "Python",
    "language": "python",
-   "name": "python2"
+   "name": "python"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/nbgrader/tests/nbextensions/files/submitted-changed.ipynb
+++ b/nbgrader/tests/nbextensions/files/submitted-changed.ipynb
@@ -149,9 +149,9 @@
   "kernelspec": {
    "display_name": "Python",
    "language": "python",
-   "name": "python2"
+   "name": "python"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/nbgrader/tests/nbextensions/files/submitted-grade-cell-changed.ipynb
+++ b/nbgrader/tests/nbextensions/files/submitted-grade-cell-changed.ipynb
@@ -149,9 +149,9 @@
   "kernelspec": {
    "display_name": "Python",
    "language": "python",
-   "name": "python2"
+   "name": "python"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/nbgrader/tests/nbextensions/files/submitted-grade-cell-type-changed.ipynb
+++ b/nbgrader/tests/nbextensions/files/submitted-grade-cell-type-changed.ipynb
@@ -147,9 +147,9 @@
   "kernelspec": {
    "display_name": "Python",
    "language": "python",
-   "name": "python2"
+   "name": "python"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/nbgrader/tests/nbextensions/files/submitted-locked-cell-changed.ipynb
+++ b/nbgrader/tests/nbextensions/files/submitted-locked-cell-changed.ipynb
@@ -150,9 +150,9 @@
   "kernelspec": {
    "display_name": "Python",
    "language": "python",
-   "name": "python2"
+   "name": "python"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/nbgrader/tests/nbextensions/files/submitted-unchanged.ipynb
+++ b/nbgrader/tests/nbextensions/files/submitted-unchanged.ipynb
@@ -149,9 +149,9 @@
   "kernelspec": {
    "display_name": "Python",
    "language": "python",
-   "name": "python2"
+   "name": "python"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/nbgrader/tests/nbextensions/files/task.ipynb
+++ b/nbgrader/tests/nbextensions/files/task.ipynb
@@ -10,7 +10,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python",
    "language": "python",
    "name": "python2"
   },

--- a/nbgrader/tests/nbextensions/files/task.ipynb
+++ b/nbgrader/tests/nbextensions/files/task.ipynb
@@ -12,19 +12,7 @@
   "kernelspec": {
    "display_name": "Python",
    "language": "python",
-   "name": "python2"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 2
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.15"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/nbgrader/tests/nbextensions/test_create_assignment.py
+++ b/nbgrader/tests/nbextensions/test_create_assignment.py
@@ -298,6 +298,7 @@ def test_manual_cell(browser, port):
     _save_and_validate(browser)
 
 
+@pytest.mark.nbextensions
 def test_task_cell(browser, port):
     _load_notebook(browser, port, name='task')
     _activate_toolbar(browser)

--- a/nbgrader/tests/preprocessors/files/bad-markdown-cell-1.ipynb
+++ b/nbgrader/tests/preprocessors/files/bad-markdown-cell-1.ipynb
@@ -26,5 +26,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/nbgrader/tests/preprocessors/files/bad-markdown-cell-2.ipynb
+++ b/nbgrader/tests/preprocessors/files/bad-markdown-cell-2.ipynb
@@ -24,5 +24,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/nbgrader/tests/preprocessors/files/blank-grade-id.ipynb
+++ b/nbgrader/tests/preprocessors/files/blank-grade-id.ipynb
@@ -36,5 +36,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/nbgrader/tests/preprocessors/files/blank-points.ipynb
+++ b/nbgrader/tests/preprocessors/files/blank-points.ipynb
@@ -25,5 +25,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/nbgrader/tests/preprocessors/files/cell-type-changed.ipynb
+++ b/nbgrader/tests/preprocessors/files/cell-type-changed.ipynb
@@ -26,5 +26,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/nbgrader/tests/preprocessors/files/duplicate-grade-ids.ipynb
+++ b/nbgrader/tests/preprocessors/files/duplicate-grade-ids.ipynb
@@ -52,5 +52,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/nbgrader/tests/preprocessors/files/header.ipynb
+++ b/nbgrader/tests/preprocessors/files/header.ipynb
@@ -20,5 +20,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/nbgrader/tests/preprocessors/files/infinite-recursion.ipynb
+++ b/nbgrader/tests/preprocessors/files/infinite-recursion.ipynb
@@ -1011,5 +1011,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/nbgrader/tests/preprocessors/files/long-output.ipynb
+++ b/nbgrader/tests/preprocessors/files/long-output.ipynb
@@ -2028,5 +2028,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/nbgrader/tests/preprocessors/files/manually-graded-code-cell.ipynb
+++ b/nbgrader/tests/preprocessors/files/manually-graded-code-cell.ipynb
@@ -36,5 +36,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/nbgrader/tests/preprocessors/files/no-cell-type.ipynb
+++ b/nbgrader/tests/preprocessors/files/no-cell-type.ipynb
@@ -25,5 +25,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/nbgrader/tests/preprocessors/files/submitted-answer-cell-type-changed.ipynb
+++ b/nbgrader/tests/preprocessors/files/submitted-answer-cell-type-changed.ipynb
@@ -153,5 +153,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/nbgrader/tests/preprocessors/files/submitted-changed.ipynb
+++ b/nbgrader/tests/preprocessors/files/submitted-changed.ipynb
@@ -169,5 +169,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/nbgrader/tests/preprocessors/files/submitted-grade-cell-changed.ipynb
+++ b/nbgrader/tests/preprocessors/files/submitted-grade-cell-changed.ipynb
@@ -193,5 +193,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/nbgrader/tests/preprocessors/files/submitted-grade-cell-type-changed.ipynb
+++ b/nbgrader/tests/preprocessors/files/submitted-grade-cell-type-changed.ipynb
@@ -153,5 +153,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/nbgrader/tests/preprocessors/files/submitted-locked-cell-changed.ipynb
+++ b/nbgrader/tests/preprocessors/files/submitted-locked-cell-changed.ipynb
@@ -198,5 +198,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/nbgrader/tests/preprocessors/files/submitted-unchanged.ipynb
+++ b/nbgrader/tests/preprocessors/files/submitted-unchanged.ipynb
@@ -205,5 +205,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/nbgrader/tests/preprocessors/files/test.ipynb
+++ b/nbgrader/tests/preprocessors/files/test.ipynb
@@ -285,5 +285,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/nbgrader/tests/preprocessors/files/test_taskcell.ipynb
+++ b/nbgrader/tests/preprocessors/files/test_taskcell.ipynb
@@ -293,7 +293,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python",
    "language": "python",
    "name": "python2"
   },

--- a/nbgrader/tests/preprocessors/files/test_taskcell.ipynb
+++ b/nbgrader/tests/preprocessors/files/test_taskcell.ipynb
@@ -295,19 +295,7 @@
   "kernelspec": {
    "display_name": "Python",
    "language": "python",
-   "name": "python2"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 2
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.15"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = --strict-markers
+markers =
+    nbextensions

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ setup_args = dict(
         "jupyter_core",
         "jupyter_client",
         "tornado",
-        "six>=1.9",
+        "six>=1.11",  # jsonschema needs >=1.11
         "requests",
         "jsonschema",
         "alembic",

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup_args = dict(
         "python-dateutil",
         "jupyter",
         "notebook>=4.2",
-        "nbconvert>=4.2",
+        "nbconvert>=4.2,<5.5",  # revert when https://github.com/jupyter/nbconvert/pull/1022 is fixed upstream
         "nbformat",
         "traitlets",
         "jupyter_core",
@@ -103,7 +103,8 @@ setup_args = dict(
         "requests",
         "jsonschema",
         "alembic",
-        "fuzzywuzzy"
+        "fuzzywuzzy",
+        "urllib3<1.25"  # >=1.25 currently conflicts with requests
     ]
 )
 

--- a/tasks.py
+++ b/tasks.py
@@ -31,6 +31,7 @@ def _check_if_directory_in_path(pth, target):
 
 def docs(args):
     del args  # unused
+    run('git clean -fdX nbgrader/docs')
     if not WINDOWS:
         run('pytest --nbval-lax --current-env nbgrader/docs/source/user_guide/*.ipynb')
     run('python nbgrader/docs/source/build_docs.py')


### PR DESCRIPTION
A few things have changed upstream causing the tests to fail. In debugging I also found a fixed a few other miscellanous bugs:

* Test notebooks shouldn't use python 2 kernels
* All nbextension tests should be marked as such
* pytest now requires custom marks to be configured in a pytest.ini file
* doc testing can fail if nbgrader_config.py already exists and defines the submitted directory to be `submitted_zip`, so clean up the config file first