### PR TITLE
Remove extra keys in nbgrader metadata and better schema mismatch errors

### DIFF
--- a/nbgrader/apps/updateapp.py
+++ b/nbgrader/apps/updateapp.py
@@ -7,7 +7,7 @@ from nbformat import current_nbformat, read as orig_read, write as orig_write
 from traitlets import Bool
 
 from .baseapp import NbGrader
-from ..nbgraderformat import MetadataValidator, write, ValidationError
+from ..nbgraderformat import MetadataValidator, write, ValidationError, SchemaTooNewError
 from ..utils import find_all_notebooks
 
 aliases = {
@@ -82,6 +82,13 @@ class UpdateApp(NbGrader):
                 except ValidationError:
                     self.log.error(traceback.format_exc())
                     self.fail("Notebook '{}' failed to validate, metadata is corrupted".format(notebook))
+                except SchemaTooNewError:
+                    self.log.error(traceback.format_exc())
+                    self.fail((
+                        "The notebook '{}' uses a newer version "
+                        "of the nbgrader metadata format. Please update your version of "
+                        "nbgrader to the latest version to be able to use this notebook."
+                    ).format(notebook))
             else:
                 orig_write(nb, notebook)
 

--- a/nbgrader/apps/validateapp.py
+++ b/nbgrader/apps/validateapp.py
@@ -7,7 +7,7 @@ from traitlets import default
 
 from .baseapp import NbGrader
 from ..validator import Validator
-from ..nbgraderformat import SchemaMismatchError
+from ..nbgraderformat import SchemaTooOldError, SchemaTooNewError
 
 aliases = {}
 flags = {
@@ -70,13 +70,21 @@ class ValidateApp(NbGrader):
             try:
                 validator.validate_and_print(filename)
 
-            except SchemaMismatchError:
+            except SchemaTooOldError:
                 self.log.error(traceback.format_exc())
                 self.fail((
                     "The notebook '{}' uses an old version "
                     "of the nbgrader metadata format. Please **back up this "
                     "notebook** and then update the metadata using:\n\nnbgrader update {}\n"
                 ).format(filename, filename))
+
+            except SchemaTooNewError:
+                self.log.error(traceback.format_exc())
+                self.fail((
+                    "The notebook '{}' uses a newer version "
+                    "of the nbgrader metadata format. Please update your version of "
+                    "nbgrader to the latest version to be able to use this notebook."
+                ).format(filename))
 
             except Exception:
                 self.log.error(traceback.format_exc())

--- a/nbgrader/converters/base.py
+++ b/nbgrader/converters/base.py
@@ -15,7 +15,7 @@ from nbconvert.writers import FilesWriter
 from ..coursedir import CourseDirectory
 from ..utils import find_all_files, rmtree, remove
 from ..preprocessors.execute import UnresponsiveKernelError
-from ..nbgraderformat import SchemaMismatchError
+from ..nbgraderformat import SchemaTooOldError, SchemaTooNewError
 
 
 class NbGraderException(Exception):
@@ -334,12 +334,22 @@ class BaseConverter(LoggingConfigurable):
                 self.log.error(msg)
                 raise NbGraderException(msg)
 
-            except SchemaMismatchError:
+            except SchemaTooOldError:
                 _handle_failure(gd)
                 msg = (
                     "One or more notebooks in the assignment use an old version \n"
                     "of the nbgrader metadata format. Please **back up your class files \n"
                     "directory** and then update the metadata using:\n\nnbgrader update .\n"
+                )
+                self.log.error(msg)
+                raise NbGraderException(msg)
+
+            except SchemaTooNewError:
+                _handle_failure(gd)
+                msg = (
+                    "One or more notebooks in the assignment use an newer version \n"
+                    "of the nbgrader metadata format. Please update your version of \n"
+                    "nbgrader to the latest version to be able to use this notebook.\n"
                 )
                 self.log.error(msg)
                 raise NbGraderException(msg)

--- a/nbgrader/nbgraderformat/__init__.py
+++ b/nbgrader/nbgraderformat/__init__.py
@@ -1,6 +1,6 @@
 SCHEMA_VERSION = 3
 
-from .common import ValidationError, SchemaMismatchError
+from .common import ValidationError, SchemaTooOldError, SchemaTooNewError
 from .v3 import MetadataValidatorV3 as MetadataValidator
 from .v3 import read_v3 as read, write_v3 as write
 from .v3 import reads_v3 as reads, writes_v3 as writes

--- a/nbgrader/nbgraderformat/common.py
+++ b/nbgrader/nbgraderformat/common.py
@@ -18,6 +18,14 @@ class SchemaMismatchError(Exception):
         self.expected_version = expected_version
 
 
+class SchemaTooOldError(SchemaMismatchError):
+    pass
+
+
+class SchemaTooNewError(SchemaMismatchError):
+    pass
+
+
 class BaseMetadataValidator(LoggingConfigurable):
 
     schema = None
@@ -51,15 +59,12 @@ class BaseMetadataValidator(LoggingConfigurable):
             return
         schema = cell.metadata['nbgrader'].get('schema_version', 0)
         if schema < SCHEMA_VERSION:
-            raise SchemaMismatchError(
+            raise SchemaTooOldError(
                 "Outdated schema version: {} (expected {})".format(schema, SCHEMA_VERSION),
                 schema, SCHEMA_VERSION)
         elif schema > SCHEMA_VERSION:
-            raise SchemaMismatchError(
-                "Schema version is too new: {} (expected {}). This means this "
-                "notebook was created with a newer version of nbgrader. Please "
-                "update your version of nbgrader to the latest version to be "
-                "able to use this notebook.".format(schema, SCHEMA_VERSION),
+            raise SchemaTooNewError(
+                "Schema version is too new: {} (expected {})".format(schema, SCHEMA_VERSION),
                 schema, SCHEMA_VERSION)
         jsonschema.validate(cell.metadata['nbgrader'], self.schema)
 

--- a/nbgrader/nbgraderformat/v1.py
+++ b/nbgrader/nbgraderformat/v1.py
@@ -40,13 +40,6 @@ class MetadataValidatorV1(BaseMetadataValidator):
         else:
             meta['points'] = 0.0
 
-        allowed = set(self.schema["properties"].keys())
-        keys = set(meta.keys()) - allowed
-        if len(keys) > 0:
-            self.log.warning("extra keys detected in metadata, these will be removed: {}".format(keys))
-            for key in keys:
-                del meta[key]
-
         meta['schema_version'] = 1
 
         return cell
@@ -63,6 +56,7 @@ class MetadataValidatorV1(BaseMetadataValidator):
         if meta['schema_version'] == 0:
             cell = self._upgrade_v0_to_v1(cell)
 
+        self._remove_extra_keys(cell)
         return cell
 
     def validate_cell(self, cell):

--- a/nbgrader/nbgraderformat/v2.py
+++ b/nbgrader/nbgraderformat/v2.py
@@ -40,6 +40,7 @@ class MetadataValidatorV2(BaseMetadataValidator):
         if cell.metadata['nbgrader']['schema_version'] == 1:
             cell = self._upgrade_v1_to_v2(cell)
 
+        self._remove_extra_keys(cell)
         return cell
 
     def validate_cell(self, cell):

--- a/nbgrader/nbgraderformat/v3.py
+++ b/nbgrader/nbgraderformat/v3.py
@@ -39,6 +39,7 @@ class MetadataValidatorV3(BaseMetadataValidator):
         if cell.metadata['nbgrader']['schema_version'] == 2:
             cell = self._upgrade_v2_to_v3(cell)
 
+        self._remove_extra_keys(cell)
         return cell
 
     def validate_cell(self, cell):

--- a/nbgrader/server_extensions/validate_assignment/handlers.py
+++ b/nbgrader/server_extensions/validate_assignment/handlers.py
@@ -14,7 +14,7 @@ from jupyter_core.paths import jupyter_config_path
 
 from ...apps import NbGrader
 from ...validator import Validator
-from ...nbgraderformat import SchemaMismatchError
+from ...nbgraderformat import SchemaTooOldError, SchemaTooNewError
 from ... import __version__ as nbgrader_version
 
 
@@ -50,13 +50,26 @@ class ValidateAssignmentHandler(IPythonHandler):
             validator = Validator(config=config)
             result = validator.validate(fullpath)
 
-        except SchemaMismatchError:
+        except SchemaTooOldError:
             self.log.error(traceback.format_exc())
             msg = (
                 "The notebook '{}' uses an old version "
                 "of the nbgrader metadata format. Please **back up this "
                 "notebook** and then update the metadata using:\n\nnbgrader update {}\n"
             ).format(fullpath, fullpath)
+            self.log.error(msg)
+            retvalue = {
+                "success": False,
+                "value": msg
+            }
+
+        except SchemaTooNewError:
+            self.log.error(traceback.format_exc())
+            msg = (
+                "The notebook '{}' uses a newer version "
+                "of the nbgrader metadata format. Please update your version of "
+                "nbgrader to the latest version to be able to use this notebook."
+            ).format(fullpath)
             self.log.error(msg)
             retvalue = {
                 "success": False,

--- a/nbgrader/tests/apps/files/too-new.ipynb
+++ b/nbgrader/tests/apps/files/too-new.ipynb
@@ -1,0 +1,32 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbgrader": {
+     "grade": false,
+     "grade_id": "cell-2298c977f4deff2b",
+     "locked": true,
+     "points": 10,
+     "schema_version": 10,
+     "solution": false,
+     "task": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# this has metadata which has a nbgrader schema that is too new!"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python",
+   "language": "python",
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/nbgrader/tests/apps/test_nbgrader_update.py
+++ b/nbgrader/tests/apps/test_nbgrader_update.py
@@ -51,6 +51,18 @@ class TestNbGraderUpdate(BaseTestApp):
         run_nbgrader(["update", "p1.ipynb", "--UpdateApp.validate=False"])
         run_nbgrader(["validate", "p1.ipynb"], retcode=1)
 
+    def test_validate_too_new(self):
+        """Does turning validation on/off work correctly when the schema is too new?"""
+
+        # updating shouldn't work if we're validating, too
+        self._copy_file(join("files", "too-new.ipynb"), "p1.ipynb")
+        run_nbgrader(["update", "p1.ipynb"], retcode=1)
+
+        # updating should work, but then validation should fail
+        self._copy_file(join("files", "too-new.ipynb"), "p1.ipynb")
+        run_nbgrader(["update", "p1.ipynb", "--UpdateApp.validate=False"])
+        run_nbgrader(["validate", "p1.ipynb"], retcode=1)
+
     def test_update_assign(self, db, course_dir):
         with open("nbgrader_config.py", "a") as fh:
             fh.write("""c.CourseDirectory.db_assignments = [dict(name='ps1', duedate='2015-02-02 14:58:23.948203 America/Los_Angeles')]\n""")

--- a/nbgrader/tests/nbgraderformat/test_v2.py
+++ b/nbgrader/tests/nbgraderformat/test_v2.py
@@ -63,6 +63,11 @@ def test_extra_keys():
     MetadataValidatorV2().upgrade_cell_metadata(cell)
     assert "foo" not in cell.metadata.nbgrader
 
+    cell = create_grade_cell("", "code", "foo", "", 1)
+    cell.metadata.nbgrader["foo"] = "bar"
+    MetadataValidatorV2().upgrade_cell_metadata(cell)
+    assert "foo" not in cell.metadata.nbgrader
+
 
 def test_schema_version():
     cell = create_grade_cell("", "code", "foo", "", 0)
@@ -85,7 +90,7 @@ def test_cell_type():
     cell.metadata.nbgrader["checksum"] = "abcd"
     cell.metadata.nbgrader["cell_type"] = "markdown"
     MetadataValidatorV2().upgrade_cell_metadata(cell)
-    assert cell.metadata.nbgrader['cell_type'] == "code"
+    assert cell.metadata.nbgrader['cell_type'] == "markdown"
 
     cell = create_grade_cell("", "code", "foo", "", 0)
     cell.metadata.nbgrader["checksum"] = "abcd"

--- a/nbgrader/tests/nbgraderformat/test_v3.py
+++ b/nbgrader/tests/nbgraderformat/test_v3.py
@@ -64,6 +64,16 @@ def test_extra_keys():
     MetadataValidatorV3().upgrade_cell_metadata(cell)
     assert "foo" not in cell.metadata.nbgrader
 
+    cell = create_grade_cell("", "code", "foo", "", 1)
+    cell.metadata.nbgrader["foo"] = "bar"
+    MetadataValidatorV3().upgrade_cell_metadata(cell)
+    assert "foo" not in cell.metadata.nbgrader
+
+    cell = create_grade_cell("", "code", "foo", "", 2)
+    cell.metadata.nbgrader["foo"] = "bar"
+    MetadataValidatorV3().upgrade_cell_metadata(cell)
+    assert "foo" not in cell.metadata.nbgrader
+
 
 def test_schema_version():
     cell = create_grade_cell("", "code", "foo", "", 0)
@@ -86,7 +96,7 @@ def test_cell_type():
     cell.metadata.nbgrader["checksum"] = "abcd"
     cell.metadata.nbgrader["cell_type"] = "markdown"
     MetadataValidatorV3().upgrade_cell_metadata(cell)
-    assert cell.metadata.nbgrader['cell_type'] == "code"
+    assert cell.metadata.nbgrader['cell_type'] == "markdown"
 
     cell = create_grade_cell("", "code", "foo", "", 0)
     cell.metadata.nbgrader["checksum"] = "abcd"


### PR DESCRIPTION
Fixes #916

I actually already had functionality for stripping extra keys, but there was a bug in how it was implemented so it wasn't actually getting trigger properly. This fixes that issue, and also clarifies if the schema version is too new (which came up in #1086)