### PR TITLE
Run test in the `python` group in parallel using pytest-xdist

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,7 @@
 pytest>=4.0
 pytest-cov
 pytest-rerunfailures
+pytest-xdist
 coverage
 selenium
 sphinx

--- a/tasks.py
+++ b/tasks.py
@@ -5,6 +5,7 @@ import sys
 import subprocess as sp
 import argparse
 
+
 def echo(msg):
     print("\033[1;37m{0}\033[0m".format(msg))
 
@@ -12,6 +13,7 @@ def echo(msg):
 def run(cmd):
     echo(cmd)
     return sp.check_call(cmd, shell=True)
+
 
 try:
     from nbformat import read
@@ -55,6 +57,7 @@ def _run_tests(mark, skip, junitxml):
         cmd.extend(['--junitxml', junitxml])
     cmd.append('-v')
     cmd.append('-x')
+    cmd.extend(['--numprocesses', 'auto'])
     cmd.extend(['--reruns', '4'])
 
     marks = []

--- a/tasks.py
+++ b/tasks.py
@@ -47,7 +47,7 @@ def cleandocs(args):
     run('python nbgrader/docs/source/clear_docs.py')
 
 
-def _run_tests(mark, skip, junitxml):
+def _run_tests(mark, skip, junitxml, paralell=False):
     cmd = []
     cmd.append('pytest')
     if not WINDOWS:
@@ -57,7 +57,8 @@ def _run_tests(mark, skip, junitxml):
         cmd.extend(['--junitxml', junitxml])
     cmd.append('-v')
     cmd.append('-x')
-    cmd.extend(['--numprocesses', 'auto'])
+    if paralell:
+        cmd.extend(['--numprocesses', 'auto'])
     cmd.extend(['--reruns', '4'])
 
     marks = []
@@ -78,7 +79,7 @@ def _run_tests(mark, skip, junitxml):
 def tests(args):
     if args.group == 'python':
         _run_tests(
-            mark="not nbextensions", skip=args.skip, junitxml=args.junitxml)
+            mark="not nbextensions", skip=args.skip, junitxml=args.junitxml, paralell=True)
 
     elif args.group == 'nbextensions':
         _run_tests(mark="nbextensions", skip=args.skip, junitxml=args.junitxml)


### PR DESCRIPTION
`python tasks.py tests --group=python` will add the `--numprocesses=auto` flag,
which will start one test runner per available CPU core.