### PR TITLE
Fix logfile

### DIFF
--- a/nbgrader/apps/baseapp.py
+++ b/nbgrader/apps/baseapp.py
@@ -73,10 +73,11 @@ class NbGrader(JupyterApp):
         return "%(color)s[%(name)s | %(levelname)s]%(end_color)s %(message)s"
 
     logfile = Unicode(
-        ".nbgrader.log",
+        "",
         help=dedent(
             """
-            Name of the logfile to log to.
+            Name of the logfile to log to. By default, log output is not written
+            to any file.
             """
         )
     ).tag(config=True)

--- a/nbgrader/apps/baseapp.py
+++ b/nbgrader/apps/baseapp.py
@@ -286,14 +286,15 @@ class NbGrader(JupyterApp):
     @catch_config_error
     def initialize(self, argv=None):
         self.update_config(self.build_extra_config())
-        if self.logfile:
-            self.init_logging(logging.FileHandler, [self.logfile], color=False)
         self.init_syspath()
         self.coursedir = CourseDirectory(parent=self)
         super(NbGrader, self).initialize(argv)
 
         # load config that is in the coursedir directory
         super(JupyterApp, self).load_config_file("nbgrader_config.py", path=self.coursedir.root)
+
+        if self.logfile:
+            self.init_logging(logging.FileHandler, [self.logfile], color=False)
 
     def init_syspath(self):
         """Add the cwd to the sys.path ($PYTHONPATH)"""

--- a/nbgrader/docs/source/configuration/jupyterhub_config.rst
+++ b/nbgrader/docs/source/configuration/jupyterhub_config.rst
@@ -42,6 +42,13 @@ integrate with JupyterHub so that all grading can occur on the same server.
     Starting in version 0.5.0 of nbgrader, the formgrader is no longer a
     standalone command. Rather, it is an extension of the Jupyter notebook.
 
+.. warning::
+
+    When using nbgrader with JupyterHub, it is strongly recommended to set a
+    logfile so that you can more easily debug problems. To do so, you can set
+    a config option, for example ``NbGrader.logfile = "/usr/local/share/jupyter/nbgrader.log"``.
+
+
 Example Use Case: One Class, One Grader
 ---------------------------------------
 

--- a/nbgrader/tests/apps/test_nbgrader.py
+++ b/nbgrader/tests/apps/test_nbgrader.py
@@ -27,9 +27,10 @@ class TestNbGrader(BaseTestApp):
 
     def test_logfile(self):
         # by default, there should be no logfile created
-        files_before = set(os.listdir())
+        cwd = os.getcwd()
+        files_before = set(os.listdir(cwd))
         run_nbgrader([])
-        files_after = set(os.listdir())
+        files_after = set(os.listdir(cwd))
         assert files_before == files_after
 
         # if we specify a logfile, it should get used

--- a/nbgrader/tests/apps/test_nbgrader.py
+++ b/nbgrader/tests/apps/test_nbgrader.py
@@ -24,3 +24,14 @@ class TestNbGrader(BaseTestApp):
             run_nbgrader(["--version"], stdout=True).splitlines()[-3:]
         ).strip()
         assert out1 == out2
+
+    def test_logfile(self):
+        # by default, there should be no logfile created
+        files_before = set(os.listdir())
+        run_nbgrader([])
+        files_after = set(os.listdir())
+        assert files_before == files_after
+
+        # if we specify a logfile, it should get used
+        run_nbgrader(["--NbGrader.logfile=log.txt"])
+        assert os.path.exists("log.txt")


### PR DESCRIPTION
Fixes #997

This makes it so that setting the logfile has an effect, and also makes the default not to log to file. I think this makes more sense, as the logfile is not so useful unless you're running in a cloud setup anyways. I have added some documentation to the JupyterHub docs to encourage people to set the logfile when they're using nbgrader with JupyterHub.