### PR TITLE
Customizable student ID in `nbgrader submit`

### DIFF
--- a/nbgrader/apps/submitapp.py
+++ b/nbgrader/apps/submitapp.py
@@ -50,7 +50,19 @@ class SubmitApp(NbGrader):
         get the most recent version. Your assignment submission are timestamped
         so instructors can tell when you turned it in. No other students will
         be able to see your submissions.
-        """
+
+        Certain setups may require to specify an alternative student id,
+        for example to include additional information such as the
+        student's group:
+
+            nbgrader submit assignment1 --student a4.jane.doo
+
+        The provided id should contain no `+` signs nor wildcards `*`.
+        This feature is typically meant for scripted use. Do *not* use
+        it to try to cheat and fake a submission from another student:
+        your actual student id can be recovered from the file ownership,
+        leaving behind a big trace leading to you.
+    """
 
     @default("classes")
     def _classes_default(self):

--- a/nbgrader/coursedir.py
+++ b/nbgrader/coursedir.py
@@ -18,7 +18,8 @@ class CourseDirectory(LoggingConfigurable):
             File glob to match student IDs. This can be changed to filter by
             student. Note: this is always changed to '.' when running `nbgrader
             assign`, as the assign step doesn't have any student ID associated
-            with it.
+            with it. With `nbgrader submit`, this instead forces the use of
+            an alternative student ID for the submission. See `nbgrader submit --help`.
 
             If the ID is purely numeric and you are passing it as a flag on the
             command line, you will need to escape the quotes in order to have

--- a/nbgrader/exchange/submit.py
+++ b/nbgrader/exchange/submit.py
@@ -53,13 +53,20 @@ class ExchangeSubmit(Exchange):
             self.fail("You don't have write permissions to the directory: {}".format(self.inbound_path))
 
         self.cache_path = os.path.join(self.cache, self.course_id)
+        if self.coursedir.student_id != '*':
+            # An explicit student id has been specified on the command line; we use it as student_id
+            if '*' in self.coursedir.student_id or '+' in self.coursedir.student_id:
+                self.fail("The student ID should contain no '*' nor '+'; got {}".format(self.coursedir.student_id))
+            student_id = self.coursedir.student_id
+        else:
+            student_id = get_username()
         if self.add_random_string:
             random_str = base64.urlsafe_b64encode(os.urandom(9)).decode('ascii')
             self.assignment_filename = '{}+{}+{}+{}'.format(
-                get_username(), self.coursedir.assignment_id, self.timestamp, random_str)
+                student_id, self.coursedir.assignment_id, self.timestamp, random_str)
         else:
             self.assignment_filename = '{}+{}+{}'.format(
-                get_username(), self.coursedir.assignment_id, self.timestamp)
+                student_id, self.coursedir.assignment_id, self.timestamp)
 
     def init_release(self):
         if self.course_id == '':

--- a/nbgrader/tests/apps/test_nbgrader_submit.py
+++ b/nbgrader/tests/apps/test_nbgrader_submit.py
@@ -159,6 +159,17 @@ class TestNbGraderSubmit(BaseTestApp):
         self._release_and_fetch("ps1", exchange, cache, course_dir)
         self._submit("--assignment=ps1", exchange, cache)
 
+    def test_submit_with_student_id(self, exchange, cache, course_dir):
+        self._release_and_fetch("ps1", exchange, cache, course_dir)
+        self._submit("ps1", exchange, cache, flags=["--student=foobar_student",])
+        filename, = os.listdir(join(cache, "abc101"))
+        username, assignment, timestamp1 = filename.split("+")[:3]
+        assert username == "foobar_student"
+        assert assignment == "ps1"
+        # '*' and '+' are forbidden
+        self._submit("ps1", exchange, cache, flags=["--student=foobar+student",], retcode=1)
+        self._submit("ps1", exchange, cache, flags=["--student=foobar*student",], retcode=1)
+
     def test_submit_multiple_courses(self, exchange, cache, course_dir):
         self._release("ps1", exchange, cache, course_dir, course="abc101")
         self._release("ps1", exchange, cache, course_dir, course="abc102")


### PR DESCRIPTION
This implements `nbgrader submit ps1 --student a4.jane.doo`

Some use cases:
- handling groups of students: helping the instructors access just the students of their group by adding a common prefix
- submissions directly from a jupyterhub, where all students share the same jovian login; in general infrastructures where all students share the same login
- a posteriori submissions by the instructor (e.g. because they are collected by some other mean)