### PR TITLE
Fix incorrect usage of Exchange.course_id

### DIFF
--- a/nbgrader/server_extensions/course_list/handlers.py
+++ b/nbgrader/server_extensions/course_list/handlers.py
@@ -81,7 +81,7 @@ class CourseListHandler(IPythonHandler):
 
         if status:
             raise gen.Return([{
-                'course_id': config.Exchange.course_id,
+                'course_id': config.CourseDirectory.course_id,
                 'url': base_url + '/formgrader',
                 'kind': 'local'
             }])


### PR DESCRIPTION
I broke the `multiple-classes-dev` branch when I merged #1113. This fixes that.