### PR TITLE
Autograde & Assign: create missing students/assignments by default

### DIFF
--- a/nbgrader/apps/assignapp.py
+++ b/nbgrader/apps/assignapp.py
@@ -35,7 +35,8 @@ flags.update({
     ),
     'create': (
         {'Assign': {'create_assignment': True}},
-        "Create an entry for the assignment in the database, if one does not already exist."
+        "Deprecated: Create an entry for the assignment in the database, if one does not already exist. "
+        "This is now the default."
     ),
     'force': (
         {'BaseConverter': {'force': True}},
@@ -82,9 +83,8 @@ class AssignApp(NbGrader):
                were modified by the student (you can prevent this by passing the
                --no-db flag).
 
-               Additionally, the assignment must already be present in the
-               database. To create it while running `nbgrader assign` if it
-               doesn't already exist, pass the --create flag.
+               If the assignment is not already present in the database, it
+               will be automatically created when running `nbgrader assign`.
 
         `nbgrader assign` takes one argument (the name of the assignment), and
         looks for notebooks in the 'source' directory by default, according to

--- a/nbgrader/apps/autogradeapp.py
+++ b/nbgrader/apps/autogradeapp.py
@@ -17,7 +17,8 @@ flags.update(nbgrader_flags)
 flags.update({
     'create': (
         {'Autograde': {'create_student': True}},
-        "Create an entry for the student in the database, if one does not already exist."
+        "Deprecated: Create an entry for the student in the database, if one does not already exist. "
+        "This is now the default."
     ),
     'no-execute': (
         {
@@ -56,9 +57,8 @@ class AutogradeApp(NbGrader):
 
             autograded/{student_id}/{assignment_id}/{notebook_id}.ipynb
 
-        The student IDs must already exist in the database. If they do not, you
-        can tell `nbgrader autograde` to add them on the fly by passing the
-        --create flag.
+        The student IDs will be created in the database if they don't already
+        exist.
 
         Note that the assignment must also be present in the database. If it is
         not, you should first create it using `nbgrader assign`. Then, during

--- a/nbgrader/converters/assign.py
+++ b/nbgrader/converters/assign.py
@@ -22,7 +22,7 @@ from ..preprocessors import (
 class Assign(BaseConverter):
 
     create_assignment = Bool(
-        False,
+        True,
         help=dedent(
             """
             Whether to create the assignment at runtime if it does not

--- a/nbgrader/converters/autograde.py
+++ b/nbgrader/converters/autograde.py
@@ -15,7 +15,7 @@ from .. import utils
 class Autograde(BaseConverter):
 
     create_student = Bool(
-        False,
+        True,
         help=dedent(
             """
             Whether to create the student at runtime if it does not

--- a/nbgrader/docs/source/user_guide/creating_and_grading_assignments.ipynb
+++ b/nbgrader/docs/source/user_guide/creating_and_grading_assignments.ipynb
@@ -979,7 +979,7 @@
    "source": [
     "%%bash\n",
     "\n",
-    "nbgrader autograde \"ps1\" --create --force"
+    "nbgrader autograde \"ps1\" --force"
    ]
   },
   {

--- a/nbgrader/docs/source/user_guide/creating_and_grading_assignments.ipynb
+++ b/nbgrader/docs/source/user_guide/creating_and_grading_assignments.ipynb
@@ -688,7 +688,7 @@
    "source": [
     "%%bash\n",
     "\n",
-    "nbgrader assign \"ps1\" --IncludeHeaderFooter.header=source/header.ipynb --create --force"
+    "nbgrader assign \"ps1\" --IncludeHeaderFooter.header=source/header.ipynb --force"
    ]
   },
   {

--- a/nbgrader/tests/apps/test_api.py
+++ b/nbgrader/tests/apps/test_api.py
@@ -83,7 +83,7 @@ class TestNbGraderAPI(BaseTestApp):
 
     def test_get_autograded_students(self, api, course_dir, db):
         self._empty_notebook(join(course_dir, "source", "ps1", "problem1.ipynb"))
-        run_nbgrader(["assign", "ps1", "--create", "--db", db])
+        run_nbgrader(["assign", "ps1", "--db", db])
 
         # submitted and autograded exist, but not in the database
         self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "problem1.ipynb"))
@@ -104,7 +104,7 @@ class TestNbGraderAPI(BaseTestApp):
 
     def test_get_autograded_students_no_timestamps(self, api, course_dir, db):
         self._empty_notebook(join(course_dir, "source", "ps1", "problem1.ipynb"))
-        run_nbgrader(["assign", "ps1", "--create", "--db", db])
+        run_nbgrader(["assign", "ps1", "--db", db])
 
         # submitted and autograded exist, but not in the database
         self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "problem1.ipynb"))
@@ -173,7 +173,7 @@ class TestNbGraderAPI(BaseTestApp):
 
         # check the values once the student version of the assignment has been created
         api.course_id = "abc101"
-        run_nbgrader(["assign", "ps1", "--create", "--db", db])
+        run_nbgrader(["assign", "ps1", "--db", db])
         a = api.get_assignment("ps1")
         assert set(a.keys()) == keys
         target = default.copy()
@@ -293,7 +293,7 @@ class TestNbGraderAPI(BaseTestApp):
         assert n1 == default.copy()
 
         # check values after nbgrader assign is run
-        run_nbgrader(["assign", "ps1", "--create", "--db", db, "--force"])
+        run_nbgrader(["assign", "ps1", "--db", db, "--force"])
         n1, = api.get_notebooks("ps1")
         assert set(n1.keys()) == keys
         target = default.copy()
@@ -335,7 +335,7 @@ class TestNbGraderAPI(BaseTestApp):
         assert s == default.copy()
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
-        run_nbgrader(["assign", "ps1", "--create", "--db", db])
+        run_nbgrader(["assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "timestamp.txt"), contents="2017-07-05T12:32:56.123456")
@@ -396,7 +396,7 @@ class TestNbGraderAPI(BaseTestApp):
         assert s == default.copy()
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
-        run_nbgrader(["assign", "ps1", "--create", "--db", db])
+        run_nbgrader(["assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         s = api.get_submission("ps1", "foo")
@@ -424,7 +424,7 @@ class TestNbGraderAPI(BaseTestApp):
         assert api.get_submissions("ps1") == []
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
-        run_nbgrader(["assign", "ps1", "--create", "--db", db])
+        run_nbgrader(["assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         timestamp = datetime.now()
@@ -439,7 +439,7 @@ class TestNbGraderAPI(BaseTestApp):
     def test_filter_existing_notebooks(self, api, course_dir, db):
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p2.ipynb"))
-        run_nbgrader(["assign", "ps1", "--create", "--db", db])
+        run_nbgrader(["assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         run_nbgrader(["autograde", "ps1", "--no-execute", "--force", "--db", db])
@@ -459,7 +459,7 @@ class TestNbGraderAPI(BaseTestApp):
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p2.ipynb"))
-        run_nbgrader(["assign", "ps1", "--create", "--db", db])
+        run_nbgrader(["assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         run_nbgrader(["autograde", "ps1", "--no-execute", "--force", "--db", db])
@@ -475,7 +475,7 @@ class TestNbGraderAPI(BaseTestApp):
 
     def test_get_notebook_submission_indices(self, api, course_dir, db):
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
-        run_nbgrader(["assign", "ps1", "--create", "--db", db])
+        run_nbgrader(["assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "bar", "ps1", "p1.ipynb"))
@@ -492,7 +492,7 @@ class TestNbGraderAPI(BaseTestApp):
         assert api.get_notebook_submissions("ps1", "p1") == []
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
-        run_nbgrader(["assign", "ps1", "--create", "--db", db])
+        run_nbgrader(["assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "bar", "ps1", "p1.ipynb"))
@@ -548,7 +548,7 @@ class TestNbGraderAPI(BaseTestApp):
             }
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
-        run_nbgrader(["assign", "ps1", "--create", "--db", db])
+        run_nbgrader(["assign", "ps1", "--db", db])
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         run_nbgrader(["autograde", "ps1", "--no-execute", "--force", "--db", db])
         assert api.get_student("foo") == {
@@ -593,7 +593,7 @@ class TestNbGraderAPI(BaseTestApp):
         assert api.get_student_submissions("foo") == []
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
-        run_nbgrader(["assign", "ps1", "--create", "--db", db])
+        run_nbgrader(["assign", "ps1", "--db", db])
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         timestamp = datetime.now()
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "timestamp.txt"), contents=timestamp.isoformat())
@@ -606,7 +606,7 @@ class TestNbGraderAPI(BaseTestApp):
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p2.ipynb"))
-        run_nbgrader(["assign", "ps1", "--create", "--db", db])
+        run_nbgrader(["assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         run_nbgrader(["autograde", "ps1", "--no-execute", "--force", "--db", db])

--- a/nbgrader/tests/apps/test_api.py
+++ b/nbgrader/tests/apps/test_api.py
@@ -94,7 +94,7 @@ class TestNbGraderAPI(BaseTestApp):
         assert api.get_autograded_students("ps1") == set([])
 
         # run autograde so things are consistent
-        run_nbgrader(["autograde", "ps1", "--create", "--no-execute", "--force", "--db", db])
+        run_nbgrader(["autograde", "ps1", "--no-execute", "--force", "--db", db])
         assert api.get_autograded_students("ps1") == {"foo"}
 
         # updated submission
@@ -112,7 +112,7 @@ class TestNbGraderAPI(BaseTestApp):
         assert api.get_autograded_students("ps1") == set([])
 
         # run autograde so things are consistent
-        run_nbgrader(["autograde", "ps1", "--create", "--no-execute", "--force", "--db", db])
+        run_nbgrader(["autograde", "ps1", "--no-execute", "--force", "--db", db])
         assert api.get_autograded_students("ps1") == {"foo"}
 
         # updated submission
@@ -347,7 +347,7 @@ class TestNbGraderAPI(BaseTestApp):
         target["display_timestamp"] = "2017-07-05 12:32:56 {}".format(self.tz)
         assert s == target
 
-        run_nbgrader(["autograde", "ps1", "--create", "--no-execute", "--force", "--db", db])
+        run_nbgrader(["autograde", "ps1", "--no-execute", "--force", "--db", db])
         s = api.get_submission("ps1", "foo")
         target = default.copy()
         target["id"] = s["id"]
@@ -405,7 +405,7 @@ class TestNbGraderAPI(BaseTestApp):
         target["submitted"] = True
         assert s == target
 
-        run_nbgrader(["autograde", "ps1", "--create", "--no-execute", "--force", "--db", db])
+        run_nbgrader(["autograde", "ps1", "--no-execute", "--force", "--db", db])
         s = api.get_submission("ps1", "foo")
         target = default.copy()
         target["id"] = s["id"]
@@ -432,7 +432,7 @@ class TestNbGraderAPI(BaseTestApp):
         s1, = api.get_submissions("ps1")
         assert s1 == api.get_submission("ps1", "foo")
 
-        run_nbgrader(["autograde", "ps1", "--create", "--no-execute", "--force", "--db", db])
+        run_nbgrader(["autograde", "ps1", "--no-execute", "--force", "--db", db])
         s1, = api.get_submissions("ps1")
         assert s1 == api.get_submission("ps1", "foo")
 
@@ -442,7 +442,7 @@ class TestNbGraderAPI(BaseTestApp):
         run_nbgrader(["assign", "ps1", "--create", "--db", db])
 
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
-        run_nbgrader(["autograde", "ps1", "--create", "--no-execute", "--force", "--db", db])
+        run_nbgrader(["autograde", "ps1", "--no-execute", "--force", "--db", db])
 
         with api.gradebook as gb:
             notebooks = gb.notebook_submissions("p1", "ps1")
@@ -462,7 +462,7 @@ class TestNbGraderAPI(BaseTestApp):
         run_nbgrader(["assign", "ps1", "--create", "--db", db])
 
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
-        run_nbgrader(["autograde", "ps1", "--create", "--no-execute", "--force", "--db", db])
+        run_nbgrader(["autograde", "ps1", "--no-execute", "--force", "--db", db])
 
         with api.gradebook as gb:
             notebooks = gb.notebook_submissions("p1", "ps1")
@@ -479,7 +479,7 @@ class TestNbGraderAPI(BaseTestApp):
 
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "bar", "ps1", "p1.ipynb"))
-        run_nbgrader(["autograde", "ps1", "--create", "--no-execute", "--force", "--db", db])
+        run_nbgrader(["autograde", "ps1", "--no-execute", "--force", "--db", db])
 
         with api.gradebook as gb:
             notebooks = gb.notebook_submissions("p1", "ps1")
@@ -496,7 +496,7 @@ class TestNbGraderAPI(BaseTestApp):
 
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "bar", "ps1", "p1.ipynb"))
-        run_nbgrader(["autograde", "ps1", "--create", "--no-execute", "--force", "--db", db])
+        run_nbgrader(["autograde", "ps1", "--no-execute", "--force", "--db", db])
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "baz", "ps1", "p1.ipynb"))
 
         s = api.get_notebook_submissions("ps1", "p1")
@@ -550,7 +550,7 @@ class TestNbGraderAPI(BaseTestApp):
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         run_nbgrader(["assign", "ps1", "--create", "--db", db])
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
-        run_nbgrader(["autograde", "ps1", "--create", "--no-execute", "--force", "--db", db])
+        run_nbgrader(["autograde", "ps1", "--no-execute", "--force", "--db", db])
         assert api.get_student("foo") == {
             "id": "foo",
             "last_name": "Foo",
@@ -597,7 +597,7 @@ class TestNbGraderAPI(BaseTestApp):
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         timestamp = datetime.now()
         self._make_file(join(course_dir, "submitted", "foo", "ps1", "timestamp.txt"), contents=timestamp.isoformat())
-        run_nbgrader(["autograde", "ps1", "--create", "--no-execute", "--force", "--db", db])
+        run_nbgrader(["autograde", "ps1", "--no-execute", "--force", "--db", db])
 
         assert api.get_student_submissions("foo") == [api.get_submission("ps1", "foo")]
 
@@ -609,7 +609,7 @@ class TestNbGraderAPI(BaseTestApp):
         run_nbgrader(["assign", "ps1", "--create", "--db", db])
 
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
-        run_nbgrader(["autograde", "ps1", "--create", "--no-execute", "--force", "--db", db])
+        run_nbgrader(["autograde", "ps1", "--no-execute", "--force", "--db", db])
 
         s_p1, s_p2 = api.get_student_notebook_submissions("foo", "ps1")
         p1, = api.get_notebook_submissions("ps1", "p1")

--- a/nbgrader/tests/apps/test_nbgrader_assign.py
+++ b/nbgrader/tests/apps/test_nbgrader_assign.py
@@ -31,11 +31,14 @@ class TestNbGraderAssign(BaseTestApp):
         run_nbgrader(["assign", "foo", "bar"], retcode=1)
 
     def test_no_assignment(self, course_dir):
-        """Is an error thrown if the assignment doesn't exist?"""
+        """Is an assignment automatically created if it doesn't exist?"""
         self._empty_notebook(join(course_dir, 'source', 'ps1', 'foo.ipynb'))
-        run_nbgrader(["assign", "ps1"], retcode=1)
-        # check that the --create flag works
-        run_nbgrader(["assign", "ps1", "--create", "--debug"])
+
+        # If we explicitly disable creating assignments, assign should fail
+        run_nbgrader(["assign", "ps1", "--Assign.create_assignment=False"], retcode=1)
+
+        # The default is now to create missing assignments (formerly --create)
+        run_nbgrader(["assign", "ps1", "--debug"])
 
     def test_single_file(self, course_dir, temp_cwd):
         """Can a single file be assigned?"""
@@ -49,7 +52,7 @@ class TestNbGraderAssign(BaseTestApp):
         """Test that an error is thrown when the assignment name is invalid."""
         self._empty_notebook(join(course_dir, 'source', 'foo+bar', 'foo.ipynb'))
         with pytest.raises(traitlets.TraitError):
-            run_nbgrader(["assign", "foo+bar", "--create"])
+            run_nbgrader(["assign", "foo+bar"])
         assert not os.path.isfile(join(course_dir, "release", "foo+bar", "foo.ipynb"))
 
     def test_multiple_files(self, course_dir):

--- a/nbgrader/tests/apps/test_nbgrader_autograde.py
+++ b/nbgrader/tests/apps/test_nbgrader_autograde.py
@@ -24,7 +24,7 @@ class TestNbGraderAutograde(BaseTestApp):
         run_nbgrader(["autograde", "--help-all"])
 
     def test_missing_student(self, db, course_dir):
-        """Is an error thrown when the student is missing?"""
+        """Is a missing student automatically created?"""
         with open("nbgrader_config.py", "a") as fh:
             fh.write("""c.CourseDirectory.db_assignments = [dict(name='ps1', duedate='2015-02-02 14:58:23.948203 America/Los_Angeles')]\n""")
             fh.write("""c.CourseDirectory.db_students = [dict(id="foo"), dict(id="bar")]""")
@@ -33,10 +33,12 @@ class TestNbGraderAutograde(BaseTestApp):
         run_nbgrader(["assign", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "baz", "ps1", "p1.ipynb"))
-        run_nbgrader(["autograde", "ps1", "--db", db], retcode=1)
 
-        # check that --create works
-        run_nbgrader(["autograde", "ps1", "--db", db, "--create"])
+        # If we explicitly disable creating students, autograde should fail
+        run_nbgrader(["autograde", "ps1", "--db", db, "--Autograde.create_student=False"], retcode=1)
+
+        # The default is now to create missing students (formerly --create)
+        run_nbgrader(["autograde", "ps1", "--db", db])
 
     def test_missing_assignment(self, db, course_dir):
         """Is an error thrown when the assignment is missing?"""

--- a/nbgrader/tests/apps/test_nbgrader_db.py
+++ b/nbgrader/tests/apps/test_nbgrader_db.py
@@ -385,8 +385,8 @@ class TestNbGraderDb(BaseTestApp):
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p2.ipynb"))
 
-        # check that nbgrader assign fails
-        run_nbgrader(["assign", "ps1", "--create"])
+        # check that nbgrader assign passes
+        run_nbgrader(["assign", "ps1"])
 
         # test upgrading with a current database
         run_nbgrader(["db", "upgrade"])
@@ -400,10 +400,10 @@ class TestNbGraderDb(BaseTestApp):
         self._copy_file(join("files", "gradebook.db"), join(course_dir, "gradebook.db"))
 
         # check that nbgrader assign fails
-        run_nbgrader(["assign", "ps1", "--create"], retcode=1)
+        run_nbgrader(["assign", "ps1"], retcode=1)
 
         # upgrade the database
         run_nbgrader(["db", "upgrade"])
 
         # check that nbgrader assign passes
-        run_nbgrader(["assign", "ps1", "--create"])
+        run_nbgrader(["assign", "ps1"])


### PR DESCRIPTION
In a demo yesterday, @jhamrick suggested that the `nbgrader autograde` should behave as though `--create` was specified by default. This implements that change.

The `--create` flag can still be passed, to allow for scripts written with it, but it's a no-op now. You can still access the old behaviour (error if student doesn't exist in the database) by passing `--Autograde.create_student=False`.

**Edit:** The same now also applies to `nbgrader assign` - `--create` is now the default.