### PR TITLE
Add CourseDir.student_id_exclude option to exclude students

### DIFF
--- a/nbgrader/converters/base.py
+++ b/nbgrader/converters/base.py
@@ -172,6 +172,11 @@ class BaseConverter(LoggingConfigurable):
         initialization was successful).
 
         """
+        if self.coursedir.student_id_exclude:
+            exclude_ids = self.coursedir.student_id_exclude.split(',')
+            if student_id in exclude_ids:
+                return False
+
         dest = os.path.normpath(self._format_dest(assignment_id, student_id))
 
         # the destination doesn't exist, so we haven't processed it

--- a/nbgrader/coursedir.py
+++ b/nbgrader/coursedir.py
@@ -55,6 +55,19 @@ class CourseDirectory(LoggingConfigurable):
             self.log.warning("student_id '%s' has trailing whitespace, stripping it away", proposal['value'])
         return proposal['value'].strip()
 
+    student_id_exclude = Unicode(
+        "",
+        help=dedent(
+            """
+            Comma-separated list of student IDs to exclude.  Counterpart of student_id.
+
+            This is useful when running commands on all students, but certain
+            students cause errors or otherwise must be left out.  Works at
+            least for autograde, generate_feedback, and release_feedback.
+            """
+        )
+    ).tag(config=True)
+
     assignment_id = Unicode(
         "",
         help=dedent(

--- a/nbgrader/exchange/release_feedback.py
+++ b/nbgrader/exchange/release_feedback.py
@@ -31,12 +31,18 @@ class ExchangeReleaseFeedback(Exchange):
         self.log.info("student_id: {}".format(student_id))
         html_files = glob.glob(os.path.join(self.src_path, student_id, self.coursedir.assignment_id, '*.html'))
         self.log.info("html_files: {}".format(html_files))
+        if self.coursedir.student_id_exclude:
+            exclude_students = set(self.coursedir.student_id_exclude.split(','))
+        else:
+            exclude_students = set()
         for html_file in html_files:
             assignment_dir, file_name = os.path.split(html_file)
             timestamp = open(os.path.join(assignment_dir, 'timestamp.txt')).read()
             self.log.info("timestamp {}".format(timestamp))
-            user = assignment_dir.split('/')[-2]
-            submissionDir = os.path.join(self.src_path, '../submitted/', '{0}/{1}'.format(user, self.coursedir.assignment_id))
+            student_id = assignment_dir.split('/')[-2]
+            if student_id in exclude_students:
+                continue
+            submissionDir = os.path.join(self.src_path, '../submitted/', '{0}/{1}'.format(student_id, self.coursedir.assignment_id))
             fname, _ = os.path.splitext(file_name.replace('.html', ''))
             self.log.info("found html file {}".format(fname))
             nbfile = "{0}/{1}.ipynb".format(submissionDir, fname)


### PR DESCRIPTION
This adds a `--CourseDirectory.student_id_exclude` which can exclude the given students from autograding and other tasks, as in #1157.  This is useful if there is a bug which causes autograding to halt if there is a problem with one particular student.

There are no tests yet and I haven't used much.  I'm not sure if I found the right place to add this.  If it is, then let me know and I'll see about adding the tests and documentation.

-----
- This is the counterpart of the CourseDir.student_id option in that
  it rejects single students, defaulting to them all.  Really, first
  student_id is applied, and then student_id_exclude ones are skipped.
- This is useful if a single student is erroring and needs to be left
  out.