### PR TITLE
Only run nbextensions tests on oldest and newest versions of python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,10 @@ matrix:
     env: GROUP=docs
   - python: nightly
     env: GROUP=docs
+  - python: 3.5
+    env: GROUP=nbextensions
+  - python: nightly
+    env: GROUP=nbextensions
 addons:
   apt:
     packages:


### PR DESCRIPTION
Will speed up running the tests a bit further too.