### PR TITLE
assignment_dir: Add into several missing places

### DIFF
--- a/nbgrader/exchange/fetch_feedback.py
+++ b/nbgrader/exchange/fetch_feedback.py
@@ -41,7 +41,7 @@ class ExchangeFetchFeedback(Exchange):
             root = os.path.join(self.coursedir.course_id, self.coursedir.assignment_id)
         else:
             root = self.coursedir.assignment_id
-        self.dest_path = os.path.abspath(os.path.join('.', root, 'feedback'))
+        self.dest_path = os.path.abspath(os.path.join(self.assignment_dir, root, 'feedback'))
 
     def do_copy(self, src, dest):
         self.log.info("Files to copy: {}".format(self.feedbackFiles))

--- a/nbgrader/exchange/list.py
+++ b/nbgrader/exchange/list.py
@@ -69,9 +69,9 @@ class ExchangeList(Exchange):
                 continue
 
             if self.path_includes_course:
-                root = os.path.join(info['course_id'], info['assignment_id'])
+                root = os.path.join(self.assignment_dir, info['course_id'], info['assignment_id'])
             else:
-                root = info['assignment_id']
+                root = os.path.join(self.assignment_dir, info['assignment_id'])
 
             if self.inbound or self.cached:
                 info['status'] = 'submitted'

--- a/nbgrader/exchange/list.py
+++ b/nbgrader/exchange/list.py
@@ -101,9 +101,9 @@ class ExchangeList(Exchange):
                     feedbackpath = os.path.join(self.root, info['course_id'], 'feedback', '{0}.html'.format(nb_hash))
                     # notebookDir should have the course_did in it if we have multiple courses ...
                     if self.path_includes_course:
-                        nbdir = os.path.join(info['course_id'], info['assignment_id'])
+                        nbdir = os.path.join(self.assignment_dir, info['course_id'], info['assignment_id'])
                     else:
-                        nbdir = os.path.join(info['assignment_id'])
+                        nbdir = os.path.join(self.assignment_dir, info['assignment_id'])
                     self.dest_path = os.path.abspath(os.path.join('.', root))
                     localFeedbackPath = os.path.join(nbdir, 'feedback', info['timestamp'], '{0}.html'.format(notebookName))
                     hasLocalFeedback = os.path.isfile(localFeedbackPath)

--- a/nbgrader/exchange/submit.py
+++ b/nbgrader/exchange/submit.py
@@ -37,7 +37,7 @@ class ExchangeSubmit(Exchange):
         else:
             root = self.coursedir.assignment_id
             other_path = "*"
-        self.src_path = os.path.abspath(root)
+        self.src_path = os.path.abspath(os.path.join(self.assignment_dir, root))
         self.coursedir.assignment_id = os.path.split(self.src_path)[-1]
         if not os.path.isdir(self.src_path):
             self._assignment_not_found(self.src_path, os.path.abspath(other_path))


### PR DESCRIPTION
This adds assignment_dir config to several places it was missing (see #1001).

Incidentally, while testing this I noticed something.  Without this, you have to be in the notebook root directory to fetch/submit/etc.  With this, you can be in any directory.  That seems to imply it would be beneficial to set the default to abspath(Jupyter notebook_dir) (but we can't use that directly, because it still needs to be configurable separately, that's the point of #1001).