### PR TITLE
make path relative

### DIFF
--- a/nbgrader/server_extensions/validate_assignment/handlers.py
+++ b/nbgrader/server_extensions/validate_assignment/handlers.py
@@ -6,6 +6,7 @@ import traceback
 
 from tornado import web
 from textwrap import dedent
+from pathlib import Path
 
 from notebook.utils import url_path_join as ujoin
 from notebook.base.handlers import IPythonHandler
@@ -43,8 +44,10 @@ class ValidateAssignmentHandler(IPythonHandler):
         return full_config
 
     def validate_notebook(self, path):
-        fullpath = os.path.join(self.notebook_dir, path)
-
+        #fullpath = os.path.join(self.notebook_dir, path)
+        notebook_dir = Path(self.notebook_dir).resolve()
+        rel_path = Path(path).relative_to('/')
+        fullpath = notebook_dir / rel_path
         try:
             config = self.load_config()
             validator = Validator(config=config)


### PR DESCRIPTION
the validate button is failing for me on current master with error messages like:

```
FileNotFoundError: [Errno 2] No such file or directory: '/source/Assign_1'
```

this is because path is being set with '/' as the first character, making the os.path.join with the notebook_dir a noop.  My fix using pathlib.relative_to works, but obviously it would be better to catch this at the initialization and make sure path is relative.