### PR TITLE
Add a course list extension that shows all courses an instructor can manage

### DIFF
--- a/nbgrader/__init__.py
+++ b/nbgrader/__init__.py
@@ -38,6 +38,14 @@ def _jupyter_nbextension_paths():
                 require="assignment_list/main"
             )
         )
+        paths.append(
+            dict(
+                section="tree",
+                src=os.path.join('nbextensions', 'course_list'),
+                dest="course_list",
+                require="course_list/main"
+            )
+        )
 
     return paths
 
@@ -50,5 +58,6 @@ def _jupyter_server_extension_paths():
 
     if sys.platform != 'win32':
         paths.append(dict(module="nbgrader.server_extensions.assignment_list"))
+        paths.append(dict(module="nbgrader.server_extensions.course_list"))
 
     return paths

--- a/nbgrader/auth/jupyterhub.py
+++ b/nbgrader/auth/jupyterhub.py
@@ -12,6 +12,31 @@ class JupyterhubApiError(Exception):
     pass
 
 
+def get_jupyterhub_user():
+    if os.getenv('JUPYTERHUB_USER'):
+        return os.environ['JUPYTERHUB_USER']
+    else:
+        raise JupyterhubEnvironmentError("JUPYTERHUB_USER env is required to run the exchange features of nbgrader.")
+
+
+def get_jupyterhub_url():
+    return os.environ.get('JUPYTERHUB_BASE_URL') or 'http://127.0.0.1:8000'
+
+
+def get_jupyterhub_api_url():
+    return os.environ.get('JUPYTERHUB_API_URL') or 'http://127.0.0.1:8081/hub/api'
+
+
+def get_jupyterhub_authorization():
+    if os.getenv('JUPYTERHUB_API_TOKEN'):
+        api_token = os.environ['JUPYTERHUB_API_TOKEN']
+    else:
+        raise JupyterhubEnvironmentError("JUPYTERHUB_API_TOKEN env is required to run the exchange features of nbgrader.")
+    return {
+        'Authorization': 'token %s' % api_token
+    }
+
+
 def _query_jupyterhub_api(method, api_path, post_data=None):
     """Query Jupyterhub api
 
@@ -32,19 +57,9 @@ def _query_jupyterhub_api(method, api_path, post_data=None):
         JSON response converted to dictionary
 
     """
-    if os.getenv('JUPYTERHUB_API_TOKEN'):
-        api_token = os.environ['JUPYTERHUB_API_TOKEN']
-    else:
-        raise JupyterhubEnvironmentError("JUPYTERHUB_API_TOKEN env is required to run the exchange features of nbgrader.")
-    hub_api_url = os.environ.get('JUPYTERHUB_API_URL') or 'http://127.0.0.1:8081/hub/api'
-    if os.getenv('JUPYTERHUB_USER'):
-        user = os.environ['JUPYTERHUB_USER']
-    else:
-        raise JupyterhubEnvironmentError("JUPYTERHUB_USER env is required to run the exchange features of nbgrader.")
-    auth_header = {
-        'Authorization': 'token %s' % api_token
-    }
-
+    hub_api_url = get_jupyterhub_api_url()
+    user = get_jupyterhub_user()
+    auth_header = get_jupyterhub_authorization()
     api_path = api_path.format(authenticated_user=user)
     req = requests.request(
         url=hub_api_url + api_path,

--- a/nbgrader/docs/source/user_guide/installation.rst
+++ b/nbgrader/docs/source/user_guide/installation.rst
@@ -98,6 +98,11 @@ or to disable the Formgrader extension::
     jupyter nbextension disable --sys-prefix formgrader/main --section=tree
     jupyter serverextension disable --sys-prefix nbgrader.server_extensions.formgrader
 
+or to disable the Course List extension::
+
+    jupyter nbextension disable --sys-prefix course_list/main --section=tree
+    jupyter serverextension disable --sys-prefix nbgrader.server_extensions.course_list
+
 For example lets assume you have installed nbgrader via `Anaconda
 <https://www.anaconda.com/download>`__ (meaning all extensions are installed
 and enabled with the ``--sys-prefix`` flag, i.e. anyone using the particular

--- a/nbgrader/nbextensions/course_list/course_list.css
+++ b/nbgrader/nbextensions/course_list/course_list.css
@@ -1,0 +1,67 @@
+#courses .panel-group .panel {
+    margin-top: 3px;
+    margin-bottom: 1em;
+}
+
+#courses .panel-group .panel .panel-heading {
+    background-color: #eee;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    padding-left: 7px;
+    padding-right: 7px;
+    line-height: 22px;
+}
+
+#courses .panel-group .panel .panel-heading a:focus, a:hover {
+    text-decoration: none;
+}
+
+#courses .panel-group .panel .panel-body {
+    padding: 0;
+}
+
+#courses .panel-group .panel .panel-body .list_container {
+    margin-top: 0px;
+    margin-bottom: 0px;
+    border: 0px;
+    border-radius: 0px;
+}
+
+#courses .panel-group .panel .panel-body .list_container .list_item {
+    border-bottom: 1px solid #ddd;
+}
+
+#courses .panel-group .panel .panel-body .list_container .list_item:last-child {
+    border-bottom: 0px;
+}
+
+#courses .list_item {
+    padding-top: 4px;
+    padding-bottom: 4px;
+    padding-left: 7px;
+    padding-right: 7px;
+    line-height: 22px;
+}
+
+#courses .list_item > div {
+    padding-top: 0;
+    padding-bottom: 0;
+    padding-left: 0;
+    padding-right: 0;
+}
+
+#courses .list_placeholder {
+    display: none;
+}
+
+#courses .list_placeholder, #courses .list_loading, #courses .list_error {
+    font-weight: bold;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    padding-left: 7px;
+    padding-right: 7px;
+}
+
+#courses .list_error, #courses .version_error {
+    display: none;
+}

--- a/nbgrader/nbextensions/course_list/course_list.js
+++ b/nbgrader/nbextensions/course_list/course_list.js
@@ -1,0 +1,139 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+define([
+    'base/js/namespace',
+    'jquery',
+    'base/js/utils',
+    'base/js/dialog',
+], function(Jupyter, $, utils, dialog) {
+    "use strict";
+
+    var ajax = utils.ajax || $.ajax;
+    // Notebook v4.3.1 enabled xsrf so use notebooks ajax that includes the
+    // xsrf token in the header data
+
+    var CourseList = function (course_list_selector, refresh_selector, options) {
+        this.course_list_selector = course_list_selector;
+        this.refresh_selector = refresh_selector;
+
+        this.course_list_element = $(course_list_selector);
+        this.refresh_element = $(refresh_selector);
+
+        this.current_course = undefined;
+        this.bind_events()
+
+        options = options || {};
+        this.options = options;
+        this.base_url = options.base_url || utils.get_body_data("baseUrl");
+
+        this.data = undefined;
+    };
+
+    CourseList.prototype.bind_events = function () {
+        var that = this;
+        this.refresh_element.click(function () {
+            that.load_list();
+        });
+    };
+
+
+    CourseList.prototype.clear_list = function (loading) {
+        this.course_list_element.children('.list_item').remove();
+        if (loading) {
+            // show loading
+            this.course_list_element.children('.list_loading').show();
+            // hide placeholders and errors
+            this.course_list_element.children('.list_placeholder').hide();
+            this.course_list_element.children('.list_error').hide();
+
+        } else {
+            // show placeholders
+            this.course_list_element.children('.list_placeholder').show();
+            // hide loading and errors
+            this.course_list_element.children('.list_loading').hide();
+            this.course_list_element.children('.list_error').hide();
+        }
+    };
+
+    CourseList.prototype.show_error = function (error) {
+        this.course_list_element.children('.list_item').remove();
+        // show errors
+        this.course_list_element.children('.list_error').show();
+        this.course_list_element.children('.list_error').text(error);
+        // hide loading and placeholding
+        this.course_list_element.children('.list_loading').hide();
+        this.course_list_element.children('.list_placeholder').hide();
+    };
+
+    CourseList.prototype.load_list = function () {
+        this.clear_list(true);
+
+        var settings = {
+            processData : false,
+            cache : false,
+            type : "GET",
+            dataType : "json",
+            success : $.proxy(this.handle_load_list, this),
+            error : utils.log_ajax_error,
+        };
+        var url = utils.url_path_join(this.base_url, 'formgraders');
+        ajax(url, settings);
+    };
+
+    CourseList.prototype.handle_load_list = function (data, status, xhr) {
+        if (data.success) {
+            this.load_list_success(data.value);
+        } else {
+            this.show_error(data.value);
+        }
+    };
+
+    CourseList.prototype.load_list_success = function (data) {
+        this.clear_list();
+        var len = data.length;
+        for (var i=0; i<len; i++) {
+            var element = $('<div/>');
+            var item = new Course(element, data[i], this.course_list_selector, $.proxy(this.handle_load_list, this), this.options);
+            this.course_list_element.append(element);
+            this.course_list_element.children('.list_placeholder').hide()
+        }
+
+        if (this.callback) {
+            this.callback();
+            this.callback = undefined;
+        }
+    };
+
+    var Course = function (element, data, parent, on_refresh, options) {
+        this.element = $(element);
+        this.course_id = data['course_id'];
+        this.formgrader_kind = data['kind'];
+        this.url = data['url'];
+        this.parent = parent;
+        this.on_refresh = on_refresh;
+        this.options = options;
+        this.style();
+        this.make_row();
+    };
+
+    Course.prototype.style = function () {
+        this.element.addClass('list_item').addClass("row");
+    };
+
+    Course.prototype.make_row = function () {
+        var row = $('<div/>').addClass('col-md-12');
+        var container = $('<span/>').addClass('item_name col-md-12');
+        var link = $('<a/>')
+            .attr('href', this.url)
+            .attr('target', '_blank')
+            .text(this.course_id);
+        container.append(link).append("(" + this.formgrader_kind + ")");
+        row.append(container);
+        this.element.empty().append(row);
+    };
+
+    return {
+        'CourseList': CourseList,
+    };
+});

--- a/nbgrader/nbextensions/course_list/course_list.js
+++ b/nbgrader/nbextensions/course_list/course_list.js
@@ -123,13 +123,13 @@ define([
 
     Course.prototype.make_row = function () {
         var row = $('<div/>').addClass('col-md-12');
-        var container = $('<span/>').addClass('item_name col-md-12');
-        var link = $('<a/>')
-            .attr('href', this.url)
-            .attr('target', '_blank')
-            .text(this.course_id);
-        container.append(link).append("(" + this.formgrader_kind + ")");
+        var container = $('<span/>').addClass('item_name col-sm-2').append(
+            $('<a/>')
+                .attr('href', this.url)
+                .attr('target', '_blank')
+                .text(this.course_id));
         row.append(container);
+        row.append($('<span/>').addClass('item_course col-sm-2').text(this.formgrader_kind));
         this.element.empty().append(row);
     };
 

--- a/nbgrader/nbextensions/course_list/main.js
+++ b/nbgrader/nbextensions/course_list/main.js
@@ -1,0 +1,101 @@
+define([
+    'base/js/namespace',
+    'jquery',
+    'base/js/utils',
+    './course_list'
+], function(Jupyter, $, utils, CourseList) {
+    "use strict";
+
+    var nbgrader_version = "0.6.0.dev";
+
+    var ajax = utils.ajax || $.ajax;
+    // Notebook v4.3.1 enabled xsrf so use notebooks ajax that includes the
+    // xsrf token in the header data
+
+    var course_html = $([
+        '<div id="courses" class="tab-pane">',
+        '  <div class="alert alert-danger version_error">',
+        '  </div>',
+        '  <div class="panel-group">',
+        '    <div class="panel panel-default">',
+        '      <div class="panel-heading">',
+        '        Available formgraders',
+        '        <span id="formgrader_buttons" class="pull-right toolbar_buttons">',
+        '        <button id="refresh_formgrader_list" title="Refresh formgrader list" class="btn btn-default btn-xs"><i class="fa fa-refresh"></i></button>',
+        '        </span>',
+        '      </div>',
+        '      <div class="panel-body">',
+        '        <div id="formgrader_list" class="list_container">',
+        '          <div id="formgrader_list_placeholder" class="row list_placeholder">',
+        '            <div> There are no available formgrader services. </div>',
+        '          </div>',
+        '          <div id="formgrader_list_loading" class="row list_loading">',
+        '            <div> Loading, please wait... </div>',
+        '          </div>',
+        '          <div id="formgrader_list_error" class="row list_error">',
+        '            <div></div>',
+        '          </div>',
+        '        </div>',
+        '      </div>',
+        '    </div>',
+        '  </div>   ',
+        '</div>'
+    ].join('\n'));
+
+    function checkNbGraderVersion(base_url) {
+        var settings = {
+            cache : false,
+            type : "GET",
+            dataType : "json",
+            data : {
+                version: nbgrader_version
+            },
+            success : function (response) {
+                if (!response['success']) {
+                    var err = $("#courses .version_error");
+                    err.text(response['message']);
+                    err.show();
+                }
+            },
+            error : utils.log_ajax_error,
+        };
+        var url = utils.url_path_join(base_url, 'nbgrader_version');
+        ajax(url, settings);
+    }
+
+    function load() {
+        if (!Jupyter.notebook_list) return;
+        var base_url = Jupyter.notebook_list.base_url;
+        $('head').append(
+            $('<link>')
+            .attr('rel', 'stylesheet')
+            .attr('type', 'text/css')
+            .attr('href', base_url + 'nbextensions/course_list/course_list.css')
+        );
+        $(".tab-content").append(course_html);
+        $("#tabs").append(
+            $('<li>')
+            .append(
+                $('<a>')
+                .attr('href', '#courses')
+                .attr('data-toggle', 'tab')
+                .text('Courses')
+                .click(function (e) {
+                    window.history.pushState(null, null, '#courses');
+                    course_list.load_list();
+                })
+            )
+        );
+        var course_list = new CourseList.CourseList(
+            '#formgrader_list',
+            '#refresh_formgrader_list',
+            {
+                base_url: Jupyter.notebook_list.base_url
+            }
+        );
+        checkNbGraderVersion(base_url);
+    }
+    return {
+        load_ipython_extension: load
+    };
+});

--- a/nbgrader/server_extensions/course_list/__init__.py
+++ b/nbgrader/server_extensions/course_list/__init__.py
@@ -1,0 +1,1 @@
+from .handlers import load_jupyter_server_extension

--- a/nbgrader/server_extensions/course_list/handlers.py
+++ b/nbgrader/server_extensions/course_list/handlers.py
@@ -40,7 +40,7 @@ class CourseListHandler(IPythonHandler):
     def get_base_url(self):
         parts = list(urllib.parse.urlsplit(self.request.full_url()))
         base_url = parts[0] + "://" + parts[1]
-        return base_url.rstrip()
+        return base_url.rstrip("/")
 
     def load_config(self):
         paths = jupyter_config_path()
@@ -60,6 +60,7 @@ class CourseListHandler(IPythonHandler):
     @gen.coroutine
     def check_for_local_formgrader(self, config):
         base_url = self.get_base_url() + "/" + self.base_url.lstrip("/")
+        base_url = base_url.rstrip("/")
         url = base_url + "/formgrader/api/status"
         header = {"Authorization": "token {}".format(self.token)}
         http_client = AsyncHTTPClient()
@@ -98,11 +99,9 @@ class CourseListHandler(IPythonHandler):
             # not running on JupyterHub, or otherwise don't have access
             raise gen.Return([])
 
+        # If course_names is None, that probably means we're not running with
+        # JupyterHub.
         if course_names is None:
-            self.log.warning(
-                "User has access to all formgraders, but I don't know how to tell "
-                "which are services are formgraders. This is probably not supposed "
-                "to happen and may mean that your nbgrader is misconfigured.")
             raise gen.Return([])
 
         base_url = get_jupyterhub_api_url()

--- a/nbgrader/server_extensions/course_list/handlers.py
+++ b/nbgrader/server_extensions/course_list/handlers.py
@@ -87,7 +87,7 @@ class CourseListHandler(IPythonHandler):
             }])
 
         self.log.error("Local formgrader not accessible")
-        raise gen.Return(course)
+        raise gen.Return([])
 
     @gen.coroutine
     def check_for_jupyterhub_formgraders(self, config):

--- a/nbgrader/server_extensions/course_list/handlers.py
+++ b/nbgrader/server_extensions/course_list/handlers.py
@@ -1,0 +1,198 @@
+"""Tornado handlers for nbgrader course list web service."""
+
+import os
+import contextlib
+import json
+import traceback
+
+from tornado import web
+from tornado.httpclient import AsyncHTTPClient
+from tornado import gen
+from textwrap import dedent
+from six.moves import urllib
+
+from notebook.utils import url_path_join as ujoin
+from notebook.base.handlers import IPythonHandler
+from traitlets.config import Config
+from jupyter_core.paths import jupyter_config_path
+
+from ...apps import NbGrader
+from ...auth import Authenticator
+from ...auth.jupyterhub import (JupyterhubEnvironmentError, get_jupyterhub_api_url,
+    get_jupyterhub_authorization, get_jupyterhub_url)
+from ... import __version__ as nbgrader_version
+
+
+@contextlib.contextmanager
+def chdir(dirname):
+    currdir = os.getcwd()
+    os.chdir(dirname)
+    yield
+    os.chdir(currdir)
+
+
+class CourseListHandler(IPythonHandler):
+
+    @property
+    def assignment_dir(self):
+        return self.settings['assignment_dir']
+
+    def get_base_url(self):
+        parts = list(urllib.parse.urlsplit(self.request.full_url()))
+        base_url = urllib.parse.urljoin(
+            parts[0] + "://" + parts[1], self.base_url.lstrip("/"))
+        return base_url
+
+    def load_config(self):
+        paths = jupyter_config_path()
+        paths.insert(0, os.getcwd())
+
+        config_found = False
+        full_config = Config()
+        for config in NbGrader._load_config_files("nbgrader_config", path=paths, log=self.log):
+            full_config.merge(config)
+            config_found = True
+
+        if not config_found:
+            self.log.warning("No nbgrader_config.py file found. Rerun with DEBUG log level to see where nbgrader is looking.")
+
+        return full_config
+
+    @gen.coroutine
+    def check_for_local_formgrader(self, config):
+        base_url = self.get_base_url()
+        url = base_url.rstrip("/") + "/formgrader/api/status"
+        header = {"Authorization": "token {}".format(self.token)}
+        http_client = AsyncHTTPClient()
+        response = yield http_client.fetch(url, headers=header)
+        try:
+            response = json.loads(response.body)
+            status = response['status']
+        except:
+            self.log.error("Couldn't decode response from local formgrader")
+            self.log.error(traceback.format_exc())
+            raise gen.Return([])
+
+        if status:
+            raise gen.Return([{
+                'course_id': config.Exchange.course_id,
+                'url': base_url + '/formgrader',
+                'kind': 'local'
+            }])
+
+        self.log.error("Local formgrader not accessible")
+        raise gen.Return(course)
+
+    @gen.coroutine
+    def check_for_jupyterhub_formgraders(self, config):
+        # first get the list of courses from the authenticator
+        auth = Authenticator(config=config)
+        try:
+            course_names = auth.get_student_courses("*")
+        except JupyterhubEnvironmentError:
+            # not running on JupyterHub, or otherwise don't have access
+            raise gen.Return([])
+
+        if course_names is None:
+            self.log.warning(
+                "User has access to all formgraders, but I don't know how to tell "
+                "which are services are formgraders. This is probably not supposed "
+                "to happen and may mean that your nbgrader is misconfigured.")
+            raise gen.Return([])
+
+        base_url = get_jupyterhub_api_url()
+        url = base_url + "/services"
+        auth = get_jupyterhub_authorization()
+
+        http_client = AsyncHTTPClient()
+        response = yield http_client.fetch(url, headers=auth)
+        services = json.loads(response.body)
+
+        courses = []
+        for course in course_names:
+            if course not in services:
+                self.log.warning("Couldn't find formgrader for course '%s'", course)
+                continue
+            service = services[course]
+            courses.append({
+                'course_id': course,
+                'url': get_jupyterhub_url() + service['prefix'].rstrip('/') + "/formgrader",
+                'kind': 'jupyterhub'
+            })
+
+        raise gen.Return(courses)
+
+    @gen.coroutine
+    @web.authenticated
+    def get(self):
+        with chdir(self.assignment_dir):
+            try:
+                config = self.load_config()
+                courses = []
+                local_courses = yield self.check_for_local_formgrader(config)
+                jhub_courses = yield self.check_for_jupyterhub_formgraders(config)
+                courses.extend(local_courses)
+                courses.extend(jhub_courses)
+
+            except:
+                self.log.error(traceback.format_exc())
+                retvalue = {
+                    "success": False,
+                    "value": traceback.format_exc()
+                }
+
+            else:
+                retvalue = {
+                    "success": True,
+                    "value": sorted(courses, key=lambda x: x['course_id'])
+                }
+
+        raise gen.Return(self.finish(json.dumps(retvalue)))
+
+
+class NbGraderVersionHandler(IPythonHandler):
+
+    @web.authenticated
+    def get(self):
+        ui_version = self.get_argument('version')
+        if ui_version != nbgrader_version:
+            msg = dedent(
+                """
+                The version of the Course List nbextension does not match
+                the server extension; the nbextension version is {} while the
+                server version is {}. This can happen if you have recently
+                upgraded nbgrader, and may cause this extension to not work
+                correctly. To fix the problem, please see the nbgrader
+                installation instructions:
+                http://nbgrader.readthedocs.io/en/stable/user_guide/installation.html
+                """.format(ui_version, nbgrader_version)
+            ).strip().replace("\n", " ")
+            self.log.error(msg)
+            result = {"success": False, "message": msg}
+        else:
+            result = {"success": True}
+
+        self.finish(json.dumps(result))
+
+
+#-----------------------------------------------------------------------------
+# URL to handler mappings
+#-----------------------------------------------------------------------------
+
+
+default_handlers = [
+    (r"/formgraders", CourseListHandler),
+    (r"/nbgrader_version", NbGraderVersionHandler)
+]
+
+
+def load_jupyter_server_extension(nbapp):
+    """Load the nbserver"""
+    nbapp.log.info("Loading the course_list nbgrader serverextension")
+    webapp = nbapp.web_app
+    base_url = webapp.settings['base_url']
+    webapp.settings['assignment_dir'] = nbapp.notebook_dir
+    webapp.add_handlers(".*$", [
+        (ujoin(base_url, pat), handler)
+        for pat, handler in default_handlers
+    ])

--- a/nbgrader/server_extensions/formgrader/apihandlers.py
+++ b/nbgrader/server_extensions/formgrader/apihandlers.py
@@ -7,6 +7,13 @@ from .base import BaseApiHandler, check_xsrf
 from ...api import MissingEntry
 
 
+class StatusHandler(BaseApiHandler):
+    @web.authenticated
+    @check_xsrf
+    def get(self):
+        self.write({"status": True})
+
+
 class GradeCollectionHandler(BaseApiHandler):
     @web.authenticated
     @check_xsrf
@@ -249,6 +256,8 @@ class AutogradeHandler(BaseApiHandler):
 
 
 default_handlers = [
+    (r"/formgrader/api/status", StatusHandler),
+
     (r"/formgrader/api/assignments", AssignmentCollectionHandler),
     (r"/formgrader/api/assignment/([^/]+)", AssignmentHandler),
     (r"/formgrader/api/assignment/([^/]+)/assign", AssignHandler),

--- a/nbgrader/tests/apps/test_nbgrader_extension.py
+++ b/nbgrader/tests/apps/test_nbgrader_extension.py
@@ -16,11 +16,12 @@ def test_nbextension_linux():
     from nbgrader import _jupyter_nbextension_paths
     with mock_platform("linux"):
         nbexts = _jupyter_nbextension_paths()
-        assert len(nbexts) == 4
+        assert len(nbexts) == 5
         assert nbexts[0]['section'] == 'notebook'
         assert nbexts[1]['section'] == 'tree'
         assert nbexts[2]['section'] == 'notebook'
         assert nbexts[3]['section'] == 'tree'
+        assert nbexts[4]['section'] == 'tree'
         paths = [ext['src'] for ext in nbexts]
         for path in paths:
             assert os.path.isdir(os.path.join(os.path.dirname(nbgrader.__file__), path))
@@ -30,11 +31,12 @@ def test_nbextension_mac():
     from nbgrader import _jupyter_nbextension_paths
     with mock_platform("darwin"):
         nbexts = _jupyter_nbextension_paths()
-        assert len(nbexts) == 4
+        assert len(nbexts) == 5
         assert nbexts[0]['section'] == 'notebook'
         assert nbexts[1]['section'] == 'tree'
         assert nbexts[2]['section'] == 'notebook'
         assert nbexts[3]['section'] == 'tree'
+        assert nbexts[4]['section'] == 'tree'
         paths = [ext['src'] for ext in nbexts]
         for path in paths:
             assert os.path.isdir(os.path.join(os.path.dirname(nbgrader.__file__), path))
@@ -57,20 +59,22 @@ def test_serverextension_linux():
     from nbgrader import _jupyter_server_extension_paths
     with mock_platform("linux"):
         serverexts = _jupyter_server_extension_paths()
-        assert len(serverexts) == 3
+        assert len(serverexts) == 4
         assert serverexts[0]['module'] == 'nbgrader.server_extensions.formgrader'
         assert serverexts[1]['module'] == 'nbgrader.server_extensions.validate_assignment'
         assert serverexts[2]['module'] == 'nbgrader.server_extensions.assignment_list'
+        assert serverexts[3]['module'] == 'nbgrader.server_extensions.course_list'
 
 
 def test_serverextension_mac():
     from nbgrader import _jupyter_server_extension_paths
     with mock_platform("darwin"):
         serverexts = _jupyter_server_extension_paths()
-        assert len(serverexts) == 3
+        assert len(serverexts) == 4
         assert serverexts[0]['module'] == 'nbgrader.server_extensions.formgrader'
         assert serverexts[1]['module'] == 'nbgrader.server_extensions.validate_assignment'
         assert serverexts[2]['module'] == 'nbgrader.server_extensions.assignment_list'
+        assert serverexts[3]['module'] == 'nbgrader.server_extensions.course_list'
 
 
 def test_serverextension_windows():

--- a/nbgrader/tests/nbextensions/conftest.py
+++ b/nbgrader/tests/nbextensions/conftest.py
@@ -95,7 +95,7 @@ def port():
     return nbserver_port
 
 
-def _make_nbserver(course_id, port, tempdir, jupyter_config_dir, jupyter_data_dir, exchange, cache):
+def _make_nbserver(course_id, port, tempdir, jupyter_config_dir, jupyter_data_dir, exchange, cache, startup_fn=None):
     env = os.environ.copy()
     env['JUPYTER_CONFIG_DIR'] = jupyter_config_dir
     env['JUPYTER_DATA_DIR'] = jupyter_data_dir
@@ -128,6 +128,9 @@ def _make_nbserver(course_id, port, tempdir, jupyter_config_dir, jupyter_data_di
                 c.Exchange.course_id = "{}"
                 """.format(exchange, cache, course_id)
             ))
+
+    if startup_fn:
+        startup_fn(env)
 
     kwargs = dict(env=env)
     if sys.platform == 'win32':

--- a/nbgrader/tests/nbextensions/test_course_list.py
+++ b/nbgrader/tests/nbextensions/test_course_list.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import TimeoutException
+
+from .conftest import notwindows, _make_nbserver, _make_browser, _close_nbserver, _close_browser
+
+
+@pytest.fixture(scope="module")
+def nbserver(request, port, tempdir, jupyter_config_dir, jupyter_data_dir, exchange, cache):
+    server = _make_nbserver("course101", port, tempdir, jupyter_config_dir, jupyter_data_dir, exchange, cache)
+
+    def fin():
+        _close_nbserver(server)
+    request.addfinalizer(fin)
+
+    return server
+
+
+@pytest.fixture(scope="module")
+def browser(request, tempdir, nbserver):
+    browser = _make_browser(tempdir)
+
+    def fin():
+        _close_browser(browser)
+    request.addfinalizer(fin)
+
+    return browser
+
+
+def _wait(browser):
+    return WebDriverWait(browser, 10)
+
+
+def _load_course_list(browser, port, retries=5):
+    # go to the correct page
+    browser.get("http://localhost:{}/tree".format(port))
+
+    def page_loaded(browser):
+        return browser.execute_script(
+            'return typeof IPython !== "undefined" && IPython.page !== undefined;')
+
+    # wait for the page to load
+    try:
+        _wait(browser).until(page_loaded)
+    except TimeoutException:
+        if retries > 0:
+            print("Retrying page load...")
+            # page timeout, but sometimes this happens, so try refreshing?
+            _load_course_list(browser, port, retries=retries - 1)
+        else:
+            print("Failed to load the page too many times")
+            raise
+
+    # wait for the extension to load
+    _wait(browser).until(EC.presence_of_element_located((By.CSS_SELECTOR, "#courses")))
+
+    # switch to the courses list
+    element = browser.find_element_by_link_text("Courses")
+    element.click()
+
+    # make sure courses are visible
+    _wait(browser).until(EC.visibility_of_element_located((By.CSS_SELECTOR, "#formgrader_list")))
+
+
+def _wait_for_list(browser, num_rows):
+    _wait(browser).until(EC.invisibility_of_element_located((By.CSS_SELECTOR, "#formgrader_list_loading")))
+    _wait(browser).until(EC.invisibility_of_element_located((By.CSS_SELECTOR, "#formgrader_list_placeholder")))
+    _wait(browser).until(EC.invisibility_of_element_located((By.CSS_SELECTOR, "#formgrader_list_error")))
+    _wait(browser).until(lambda browser: len(browser.find_elements_by_css_selector("#formgrader_list > .list_item")) == num_rows)
+    rows = browser.find_elements_by_css_selector("#formgrader_list > .list_item")
+    assert len(rows) == num_rows
+    return rows
+
+
+@pytest.mark.nbextensions
+@notwindows
+def test_show_courses_list(browser, port, tempdir):
+    _load_course_list(browser, port)
+
+    # check that there is one local course
+    rows = _wait_for_list(browser, 1)
+    assert rows[0].text == "course101\nlocal"
+
+    # make sure the url of the course is correct
+    link = browser.find_elements_by_css_selector("#formgrader_list > .list_item a")[0]
+    url = link.get_attribute("href")
+    assert url == "http://localhost:{}/formgrader".format(port)
+
+


### PR DESCRIPTION
Fixes #1060 and related to #1030

This creates a new extension called `course_list` that displays all courses available to an instructor, including local ones (that are loaded into the same single user notebook) and JupyterHub ones (which are found by querying the JupyterHub services). Currently it looks something like this:

![image](https://user-images.githubusercontent.com/83444/58709535-4665ba00-83b2-11e9-9b51-56622d5102db.png)

- [x] add docs
- [x] add tests
- [x] tes with a full JupyterHub setup

@damianavila @BertR @sigurdurb
