### PR TITLE
Associate feedback files with unique submission attempts

### DIFF
--- a/nbgrader/exchange/fetch_feedback.py
+++ b/nbgrader/exchange/fetch_feedback.py
@@ -3,7 +3,7 @@ import shutil
 import glob
 
 from .exchange import Exchange
-from ..utils import check_mode, notebook_hash
+from ..utils import check_mode, notebook_hash, make_unique_key, get_username
 
 
 class ExchangeFetchFeedback(Exchange):
@@ -15,25 +15,71 @@ class ExchangeFetchFeedback(Exchange):
         self.course_path = os.path.join(self.root, self.coursedir.course_id)
         self.outbound_path = os.path.join(self.course_path, 'feedback')
         self.src_path = os.path.join(self.outbound_path)
+        self.cache_path = os.path.join(self.cache, self.coursedir.course_id)
+
+        if self.coursedir.student_id != '*':
+            # An explicit student id has been specified on the command line; we use it as student_id
+            if '*' in self.coursedir.student_id or '+' in self.coursedir.student_id:
+                self.fail("The student ID should contain no '*' nor '+'; got {}".format(self.coursedir.student_id))
+            student_id = self.coursedir.student_id
+        else:
+            student_id = get_username()
+
         if not os.path.isdir(self.src_path):
             self._assignment_not_found(
                 self.src_path,
                 os.path.join(self.outbound_path, "*"))
         if not check_mode(self.src_path, execute=True):
             self.fail("You don't have execute permissions for the directory: {}".format(self.src_path))
+
         assignment_id = self.coursedir.assignment_id if self.coursedir.assignment_id else '*'
-        pattern = os.path.join(self.cache, self.coursedir.course_id, '*+{}+*/*.ipynb'.format(assignment_id))
-        notebooks = glob.glob(pattern)
-        self.log.info("pattern: {}".format(pattern))
-        self.feedbackFiles = []
-        self.log.info("notebooks: {}".format(notebooks))
-        for notebook in notebooks:
-            directory, nbname = os.path.split(notebook)
-            timestamp = directory.split('/')[-1].split('+')[-1]
-            nb_hash = notebook_hash(notebook)
-            feedbackpath = os.path.join(self.root, self.coursedir.course_id, 'feedback', '{0}.html'.format(nb_hash))
-            if os.path.exists(feedbackpath):
-                self.feedbackFiles.append((nbname, timestamp, feedbackpath))
+        pattern = os.path.join(self.cache_path, '*+{}+*'.format(assignment_id))
+        self.log.debug(
+            "Looking for submissions with pattern: {}".format(pattern))
+
+        self.feedback_files = []
+        submissions = [os.path.split(x)[-1] for x in glob.glob(pattern)]
+        for submission in submissions:
+            _, assignment_id, timestamp = submission.split('/')[-1].split('+')
+            self.log.debug(
+                "Looking for feedback for '{}/{}' submitted at {}".format(
+                    self.coursedir.course_id, assignment_id, timestamp))
+            pattern = os.path.join(self.cache_path, submission, "*.ipynb")
+            notebooks = glob.glob(pattern)
+            for notebook in notebooks:
+                notebook_id = os.path.splitext(os.path.split(notebook)[-1])[0]
+                unique_key = make_unique_key(
+                    self.coursedir.course_id,
+                    assignment_id,
+                    notebook_id,
+                    student_id,
+                    timestamp)
+
+                # Look for the feedback using new-style of feedback
+                self.log.debug("Unique key is: {}".format(unique_key))
+                nb_hash = notebook_hash(notebook, unique_key)
+                feedbackpath = os.path.join(self.outbound_path, '{0}.html'.format(nb_hash))
+                if os.path.exists(feedbackpath):
+                    self.feedback_files.append((notebook_id, timestamp, feedbackpath))
+                    self.log.info(
+                        "Found feedback for '{}/{}/{}' submitted at {}".format(
+                            self.coursedir.course_id, assignment_id, notebook_id, timestamp))
+                    continue
+
+                # If it doesn't exist, try the legacy hashing
+                nb_hash = notebook_hash(notebook)
+                feedbackpath = os.path.join(self.outbound_path, '{0}.html'.format(nb_hash))
+                if os.path.exists(feedbackpath):
+                    self.feedback_files.append((notebook_id, timestamp, feedbackpath))
+                    self.log.warning(
+                        "Found legacy feedback for '{}/{}/{}' submitted at {}".format(
+                            self.coursedir.course_id, assignment_id, notebook_id, timestamp))
+                    continue
+
+                # If we reached here, then there's no feedback available
+                self.log.warning(
+                    "Could not find feedback for '{}/{}/{}' submitted at {}".format(
+                        self.coursedir.course_id, assignment_id, notebook_id, timestamp))
 
     def init_dest(self):
         if self.path_includes_course:
@@ -43,16 +89,17 @@ class ExchangeFetchFeedback(Exchange):
         self.dest_path = os.path.abspath(os.path.join(self.assignment_dir, root, 'feedback'))
 
     def do_copy(self, src, dest):
-        self.log.info("Files to copy: {}".format(self.feedbackFiles))
-        for nbname, timestamp, feedbackpath in self.feedbackFiles:
-            self.log.info('{}'.format((nbname, timestamp, feedbackpath)))
-            destWithTimestamp = os.path.join(dest, timestamp)
-            if not os.path.isdir(destWithTimestamp):
-                os.makedirs(destWithTimestamp)
-            noExt, _ = os.path.splitext(nbname)
-            newName = noExt + '.html'
-            htmlFile = os.path.join(destWithTimestamp, newName)
-            shutil.copy(feedbackpath, htmlFile)
+        for notebook_id, timestamp, feedbackpath in self.feedback_files:
+            dest_with_timestamp = os.path.join(dest, timestamp)
+            if not os.path.isdir(dest_with_timestamp):
+                os.makedirs(dest_with_timestamp)
+            new_name = notebook_id + '.html'
+            html_file = os.path.join(dest_with_timestamp, new_name)
+            self.log.debug("Copying feedback from {} to {}".format(feedbackpath, html_file))
+            if os.path.exists(html_file):
+                self.log.debug("Overwriting existing feedback: {}".format(html_file))
+            shutil.copy(feedbackpath, html_file)
+            self.log.info("Fetched feedback: {}".format(html_file))
 
     def copy_files(self):
         self.log.info("Source: {}".format(self.src_path))

--- a/nbgrader/exchange/list.py
+++ b/nbgrader/exchange/list.py
@@ -2,9 +2,8 @@ import os
 import glob
 import shutil
 import re
-import hashlib
 from traitlets import Bool
-from ..utils import notebook_hash
+from ..utils import notebook_hash, make_unique_key
 from .exchange import Exchange
 
 
@@ -45,7 +44,15 @@ class ExchangeList(Exchange):
         return m.groupdict()
 
     def format_inbound_assignment(self, info):
-        return "{course_id} {student_id} {assignment_id} {timestamp}".format(**info)
+        msg = "{course_id} {student_id} {assignment_id} {timestamp}".format(**info)
+        if info['status'] == 'submitted':
+            if info['has_local_feedback']:
+                msg += " (feedback already fetched)"
+            elif info['has_exchange_feedback']:
+                msg += " (feedback ready to be fetched)"
+            else:
+                msg += " (no feedback available)"
+        return msg
 
     def format_outbound_assignment(self, info):
         msg = "{course_id} {assignment_id}".format(**info)
@@ -57,28 +64,28 @@ class ExchangeList(Exchange):
         pass
 
     def parse_assignments(self):
-        assignments = []
         if self.coursedir.student_id:
             courses = self.authenticator.get_student_courses(self.coursedir.student_id)
         else:
             courses = None
 
+        assignments = []
         for path in self.assignments:
             info = self.parse_assignment(path)
             if courses is not None and info['course_id'] not in courses:
                 continue
 
             if self.path_includes_course:
-                root = os.path.join(self.assignment_dir, info['course_id'], info['assignment_id'])
+                assignment_dir = os.path.join(self.assignment_dir, info['course_id'], info['assignment_id'])
             else:
-                root = os.path.join(self.assignment_dir, info['assignment_id'])
+                assignment_dir = os.path.join(self.assignment_dir, info['assignment_id'])
 
             if self.inbound or self.cached:
                 info['status'] = 'submitted'
                 info['path'] = path
-            elif os.path.exists(root):
+            elif os.path.exists(assignment_dir):
                 info['status'] = 'fetched'
-                info['path'] = os.path.abspath(root)
+                info['path'] = os.path.abspath(assignment_dir)
             else:
                 info['status'] = 'released'
                 info['path'] = path
@@ -86,43 +93,95 @@ class ExchangeList(Exchange):
             if self.remove:
                 info['status'] = 'removed'
 
+            notebooks = sorted(glob.glob(os.path.join(info['path'], '*.ipynb')))
+            if not notebooks:
+                self.log.warning("No notebooks found in {}".format(info['path']))
+
             info['notebooks'] = []
-            hasFeedback = False
-            allFeedbackDownloaded = True
-            for notebook in sorted(glob.glob(os.path.join(info['path'], '*.ipynb'))):
-                nbInfo = {
+            for notebook in notebooks:
+                nb_info = {
                     'notebook_id': os.path.splitext(os.path.split(notebook)[1])[0],
                     'path': os.path.abspath(notebook)
                 }
-                if info['status'] == 'submitted':
+                if info['status'] != 'submitted':
+                    info['notebooks'].append(nb_info)
+                    continue
+
+                nb_info['has_local_feedback'] = False
+                nb_info['has_exchange_feedback'] = False
+                nb_info['local_feedback_path'] = None
+
+                # Check whether feedback has been fetched already.
+                local_feedback_dir = os.path.join(
+                    assignment_dir, 'feedback', info['timestamp'])
+                local_feedback_path = os.path.join(
+                    local_feedback_dir, '{0}.html'.format(nb_info['notebook_id']))
+                has_local_feedback = os.path.isfile(local_feedback_path)
+
+                # Also look to see if there is feedback available to fetch.
+                unique_key = make_unique_key(
+                    info['course_id'],
+                    info['assignment_id'],
+                    nb_info['notebook_id'],
+                    info['student_id'],
+                    info['timestamp'])
+                self.log.debug("Unique key is: {}".format(unique_key))
+                nb_hash = notebook_hash(notebook, unique_key)
+                exchange_feedback_path = os.path.join(
+                    self.root, info['course_id'], 'feedback', '{0}.html'.format(nb_hash))
+                has_exchange_feedback = os.path.isfile(exchange_feedback_path)
+                if not has_exchange_feedback:
+                    # Try looking for legacy feedback.
                     nb_hash = notebook_hash(notebook)
-                    notebookDir, notebookFilename = os.path.split(notebook)
-                    notebookName, _ = os.path.splitext(notebookFilename)
-                    feedbackpath = os.path.join(self.root, info['course_id'], 'feedback', '{0}.html'.format(nb_hash))
-                    # notebookDir should have the course_id in it if we have multiple courses ...
-                    if self.path_includes_course:
-                        nbdir = os.path.join(self.assignment_dir, info['course_id'], info['assignment_id'])
-                    else:
-                        nbdir = os.path.join(self.assignment_dir, info['assignment_id'])
-                    self.dest_path = os.path.abspath(os.path.join('.', root))
-                    localFeedbackPath = os.path.join(nbdir, 'feedback', info['timestamp'], '{0}.html'.format(notebookName))
-                    hasLocalFeedback = os.path.isfile(localFeedbackPath)
-                    # could check for new version here
-                    nbInfo['hasLocalFeedback'] = hasLocalFeedback
-                    feedbackAvailable = os.path.exists(feedbackpath)
-                    if feedbackAvailable:
-                        nbInfo['feedbackPath'] = feedbackpath
-                        hasFeedback = True
-                    if hasLocalFeedback:
-                        nbInfo['localFeedbackPath'] = localFeedbackPath
-                    if feedbackAvailable and not hasLocalFeedback:
-                        allFeedbackDownloaded = False
+                    exchange_feedback_path = os.path.join(
+                        self.root, info['course_id'], 'feedback', '{0}.html'.format(nb_hash))
+                    has_exchange_feedback = os.path.isfile(exchange_feedback_path)
 
-                info['notebooks'].append(nbInfo)
+                nb_info['has_local_feedback'] = has_local_feedback
+                nb_info['has_exchange_feedback'] = has_exchange_feedback
+                if has_local_feedback:
+                    nb_info['local_feedback_path'] = local_feedback_path
+                info['notebooks'].append(nb_info)
 
-            info['hasFeedback'] = hasFeedback
-            info['allFeedbackDownloaded'] = allFeedbackDownloaded
+            if info['status'] == 'submitted':
+                if info['notebooks']:
+                    has_local_feedback = all([nb['has_local_feedback'] for nb in info['notebooks']])
+                    has_exchange_feedback = all([nb['has_exchange_feedback'] for nb in info['notebooks']])
+                else:
+                    has_local_feedback = False
+                    has_exchange_feedback = False
+
+                info['has_local_feedback'] = has_local_feedback
+                info['has_exchange_feedback'] = has_exchange_feedback
+                if has_local_feedback:
+                    info['local_feedback_path'] = os.path.join(
+                        assignment_dir, 'feedback', info['timestamp'])
+                else:
+                    info['local_feedback_path'] = None
+
             assignments.append(info)
+
+        # partition the assignments into groups for course/student/assignment
+        if self.inbound or self.cached:
+            _get_key = lambda info: (info['course_id'], info['student_id'], info['assignment_id'])
+            _match_key = lambda info, key: (
+                info['course_id'] == key[0] and
+                info['student_id'] == key[1] and
+                info['assignment_id'] == key[2])
+            assignment_keys = sorted(list(set([_get_key(info) for info in assignments])))
+            assignment_submissions = []
+            for key in assignment_keys:
+                submissions = [x for x in assignments if _match_key(x, key)]
+                submissions = sorted(submissions, key=lambda x: x['timestamp'])
+                info = {
+                    'course_id': key[0],
+                    'student_id': key[1],
+                    'assignment_id': key[2],
+                    'status': submissions[0]['status'],
+                    'submissions': submissions
+                }
+                assignment_submissions.append(info)
+            assignments = assignment_submissions
 
         return assignments
 
@@ -132,8 +191,9 @@ class ExchangeList(Exchange):
 
         if self.inbound or self.cached:
             self.log.info("Submitted assignments:")
-            for info in assignments:
-                self.log.info(self.format_inbound_assignment(info))
+            for assignment in assignments:
+                for info in assignment['submissions']:
+                    self.log.info(self.format_inbound_assignment(info))
         else:
             self.log.info("Released assignments:")
             for info in assignments:
@@ -147,8 +207,9 @@ class ExchangeList(Exchange):
 
         if self.inbound or self.cached:
             self.log.info("Removing submitted assignments:")
-            for info in assignments:
-                self.log.info(self.format_inbound_assignment(info))
+            for assignment in assignments:
+                for info in assignment['submissions']:
+                    self.log.info(self.format_inbound_assignment(info))
         else:
             self.log.info("Removing released assignments:")
             for info in assignments:

--- a/nbgrader/exchange/release_feedback.py
+++ b/nbgrader/exchange/release_feedback.py
@@ -1,16 +1,20 @@
 import os
 import shutil
 import glob
+import re
 from stat import S_IRUSR, S_IWUSR, S_IXUSR, S_IRGRP, S_IWGRP, S_IXGRP, S_IXOTH, S_ISGID
 
 from .exchange import Exchange
-from ..utils import notebook_hash
+from ..utils import notebook_hash, make_unique_key
 
 
 class ExchangeReleaseFeedback(Exchange):
 
     def init_src(self):
-        self.src_path = os.path.join(self.coursedir.root, self.coursedir.feedback_directory)
+        student_id = self.coursedir.student_id if self.coursedir.student_id else '*'
+        self.src_path = self.coursedir.format_path(
+            self.coursedir.feedback_directory, student_id,
+            self.coursedir.assignment_id)
 
     def init_dest(self):
         if self.coursedir.course_id == '':
@@ -22,31 +26,58 @@ class ExchangeReleaseFeedback(Exchange):
         # 0755
         self.ensure_directory(
             self.outbound_feedback_path,
-            S_IRUSR | S_IWUSR | S_IXUSR | S_IXGRP | S_IXOTH | ((S_IRGRP|S_IWGRP|S_ISGID) if self.coursedir.groupshared else 0)
+            (S_IRUSR | S_IWUSR | S_IXUSR | S_IXGRP | S_IXOTH |
+             ((S_IRGRP|S_IWGRP|S_ISGID) if self.coursedir.groupshared else 0))
         )
 
     def copy_files(self):
-        self.log.info("using src path: {}".format(self.src_path))
-        student_id = self.coursedir.student_id if self.coursedir.student_id else '*'
-        self.log.info("student_id: {}".format(student_id))
-        html_files = glob.glob(os.path.join(self.src_path, student_id, self.coursedir.assignment_id, '*.html'))
-        self.log.info("html_files: {}".format(html_files))
         if self.coursedir.student_id_exclude:
             exclude_students = set(self.coursedir.student_id_exclude.split(','))
         else:
             exclude_students = set()
+
+        html_files = glob.glob(os.path.join(self.src_path, "*.html"))
         for html_file in html_files:
-            assignment_dir, file_name = os.path.split(html_file)
-            timestamp = open(os.path.join(assignment_dir, 'timestamp.txt')).read()
-            self.log.info("timestamp {}".format(timestamp))
-            student_id = assignment_dir.split('/')[-2]
-            if student_id in exclude_students:
+            regexp = re.escape(os.path.sep).join([
+                self.coursedir.format_path(
+                    self.coursedir.feedback_directory,
+                    "(?P<student_id>.*)",
+                    self.coursedir.assignment_id, escape=True),
+                "(?P<notebook_id>.*).html"
+            ])
+
+            m = re.match(regexp, html_file)
+            if m is None:
+                msg = "Could not match '%s' with regexp '%s'" % (html_file, regexp)
+                self.log.error(msg)
                 continue
-            submissionDir = os.path.join(self.src_path, '../submitted/', '{0}/{1}'.format(student_id, self.coursedir.assignment_id))
-            fname, _ = os.path.splitext(file_name.replace('.html', ''))
-            self.log.info("found html file {}".format(fname))
-            nbfile = "{0}/{1}.ipynb".format(submissionDir, fname)
-            checksum = notebook_hash(nbfile)
-            dest = os.path.join(self.dest_path, checksum + '.html')
-            self.log.info(dest)
+
+            gd = m.groupdict()
+            student_id = gd['student_id']
+            notebook_id = gd['notebook_id']
+            if student_id in exclude_students:
+                self.log.debug("Skipping student '{}'".format(student_id))
+                continue
+
+            feedback_dir = os.path.split(html_file)[0]
+            submission_dir = self.coursedir.format_path(
+                self.coursedir.submitted_directory, student_id,
+                self.coursedir.assignment_id)
+
+            timestamp = open(os.path.join(feedback_dir, 'timestamp.txt')).read()
+            nbfile = os.path.join(submission_dir, "{}.ipynb".format(notebook_id))
+            unique_key = make_unique_key(
+                self.coursedir.course_id,
+                self.coursedir.assignment_id,
+                notebook_id,
+                student_id,
+                timestamp)
+
+            self.log.debug("Unique key is: {}".format(unique_key))
+            checksum = notebook_hash(nbfile, unique_key)
+            dest = os.path.join(self.dest_path, "{}.html".format(checksum))
+
+            self.log.info("Releasing feedback for student '{}' on assignment '{}/{}/{}' ({})".format(
+                student_id, self.coursedir.course_id, self.coursedir.assignment_id, notebook_id, timestamp))
             shutil.copy(html_file, dest)
+            self.log.info("Feedback released to: {}".format(dest))

--- a/nbgrader/server_extensions/assignment_list/handlers.py
+++ b/nbgrader/server_extensions/assignment_list/handlers.py
@@ -121,9 +121,14 @@ class AssignmentList(LoggingConfigurable):
                 }
 
             else:
+                for assignment in assignments:
+                    assignment["submissions"] = sorted(
+                        assignment["submissions"],
+                        key=lambda x: x["timestamp"])
+                assignments = sorted(assignments, key=lambda x: x["assignment_id"])
                 retvalue = {
                     "success": True,
-                    "value": sorted(assignments, key=lambda x: x['timestamp'], reverse=True)
+                    "value": assignments
                 }
 
         return retvalue

--- a/nbgrader/tests/apps/test_api.py
+++ b/nbgrader/tests/apps/test_api.py
@@ -731,7 +731,7 @@ class TestNbGraderAPI(BaseTestApp):
         os.makedirs(join(course_dir, "submitted", "foo", "ps2"))
         result = api.generate_feedback("ps2", "foo")
         assert not result["success"]
-        
+
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps2", "p2.ipynb"))
         api.generate_assignment("ps2")
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "foo", "ps2", "p2.ipynb"))
@@ -750,17 +750,17 @@ class TestNbGraderAPI(BaseTestApp):
         result = api.release_feedback("ps1", "foo")
         assert result["success"]
         assert os.path.isdir(join(exchange, "abc101", "feedback"))
-        assert os.path.exists(join(exchange, "abc101", "feedback", "65f5ff7800d0926ae6869e70f4da0b27.html"))
-        # add another assignment         
+        assert os.path.exists(join(exchange, "abc101", "feedback", "c600ef68c434c3d136bb5e68ea874169.html"))
+        # add another assignment
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps2", "p2.ipynb"))
         api.generate_assignment("ps2")
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "submitted", "foo", "ps2", "p2.ipynb"))
         self._copy_file(join("files", "timestamp.txt"), join(course_dir, "submitted", "foo", "ps2", "timestamp.txt"))
         api.autograde("ps2", "foo")
         api.generate_feedback("ps2", "foo")
-        api.release_feedback("ps2", "foo")
+        result = api.release_feedback("ps2", "foo")
         assert result["success"]
-        assert os.path.exists(join(exchange, "abc101", "feedback", "a7efd7718119cc393418ad9a185b5b3b.html"))
+        assert os.path.exists(join(exchange, "abc101", "feedback", "e190e1f234b633832f2069f4f8a3a680.html"))
 
     @notwindows
     def test_fetch_feedback(self, api, course_dir, db, cache):
@@ -779,17 +779,17 @@ class TestNbGraderAPI(BaseTestApp):
         assert result["success"]
         assert os.path.isdir(join("ps1", "feedback"))
         assert os.path.exists(join("ps1", "feedback", timestamp, "p1.html"))
-        # add another assignment         
-        self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps2", "ps2.ipynb"))
+        # add another assignment
+        self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps2", "p2.ipynb"))
         api.generate_assignment("ps2")
         cachepath = join(cache, "abc101", "foo+ps2+{}".format(timestamp))
-        self._copy_file(join("files", "submitted-changed.ipynb"), join(cachepath, "ps2.ipynb"))
+        self._copy_file(join("files", "submitted-unchanged.ipynb"), join(cachepath, "p2.ipynb"))
         self._copy_file(join("files", "timestamp.txt"), join(cachepath, "timestamp.txt"))
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "submitted", "foo", "ps2", "p2.ipynb"))
         self._copy_file(join("files", "timestamp.txt"), join(course_dir, "submitted", "foo", "ps2", "timestamp.txt"))
         api.autograde("ps2", "foo")
         api.generate_feedback("ps2", "foo")
         api.release_feedback("ps2", "foo")
-        api.fetch_feedback("ps2", "foo")
+        result = api.fetch_feedback("ps2", "foo")
         assert result["success"]
-        assert os.path.exists(join("ps2", "feedback", timestamp, "ps2.html"))
+        assert os.path.exists(join("ps2", "feedback", timestamp, "p2.html"))

--- a/nbgrader/tests/apps/test_nbgrader_list.py
+++ b/nbgrader/tests/apps/test_nbgrader_list.py
@@ -18,6 +18,24 @@ class TestNbGraderList(BaseTestApp):
         run_nbgrader([
             "release_assignment", assignment,
             "--course", course,
+            "--CourseDirectory.root={}".format(course_dir),
+            "--Exchange.cache={}".format(cache),
+            "--Exchange.root={}".format(exchange)
+        ])
+
+    def _release_full(self, assignment, exchange, cache, course_dir, course="abc101"):
+        self._copy_file(os.path.join("files", "test.ipynb"), os.path.join(course_dir, "source", assignment, "p1.ipynb"))
+        run_nbgrader([
+            "generate_assignment", assignment,
+            "--course", course,
+            "--CourseDirectory.root={}".format(course_dir),
+            "--Exchange.cache={}".format(cache),
+            "--Exchange.root={}".format(exchange)
+        ])
+        run_nbgrader([
+            "release_assignment", assignment,
+            "--course", course,
+            "--CourseDirectory.root={}".format(course_dir),
             "--Exchange.cache={}".format(cache),
             "--Exchange.root={}".format(exchange)
         ])
@@ -38,6 +56,50 @@ class TestNbGraderList(BaseTestApp):
     def _submit(self, assignment, exchange, cache, course="abc101", flags=None):
         cmd = [
             "submit", assignment,
+            "--course", course,
+            "--Exchange.cache={}".format(cache),
+            "--Exchange.root={}".format(exchange)
+        ]
+
+        if flags is not None:
+            cmd.extend(flags)
+
+        run_nbgrader(cmd)
+
+    def _make_feedback(self, assignment, exchange, cache, course_dir, course="abc101"):
+        run_nbgrader([
+            "collect", assignment,
+            "--update",
+            "--course", course,
+            "--CourseDirectory.root={}".format(course_dir),
+            "--Exchange.cache={}".format(cache),
+            "--Exchange.root={}".format(exchange)
+        ])
+        run_nbgrader([
+            "autograde", assignment,
+            "--course", course,
+            "--CourseDirectory.root={}".format(course_dir),
+            "--Exchange.cache={}".format(cache),
+            "--Exchange.root={}".format(exchange)
+        ])
+        run_nbgrader([
+            "generate_feedback", assignment,
+            "--course", course,
+            "--CourseDirectory.root={}".format(course_dir),
+            "--Exchange.cache={}".format(cache),
+            "--Exchange.root={}".format(exchange)
+        ])
+        run_nbgrader([
+            "release_feedback", assignment,
+            "--course", course,
+            "--CourseDirectory.root={}".format(course_dir),
+            "--Exchange.cache={}".format(cache),
+            "--Exchange.root={}".format(exchange)
+        ])
+
+    def _fetch_feedback(self, assignment, exchange, cache, course="abc101", flags=None):
+        cmd = [
+            "fetch_feedback", assignment,
             "--course", course,
             "--Exchange.cache={}".format(cache),
             "--Exchange.root={}".format(exchange)
@@ -156,7 +218,7 @@ class TestNbGraderList(BaseTestApp):
         assert self._list(exchange, cache, "ps1", flags=["--inbound"]) == dedent(
             """
             [ListApp | INFO] Submitted assignments:
-            [ListApp | INFO] abc101 {} ps1 {}
+            [ListApp | INFO] abc101 {} ps1 {} (no feedback available)
             """.format(get_username(), timestamp)
         ).lstrip()
 
@@ -167,8 +229,8 @@ class TestNbGraderList(BaseTestApp):
         assert self._list(exchange, cache, "ps1", flags=["--inbound"]) == dedent(
             """
             [ListApp | INFO] Submitted assignments:
-            [ListApp | INFO] abc101 {} ps1 {}
-            [ListApp | INFO] abc101 {} ps1 {}
+            [ListApp | INFO] abc101 {} ps1 {} (no feedback available)
+            [ListApp | INFO] abc101 {} ps1 {} (no feedback available)
             """.format(get_username(), timestamps[0], get_username(), timestamps[1])
         ).lstrip()
 
@@ -188,7 +250,7 @@ class TestNbGraderList(BaseTestApp):
         assert self._list(exchange, cache, "ps1", flags=["--inbound"]) == dedent(
             """
             [ListApp | INFO] Submitted assignments:
-            [ListApp | INFO] abc101 {} ps1 {}
+            [ListApp | INFO] abc101 {} ps1 {} (no feedback available)
             """.format(get_username(), timestamp)
         ).lstrip()
 
@@ -199,8 +261,8 @@ class TestNbGraderList(BaseTestApp):
         assert self._list(exchange, cache, "ps1", flags=["--inbound"]) == dedent(
             """
             [ListApp | INFO] Submitted assignments:
-            [ListApp | INFO] abc101 {} ps1 {}
-            [ListApp | INFO] abc101 {} ps1 {}
+            [ListApp | INFO] abc101 {} ps1 {} (no feedback available)
+            [ListApp | INFO] abc101 {} ps1 {} (no feedback available)
             """.format(get_username(), timestamps[0], get_username(), timestamps[1])
         ).lstrip()
 
@@ -220,7 +282,7 @@ class TestNbGraderList(BaseTestApp):
         assert self._list(exchange, cache, "ps1", flags=["--cached"]) == dedent(
             """
             [ListApp | INFO] Submitted assignments:
-            [ListApp | INFO] abc101 {} ps1 {}
+            [ListApp | INFO] abc101 {} ps1 {} (no feedback available)
             """.format(get_username(), timestamp)
         ).lstrip()
 
@@ -232,8 +294,8 @@ class TestNbGraderList(BaseTestApp):
         assert self._list(exchange, cache, "ps1", flags=["--cached"]) == dedent(
             """
             [ListApp | INFO] Submitted assignments:
-            [ListApp | INFO] abc101 {} ps1 {}
-            [ListApp | INFO] abc101 {} ps1 {}
+            [ListApp | INFO] abc101 {} ps1 {} (no feedback available)
+            [ListApp | INFO] abc101 {} ps1 {} (no feedback available)
             """.format(get_username(), timestamps[0], get_username(), timestamps[1])
         ).lstrip()
 
@@ -252,7 +314,7 @@ class TestNbGraderList(BaseTestApp):
         assert self._list(exchange, cache, flags=["--inbound"]) == dedent(
             """
             [ListApp | INFO] Submitted assignments:
-            [ListApp | INFO] abc101 {} ps2 {}
+            [ListApp | INFO] abc101 {} ps2 {} (no feedback available)
             """.format(get_username(), timestamps[1])
         ).lstrip()
         assert len(os.listdir(os.path.join(exchange, "abc101", "inbound"))) == 1
@@ -280,7 +342,7 @@ class TestNbGraderList(BaseTestApp):
         assert self._list(exchange, cache, flags=["--cached"]) == dedent(
             """
             [ListApp | INFO] Submitted assignments:
-            [ListApp | INFO] abc101 {} ps2 {}
+            [ListApp | INFO] abc101 {} ps2 {} (no feedback available)
             """.format(get_username(), timestamps[1])
         ).lstrip()
         assert len(os.listdir(os.path.join(cache, "abc101"))) == 1
@@ -307,6 +369,108 @@ class TestNbGraderList(BaseTestApp):
         assert self._list(exchange, cache, "ps1", flags=["--inbound"]) == dedent(
             """
             [ListApp | INFO] Submitted assignments:
-            [ListApp | INFO] abc101 {} ps1 {}
+            [ListApp | INFO] abc101 {} ps1 {} (no feedback available)
             """.format(get_username(), timestamp)
+        ).lstrip()
+
+    def test_list_feedback_inbound(self, exchange, cache, course_dir):
+        self._release_full("ps1", exchange, cache, course_dir)
+        self._fetch("ps1", exchange, cache)
+        self._submit("ps1", exchange, cache)
+        self._make_feedback("ps1", exchange, cache, course_dir)
+        time.sleep(1)
+        self._submit("ps1", exchange, cache)
+
+        filenames = sorted(os.listdir(os.path.join(exchange, "abc101", "inbound")))
+        timestamps = [x.split("+")[2] for x in filenames]
+        assert self._list(exchange, cache, "ps1", flags=["--inbound"]) == dedent(
+            """
+            [ListApp | INFO] Submitted assignments:
+            [ListApp | INFO] abc101 {} ps1 {} (feedback ready to be fetched)
+            [ListApp | INFO] abc101 {} ps1 {} (no feedback available)
+            """.format(get_username(), timestamps[0], get_username(), timestamps[1])
+        ).lstrip()
+
+        self._fetch_feedback("ps1", exchange, cache)
+        filenames = sorted(os.listdir(os.path.join(exchange, "abc101", "inbound")))
+        timestamps = [x.split("+")[2] for x in filenames]
+        assert self._list(exchange, cache, "ps1", flags=["--inbound"]) == dedent(
+            """
+            [ListApp | INFO] Submitted assignments:
+            [ListApp | INFO] abc101 {} ps1 {} (feedback already fetched)
+            [ListApp | INFO] abc101 {} ps1 {} (no feedback available)
+            """.format(get_username(), timestamps[0], get_username(), timestamps[1])
+        ).lstrip()
+
+        self._make_feedback("ps1", exchange, cache, course_dir)
+        filenames = sorted(os.listdir(os.path.join(exchange, "abc101", "inbound")))
+        timestamps = [x.split("+")[2] for x in filenames]
+        assert self._list(exchange, cache, "ps1", flags=["--inbound"]) == dedent(
+            """
+            [ListApp | INFO] Submitted assignments:
+            [ListApp | INFO] abc101 {} ps1 {} (feedback already fetched)
+            [ListApp | INFO] abc101 {} ps1 {} (feedback ready to be fetched)
+            """.format(get_username(), timestamps[0], get_username(), timestamps[1])
+        ).lstrip()
+
+        self._fetch_feedback("ps1", exchange, cache)
+        filenames = sorted(os.listdir(os.path.join(exchange, "abc101", "inbound")))
+        timestamps = [x.split("+")[2] for x in filenames]
+        assert self._list(exchange, cache, "ps1", flags=["--inbound"]) == dedent(
+            """
+            [ListApp | INFO] Submitted assignments:
+            [ListApp | INFO] abc101 {} ps1 {} (feedback already fetched)
+            [ListApp | INFO] abc101 {} ps1 {} (feedback already fetched)
+            """.format(get_username(), timestamps[0], get_username(), timestamps[1])
+        ).lstrip()
+
+    def test_list_feedback_cached(self, exchange, cache, course_dir):
+        self._release_full("ps1", exchange, cache, course_dir)
+        self._fetch("ps1", exchange, cache)
+        self._submit("ps1", exchange, cache)
+        self._make_feedback("ps1", exchange, cache, course_dir)
+        time.sleep(1)
+        self._submit("ps1", exchange, cache)
+
+        filenames = sorted(os.listdir(os.path.join(exchange, "abc101", "inbound")))
+        timestamps = [x.split("+")[2] for x in filenames]
+        assert self._list(exchange, cache, "ps1", flags=["--cached"]) == dedent(
+            """
+            [ListApp | INFO] Submitted assignments:
+            [ListApp | INFO] abc101 {} ps1 {} (feedback ready to be fetched)
+            [ListApp | INFO] abc101 {} ps1 {} (no feedback available)
+            """.format(get_username(), timestamps[0], get_username(), timestamps[1])
+        ).lstrip()
+
+        self._fetch_feedback("ps1", exchange, cache)
+        filenames = sorted(os.listdir(os.path.join(exchange, "abc101", "inbound")))
+        timestamps = [x.split("+")[2] for x in filenames]
+        assert self._list(exchange, cache, "ps1", flags=["--cached"]) == dedent(
+            """
+            [ListApp | INFO] Submitted assignments:
+            [ListApp | INFO] abc101 {} ps1 {} (feedback already fetched)
+            [ListApp | INFO] abc101 {} ps1 {} (no feedback available)
+            """.format(get_username(), timestamps[0], get_username(), timestamps[1])
+        ).lstrip()
+
+        self._make_feedback("ps1", exchange, cache, course_dir)
+        filenames = sorted(os.listdir(os.path.join(exchange, "abc101", "inbound")))
+        timestamps = [x.split("+")[2] for x in filenames]
+        assert self._list(exchange, cache, "ps1", flags=["--cached"]) == dedent(
+            """
+            [ListApp | INFO] Submitted assignments:
+            [ListApp | INFO] abc101 {} ps1 {} (feedback already fetched)
+            [ListApp | INFO] abc101 {} ps1 {} (feedback ready to be fetched)
+            """.format(get_username(), timestamps[0], get_username(), timestamps[1])
+        ).lstrip()
+
+        self._fetch_feedback("ps1", exchange, cache)
+        filenames = sorted(os.listdir(os.path.join(exchange, "abc101", "inbound")))
+        timestamps = [x.split("+")[2] for x in filenames]
+        assert self._list(exchange, cache, "ps1", flags=["--cached"]) == dedent(
+            """
+            [ListApp | INFO] Submitted assignments:
+            [ListApp | INFO] abc101 {} ps1 {} (feedback already fetched)
+            [ListApp | INFO] abc101 {} ps1 {} (feedback already fetched)
+            """.format(get_username(), timestamps[0], get_username(), timestamps[1])
         ).lstrip()

--- a/nbgrader/tests/apps/test_nbgrader_releasefeedback.py
+++ b/nbgrader/tests/apps/test_nbgrader_releasefeedback.py
@@ -3,7 +3,7 @@ import sys
 from os.path import join, exists, isfile
 import pytest
 
-from ...utils import remove, notebook_hash
+from ...utils import notebook_hash, make_unique_key
 from .. import run_nbgrader
 from .base import BaseTestApp
 from .conftest import notwindows
@@ -34,13 +34,14 @@ class TestNbGraderReleaseFeedback(BaseTestApp):
         nb_path = join(course_dir, "submitted", "foo", "ps1", "p1.ipynb")
         self._copy_file(join("files", "submitted-unchanged.ipynb"), nb_path)
         self._copy_file(join("files", "timestamp.txt"), join(course_dir, "submitted", "foo", "ps1", "timestamp.txt"))
-        
+
         run_nbgrader(["autograde", "ps1", "--db", db])
         run_nbgrader(["generate_feedback", "ps1", "--db", db])
         run_nbgrader(["release_feedback", "ps1", "--Exchange.root={}".format(exchange), '--course', 'abc101'])
-        nb_hash = notebook_hash(nb_path)
+        unique_key = make_unique_key("abc101", "ps1", "p1", "foo", "2019-05-30 11:44:01.911849 UTC")
+        nb_hash = notebook_hash(nb_path, unique_key)
         assert exists(join(exchange, "abc101", "feedback", "{}.html".format(nb_hash)))
-        # release feedback shoul overwrite without error
+        # release feedback should overwrite without error
         run_nbgrader(["release_feedback", "ps1", "--Exchange.root={}".format(exchange), '--course', 'abc101'])
 
     @notwindows
@@ -57,15 +58,17 @@ class TestNbGraderReleaseFeedback(BaseTestApp):
         nb_path2 = join(course_dir, "submitted", "bar", "ps1", "p1.ipynb")
         self._copy_file(join("files", "submitted-changed.ipynb"), nb_path2)
         self._copy_file(join("files", "timestamp.txt"), join(course_dir, "submitted", "bar", "ps1", "timestamp.txt"))
-        
+
         run_nbgrader(["autograde", "ps1", "--db", db])
         run_nbgrader(["generate_feedback", "ps1", "--db", db])
         run_nbgrader(["release_feedback", "ps1", "--Exchange.root={}".format(exchange), '--course', 'abc101', '--student', 'foo'])
-        nb_hash = notebook_hash(nb_path)
+        unique_key = make_unique_key("abc101", "ps1", "p1", "foo", "2019-05-30 11:44:01.911849 UTC")
+        nb_hash = notebook_hash(nb_path, unique_key)
         assert exists(join(exchange, "abc101", "feedback", "{}.html".format(nb_hash)))
-        nb_hash2 = notebook_hash(nb_path2)
+        unique_key2 = make_unique_key("abc101", "ps1", "p1", "bar", "2019-05-30 11:44:01.911849 UTC")
+        nb_hash2 = notebook_hash(nb_path2, unique_key2)
         assert not exists(join(exchange, "abc101", "feedback", "{}.html".format(nb_hash2)))
-        # release feedback shoul overwrite without error
+        # release feedback should overwrite without error
         run_nbgrader(["release_feedback", "ps1", "--Exchange.root={}".format(exchange), '--course', 'abc101'])
 
     @notwindows
@@ -87,9 +90,11 @@ class TestNbGraderReleaseFeedback(BaseTestApp):
         run_nbgrader(["generate_feedback", "ps1", "--db", db])
         run_nbgrader(["release_feedback", "ps1", "--Exchange.root={}".format(exchange), '--course', 'abc101',
                       "--CourseDirectory.student_id_exclude=bar,baz"]) # baz doesn't exist, test still OK though
-        nb_hash = notebook_hash(nb_path) # foo
+        unique_key = make_unique_key("abc101", "ps1", "p1", "foo", "2019-05-30 11:44:01.911849 UTC")
+        nb_hash = notebook_hash(nb_path, unique_key) # foo
         assert exists(join(exchange, "abc101", "feedback", "{}.html".format(nb_hash)))
-        nb_hash2 = notebook_hash(nb_path2) # bar
+        unique_key2 = make_unique_key("abc101", "ps1", "p1", "bar", "2019-05-30 11:44:01.911849 UTC")
+        nb_hash2 = notebook_hash(nb_path2, unique_key2) # bar
         assert not exists(join(exchange, "abc101", "feedback", "{}.html".format(nb_hash2)))
         # release feedback should overwrite without error
         run_nbgrader(["release_feedback", "ps1", "--Exchange.root={}".format(exchange), '--course', 'abc101'])
@@ -109,7 +114,8 @@ class TestNbGraderReleaseFeedback(BaseTestApp):
         nb_path = join(course_dir, "submitted", "foo", "ps1", "p1.ipynb")
         self._copy_file(join("files", "submitted-unchanged.ipynb"), nb_path)
         self._copy_file(join("files", "timestamp.txt"), join(course_dir, "submitted", "foo", "ps1", "timestamp.txt"))
-        nb_hash = notebook_hash(nb_path)
+        unique_key = make_unique_key("abc101", "ps1", "p1", "foo", "2019-05-30 11:44:01.911849 UTC")
+        nb_hash = notebook_hash(nb_path, unique_key)
 
         self._empty_notebook(join(course_dir, "submitted", "foo", "ps1", "foo.ipynb"))
         run_nbgrader(["autograde", "ps1", "--db", db])

--- a/nbgrader/tests/nbextensions/test_assignment_list.py
+++ b/nbgrader/tests/nbextensions/test_assignment_list.py
@@ -273,9 +273,12 @@ def test_submit_assignment(browser, port, class_files, tempdir):
     rows[0].find_element_by_css_selector(".item_status button").click()
 
     # wait for the submitted assignments list to update
-    rows = _wait_for_list(browser, "submitted", 1 + 1)  # the new assignment list adds one line for each assignment and one for each submission
+    rows = _wait_for_list(browser, "submitted", 1)
     assert rows[0].find_element_by_class_name("item_name").text == "ps.01"
     assert rows[0].find_element_by_class_name("item_course").text == "xyz 200"
+    rows = browser.find_elements_by_css_selector("#nbgrader-xyz_200-ps01-submissions > .list_item")
+    rows = rows[1:]  # first row is empty
+    assert len(rows) == 1
 
     # submit it again
     time.sleep(1)
@@ -283,13 +286,15 @@ def test_submit_assignment(browser, port, class_files, tempdir):
     rows[0].find_element_by_css_selector(".item_status button").click()
 
     # wait for the submitted assignments list to update
-    # the new assignment list adds one line for each assignment and one for each submission
-    rows = _wait_for_list(browser, "submitted", 2 + 1) 
-    rows.sort(key=_sort_rows)
-    assert rows[2].find_element_by_class_name("item_name").text == "ps.01"
-    assert rows[2].find_element_by_class_name("item_course").text == "xyz 200"
-    assert rows[0].find_element_by_class_name("item_status").text != rows[1].find_element_by_class_name("item_status").text
-
+    rows = _wait_for_list(browser, "submitted", 1)
+    assert rows[0].find_element_by_class_name("item_name").text == "ps.01"
+    assert rows[0].find_element_by_class_name("item_course").text == "xyz 200"
+    rows = browser.find_elements_by_css_selector("#nbgrader-xyz_200-ps01-submissions > .list_item")
+    rows = rows[1:]  # first row is empty
+    assert len(rows) == 2
+    timestamp1 = rows[0].find_element_by_css_selector(".item_name").text
+    timestamp2 = rows[1].find_element_by_css_selector(".item_name").text
+    assert timestamp1 != timestamp2
 
 @pytest.mark.nbextensions
 @notwindows
@@ -313,11 +318,17 @@ def test_submit_assignment_missing_notebooks(browser, port, class_files, tempdir
     rows[0].find_element_by_css_selector(".item_status button").click()
 
     # wait for the submitted assignments list to update
-    rows = _wait_for_list(browser, "submitted", 3 + 1)  # the new assignment list adds one line for each assignment and one for each submission
-    rows.sort(key=_sort_rows)
-    assert rows[3].find_element_by_class_name("item_name").text == "ps.01"
-    assert rows[3].find_element_by_class_name("item_course").text == "xyz 200"
-    assert rows[0].find_element_by_class_name("item_status").text != rows[2].find_element_by_class_name("item_status").text
+    rows = _wait_for_list(browser, "submitted", 1)
+    assert rows[0].find_element_by_class_name("item_name").text == "ps.01"
+    assert rows[0].find_element_by_class_name("item_course").text == "xyz 200"
+    rows = browser.find_elements_by_css_selector("#nbgrader-xyz_200-ps01-submissions > .list_item")
+    rows = rows[1:]  # first row is empty
+    assert len(rows) == 3
+    timestamp1 = rows[0].find_element_by_css_selector(".item_name").text
+    timestamp2 = rows[1].find_element_by_css_selector(".item_name").text
+    timestamp3 = rows[2].find_element_by_css_selector(".item_name").text
+    assert timestamp1 != timestamp2
+    assert timestamp2 != timestamp3
 
     # set strict flag
     with open('nbgrader_config.py', 'a') as config:
@@ -337,13 +348,14 @@ def test_submit_assignment_missing_notebooks(browser, port, class_files, tempdir
     _dismiss_modal(browser)
 
     # check submitted assignments list remains unchanged
-    rows = _wait_for_list(browser, "submitted", 3 + 1)  # the new assignment list adds one line for each assignment and one for each submission
-    rows.sort(key=_sort_rows)
-    assert rows[3].find_element_by_class_name("item_name").text == "ps.01"
-    assert rows[3].find_element_by_class_name("item_course").text == "xyz 200"
-    assert rows[0].find_element_by_class_name("item_status").text != rows[2].find_element_by_class_name("item_status").text
+    rows = _wait_for_list(browser, "submitted", 1)
+    assert rows[0].find_element_by_class_name("item_name").text == "ps.01"
+    assert rows[0].find_element_by_class_name("item_course").text == "xyz 200"
+    rows = browser.find_elements_by_css_selector("#nbgrader-xyz_200-ps01-submissions > .list_item")
+    rows = rows[1:]  # first row is empty
+    assert len(rows) == 3
 
-    # clean up for following tests: rename notebook back to origional name
+    # clean up for following tests: rename notebook back to original name
     assert os.path.exists(os.path.join(tempdir, "ps.01"))
     if os.path.isfile(os.path.join(tempdir, "ps.01", "my problem 1.ipynb")):
         os.rename(
@@ -391,10 +403,12 @@ def test_submit_other_assignment(browser, port, class_files, tempdir):
     rows[0].find_element_by_css_selector(".item_status button").click()
 
     # wait for the submitted assignments list to update
-    rows = _wait_for_list(browser, "submitted", 1 + 1)  # the new assignment list adds one line for each assignment and one for each submission
-    rows.sort(key=_sort_rows)
-    assert rows[1].find_element_by_class_name("item_name").text == "Problem Set 1"
-    assert rows[1].find_element_by_class_name("item_course").text == "abc101"
+    rows = _wait_for_list(browser, "submitted", 1)
+    assert rows[0].find_element_by_class_name("item_name").text == "Problem Set 1"
+    assert rows[0].find_element_by_class_name("item_course").text == "abc101"
+    rows = browser.find_elements_by_css_selector("#nbgrader-abc101-Problem_Set_1-submissions > .list_item")
+    rows = rows[1:]  # first row is empty
+    assert len(rows) == 1
 
 
 @pytest.mark.nbextensions

--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -535,7 +535,14 @@ def capture_log(app, fmt="[%(levelname)s] %(message)s"):
     return result
 
 
-def notebook_hash(path):
+def notebook_hash(path, unique_key=None):
     m = hashlib.md5()
     m.update(open(path, 'rb').read())
+    if unique_key:
+        m.update(to_bytes(unique_key))
     return m.hexdigest()
+
+
+def make_unique_key(course_id, assignment_id, notebook_id, student_id, timestamp):
+    return "+".join([
+        course_id, assignment_id, notebook_id, student_id, timestamp])


### PR DESCRIPTION
This updates the logic for computing the feedback hashes so that the hash depends both on the feedback contents as well as the course, assignment id, notebook id, student id, and timestamp. Feedback files using the previous hashing scheme should still be detected, however, so this should be backwards compatible with previously generated feedback files.

This alleviates the issue in #1141 where it was possible to fetch feedback for only some notebooks in an assignment, which had feedback available because the notebook contents hadn't changed. It also fixes the confusing behavior whereby if a student submits an unchanged assignment, they immediately have feedback available---technically it will be the same behavior, but I found this surprising and confusing since I hadn't gone through the actual process of generating feedback yet.

In the process of doing this, I restructured a bit the integration between `nbgrader list` and the Assignment List extension:
* `nbgrader list` now returns a list of submissions for each assignment, rather than a flat list of assignment submissions. 
* `nbgrader list` also now lists in the command line output what the status of feedback is (available, ready to be fetched, not available).
* Fixed a few subtle bugs relating to if you have set custom values for the `feedback` or `submitted` directories, or the way the nbgrader directory is structured.
* Also did some general code cleanup (there were some variables that were defined but not used, or two variables defined for the same thing).
* In the Assignment List extension, I created a new `Submission` class to handle the view of each individual submission.
* Separate submissions for an assignment are now listed indented under the assignment name:

<img width="1158" alt="Screen Shot 2019-08-26 at 5 33 18 PM" src="https://user-images.githubusercontent.com/83444/63706545-9fb17e00-c827-11e9-8c80-9351cbb67829.png">

Closes: #1141