### PR TITLE
Ensure course directory root path has no trailing slashes

### DIFF
--- a/nbgrader/coursedir.py
+++ b/nbgrader/coursedir.py
@@ -206,6 +206,13 @@ class CourseDirectory(LoggingConfigurable):
     def _root_default(self):
         return os.getcwd()
 
+    @validate('root')
+    def _validate_root(self, proposal):
+        path = os.path.abspath(proposal['value'])
+        if path != proposal['value']:
+            self.log.warning("root '%s' is not absolute, standardizing it to '%s", proposal['value'], path)
+        return path
+
     ignore = List(
         [
             ".ipynb_checkpoints",

--- a/nbgrader/tests/apps/test_nbgrader_assign.py
+++ b/nbgrader/tests/apps/test_nbgrader_assign.py
@@ -334,7 +334,7 @@ class TestNbGraderAssign(BaseTestApp):
         """Can a single file be assigned?"""
         self._empty_notebook(join(course_dir, 'source', 'ps1', 'foo.ipynb'))
         if sys.platform == 'win32':
-            trailing_slash = "\\"
+            trailing_slash = "\\\\"
         else:
             trailing_slash = "/"
         with open("nbgrader_config.py", "a") as fh:

--- a/nbgrader/tests/apps/test_nbgrader_assign.py
+++ b/nbgrader/tests/apps/test_nbgrader_assign.py
@@ -335,10 +335,11 @@ class TestNbGraderAssign(BaseTestApp):
         self._empty_notebook(join(course_dir, 'source', 'ps1', 'foo.ipynb'))
         if sys.platform == 'win32':
             trailing_slash = "\\\\"
+            path = course_dir.replace("\\", "\\\\") + trailing_slash
         else:
             trailing_slash = "/"
+            path = course_dir + trailing_slash
         with open("nbgrader_config.py", "a") as fh:
-            fh.write("""c.CourseDirectory.root = "{}{}"\n""".format(
-                course_dir, trailing_slash))
+            fh.write("""c.CourseDirectory.root = "{}"\n""".format(path))
         run_nbgrader(["assign", "ps1"])
         assert os.path.isfile(join(course_dir, "release", "ps1", "foo.ipynb"))

--- a/nbgrader/tests/apps/test_nbgrader_assign.py
+++ b/nbgrader/tests/apps/test_nbgrader_assign.py
@@ -330,5 +330,15 @@ class TestNbGraderAssign(BaseTestApp):
         run_nbgrader(["assign", "ps1"])
         assert os.path.isfile(join(course_dir, "release", "ps1", "foo.ipynb"))
 
-
-
+    def test_trailing_slash(self, course_dir):
+        """Can a single file be assigned?"""
+        self._empty_notebook(join(course_dir, 'source', 'ps1', 'foo.ipynb'))
+        if sys.platform == 'win32':
+            trailing_slash = "\\"
+        else:
+            trailing_slash = "/"
+        with open("nbgrader_config.py", "a") as fh:
+            fh.write("""c.CourseDirectory.root = "{}{}"\n""".format(
+                course_dir, trailing_slash))
+        run_nbgrader(["assign", "ps1"])
+        assert os.path.isfile(join(course_dir, "release", "ps1", "foo.ipynb"))


### PR DESCRIPTION
Fixes #1008

This standardizes the path to the course directory root so that it is an absolute path, and adds a test to be sure that the trailing slashes are indeed removed.