### PR TITLE
Fix typo in tmp filename prefix in conftest.py

### DIFF
--- a/nbgrader/tests/apps/conftest.py
+++ b/nbgrader/tests/apps/conftest.py
@@ -36,7 +36,7 @@ def course_dir(request):
 @pytest.fixture
 def temp_cwd(request, course_dir):
     orig_dir = os.getcwd()
-    path = tempfile.mkdtemp(prefix='tmp-cdw-')
+    path = tempfile.mkdtemp(prefix='tmp-cwd-')
     os.chdir(path)
 
     with open("nbgrader_config.py", "w") as fh:


### PR DESCRIPTION
This fixes a typo from pull request #1109.