### PR TITLE
Locate all configurable classes for generate_config subcommand

### DIFF
--- a/nbgrader/apps/generateconfigapp.py
+++ b/nbgrader/apps/generateconfigapp.py
@@ -2,7 +2,7 @@
 
 import os
 
-from traitlets import Unicode
+from traitlets import default, Unicode
 from traitlets.config.application import catch_config_error
 from .baseapp import NbGrader
 
@@ -17,6 +17,10 @@ class GenerateConfigApp(NbGrader):
         "nbgrader_config.py",
         help="The name of the configuration file to generate."
     ).tag(config=True)
+
+    @default("classes")
+    def _classes_default(self):
+        return self.all_configurable_classes()
 
     @catch_config_error
     def initialize(self, argv=None):

--- a/nbgrader/apps/nbgraderapp.py
+++ b/nbgrader/apps/nbgraderapp.py
@@ -11,11 +11,6 @@ from traitlets.config.application import catch_config_error
 from jupyter_core.application import NoStart
 
 import nbgrader
-from .. import preprocessors
-from .. import plugins
-from ..coursedir import CourseDirectory
-from .. import exchange
-from .. import converters
 from .baseapp import nbgrader_aliases, nbgrader_flags
 from . import (
     NbGrader,
@@ -244,41 +239,7 @@ class NbGraderApp(NbGrader):
 
     @default("classes")
     def _classes_default(self):
-        classes = super(NbGraderApp, self)._classes_default()
-
-        # include the coursedirectory
-        classes.append(CourseDirectory)
-
-        # include all the apps that have configurable options
-        for _, (app, _) in self.subcommands.items():
-            if len(app.class_traits(config=True)) > 0:
-                classes.append(app)
-
-        # include plugins that have configurable options
-        for pg_name in plugins.__all__:
-            pg = getattr(plugins, pg_name)
-            if pg.class_traits(config=True):
-                classes.append(pg)
-
-        # include all preprocessors that have configurable options
-        for pp_name in preprocessors.__all__:
-            pp = getattr(preprocessors, pp_name)
-            if len(pp.class_traits(config=True)) > 0:
-                classes.append(pp)
-
-        # include all the exchange actions
-        for ex_name in exchange.__all__:
-            ex = getattr(exchange, ex_name)
-            if hasattr(ex, "class_traits") and ex.class_traits(config=True):
-                classes.append(ex)
-
-        # include all the converters
-        for ex_name in converters.__all__:
-            ex = getattr(converters, ex_name)
-            if hasattr(ex, "class_traits") and ex.class_traits(config=True):
-                classes.append(ex)
-
-        return classes
+        return self.all_configurable_classes()
 
     @catch_config_error
     def initialize(self, argv=None):

--- a/nbgrader/tests/apps/test_nbgrader_generate_config.py
+++ b/nbgrader/tests/apps/test_nbgrader_generate_config.py
@@ -20,5 +20,11 @@ class TestNbGraderGenerateConfig(BaseTestApp):
         run_nbgrader(["generate_config"])
         assert os.path.isfile("nbgrader_config.py")
 
+        with open("nbgrader_config.py") as f:
+            contents = f.read()
+
+        # This was missing in issue #1089
+        assert "AssignLatePenalties" in contents
+
         # does it fail if it already exists?
         run_nbgrader(["generate_config"], retcode=1)


### PR DESCRIPTION
The generate_config subcommand uses its own `.classes` attribute to find the classes to expose in the config file. So it needs to look up the whole list like NbgraderApp does (for `--help-all`). This PR adds it as a new method on the base class, and makes both applications call that.

Closes gh-1089