### PR TITLE
Add test to ensure that db upgrade succeeds before running assign

### DIFF
--- a/nbgrader/tests/apps/test_nbgrader_db.py
+++ b/nbgrader/tests/apps/test_nbgrader_db.py
@@ -391,6 +391,20 @@ class TestNbGraderDb(BaseTestApp):
         # test upgrading with a current database
         run_nbgrader(["db", "upgrade"])
 
+    def test_upgrade_old_db_no_assign(self, course_dir):
+        # add assignment files
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p2.ipynb"))
+
+        # replace the gradebook with an old version
+        self._copy_file(join("files", "gradebook.db"), join(course_dir, "gradebook.db"))
+
+        # upgrade the database
+        run_nbgrader(["db", "upgrade"])
+
+        # check that nbgrader assign passes
+        run_nbgrader(["assign", "ps1"])
+
     def test_upgrade_old_db(self, course_dir):
         # add assignment files
         self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))


### PR DESCRIPTION
There was a bug in the tests for upgrading the database in which they were succeeding, but this is because when `nbgrader assign` was run in the test case, it created the required database tables. This adds a test which does not first run `nbgrader assign` to account for this issue, and fixes the alembic scripts so that the test succeeds.