### PR TITLE
Move the fetch feedback API from formgrader to assignment_list

### DIFF
--- a/nbgrader/nbextensions/assignment_list/assignment_list.js
+++ b/nbgrader/nbextensions/assignment_list/assignment_list.js
@@ -595,11 +595,7 @@ define([
             button.attr('disabled', 'disabled');
             var url = utils.url_path_join(
                 that.base_url,
-                'formgrader',
-                'api',
-                'assignment',
-                that.data.assignment_id,
-                that.data.student_id,
+                'assignments',
                 'fetch_feedback'
             );
             ajax(url, settings);

--- a/nbgrader/server_extensions/formgrader/apihandlers.py
+++ b/nbgrader/server_extensions/formgrader/apihandlers.py
@@ -312,15 +312,6 @@ class ReleaseFeedbackHandler(BaseApiHandler):
         self.write(json.dumps(self.api.release_feedback(assignment_id, student_id)))
 
 
-class FetchFeedbackHandler(BaseApiHandler):
-    @web.authenticated
-    @check_xsrf
-    @check_notebook_dir
-    def post(self, assignment_id, student_id):
-        ret_dict = {}
-        ret_dict.update(self.api.fetch_feedback(assignment_id, student_id))
-        self.write(json.dumps(ret_dict))        
-
 default_handlers = [
     (r"/formgrader/api/status", StatusHandler),
 
@@ -334,7 +325,6 @@ default_handlers = [
     (r"/formgrader/api/assignment/([^/]+)/release_feedback", ReleaseAllFeedbackHandler),
     (r"/formgrader/api/assignment/([^/]+)/([^/]+)/generate_feedback", GenerateFeedbackHandler),
     (r"/formgrader/api/assignment/([^/]+)/([^/]+)/release_feedback", ReleaseFeedbackHandler),
-    (r"/formgrader/api/assignment/([^/]+)/([^/]+)/fetch_feedback", FetchFeedbackHandler),
 
     (r"/formgrader/api/notebooks/([^/]+)", NotebookCollectionHandler),
 


### PR DESCRIPTION
- I was basically operating by guessing, so someone should check if
  this is appropriate - there's quite a difference between the way
  that assignment_list and formgrader access the API.  I copied from
  the "fetch" is assignment_list and adjusted ExchangeFetchAssignment
  to ExchangeFetchFeedback
- Also there's a bit too much copy-and-paste, but fixing that is
  beyond me...
- But I did just run this and it *seems* to work... as in it can
  fetch.
- Closes: #1181