### PR TITLE
Improve coverage of nbgraderformat

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,7 +5,5 @@ source = nbgrader
 
 [report]
 omit =
-    /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/*
     nbgrader/tests/*
-    nbgrader/apps/notebookapp.py
-    nbgrader/alembic
+    nbgrader/alembic/*

--- a/nbgrader/nbgraderformat/__init__.py
+++ b/nbgrader/nbgraderformat/__init__.py
@@ -1,6 +1,6 @@
-SCHEMA_VERSION = 3
-
 from .common import ValidationError, SchemaTooOldError, SchemaTooNewError
 from .v3 import MetadataValidatorV3 as MetadataValidator
 from .v3 import read_v3 as read, write_v3 as write
 from .v3 import reads_v3 as reads, writes_v3 as writes
+
+SCHEMA_VERSION = MetadataValidator.schema_version

--- a/nbgrader/nbgraderformat/v1.py
+++ b/nbgrader/nbgraderformat/v1.py
@@ -1,15 +1,13 @@
-import warnings
-
 from nbformat import read as _read, reads as _reads
 from nbformat import write as _write, writes as _writes
 from .common import BaseMetadataValidator, ValidationError
 
 class MetadataValidatorV1(BaseMetadataValidator):
 
-    schema = None
+    schema_version = 1
 
     def __init__(self):
-        super(MetadataValidatorV1, self).__init__(1)
+        super(MetadataValidatorV1, self).__init__()
 
     def _upgrade_v0_to_v1(self, cell):
         meta = cell.metadata['nbgrader']
@@ -40,7 +38,7 @@ class MetadataValidatorV1(BaseMetadataValidator):
         else:
             meta['points'] = 0.0
 
-        meta['schema_version'] = 1
+        meta['schema_version'] = self.schema_version
 
         return cell
 
@@ -48,13 +46,14 @@ class MetadataValidatorV1(BaseMetadataValidator):
         if 'nbgrader' not in cell.metadata:
             return cell
 
-        meta = cell.metadata['nbgrader']
+        if 'schema_version' not in cell.metadata['nbgrader']:
+            cell.metadata['nbgrader']['schema_version'] = 0
 
-        if 'schema_version' not in meta:
-            meta['schema_version'] = 0
-
-        if meta['schema_version'] == 0:
+        if cell.metadata['nbgrader']['schema_version'] == 0:
             cell = self._upgrade_v0_to_v1(cell)
+
+        if 'nbgrader' not in cell.metadata:
+            return cell
 
         self._remove_extra_keys(cell)
         return cell

--- a/nbgrader/nbgraderformat/v2.py
+++ b/nbgrader/nbgraderformat/v2.py
@@ -2,15 +2,14 @@ from nbformat import read as _read, reads as _reads
 from nbformat import write as _write, writes as _writes
 from .v1 import MetadataValidatorV1
 from .common import BaseMetadataValidator, ValidationError
-from ..utils import is_grade, is_solution, is_locked
 
 
 class MetadataValidatorV2(BaseMetadataValidator):
 
-    schema = None
+    schema_version = 2
 
     def __init__(self):
-        super(MetadataValidatorV2, self).__init__(2)
+        super(MetadataValidatorV2, self).__init__()
         self.v1 = MetadataValidatorV1()
 
     def _upgrade_v1_to_v2(self, cell):
@@ -21,7 +20,7 @@ class MetadataValidatorV2(BaseMetadataValidator):
             self.log.warning("Cell does not have a stored cell type! Adding default cell type.")
             meta['cell_type'] = cell.cell_type
 
-        meta['schema_version'] = 2
+        meta['schema_version'] = self.schema_version
 
         return cell
 

--- a/nbgrader/nbgraderformat/v3.py
+++ b/nbgrader/nbgraderformat/v3.py
@@ -3,21 +3,20 @@ from nbformat import write as _write, writes as _writes
 from .v1 import MetadataValidatorV1
 from .v2 import MetadataValidatorV2
 from .common import BaseMetadataValidator, ValidationError
-from ..utils import is_grade, is_solution, is_locked
 
 
 class MetadataValidatorV3(BaseMetadataValidator):
 
-    schema = None
+    schema_version = 3
 
     def __init__(self):
-        super(MetadataValidatorV3, self).__init__(3)
+        super(MetadataValidatorV3, self).__init__()
         self.v1 = MetadataValidatorV1()
         self.v2 = MetadataValidatorV2()
 
     def _upgrade_v2_to_v3(self, cell):
         meta = cell.metadata['nbgrader']
-        meta['schema_version'] = 3
+        meta['schema_version'] = self.schema_version
 
         return cell
 

--- a/nbgrader/tests/__init__.py
+++ b/nbgrader/tests/__init__.py
@@ -33,6 +33,26 @@ def create_text_cell():
     return cell
 
 
+def create_regular_cell(source, cell_type, schema_version=SCHEMA_VERSION):
+    if cell_type == "markdown":
+        cell = new_markdown_cell(source=source)
+    elif cell_type == "code":
+        cell = new_code_cell(source=source)
+    else:
+        raise ValueError("invalid cell type: {}".format(cell_type))
+
+    cell.metadata.nbgrader = {}
+    cell.metadata.nbgrader["grade"] = False
+    cell.metadata.nbgrader["grade_id"] = ""
+    cell.metadata.nbgrader["points"] = 0.0
+    cell.metadata.nbgrader["solution"] = False
+    cell.metadata.nbgrader["task"] = False
+    cell.metadata.nbgrader["locked"] = False
+    cell.metadata.nbgrader["schema_version"] = schema_version
+
+    return cell
+
+
 def create_grade_cell(source, cell_type, grade_id, points, schema_version=SCHEMA_VERSION):
     if cell_type == "markdown":
         cell = new_markdown_cell(source=source)
@@ -114,6 +134,8 @@ def create_grade_and_solution_cell(source, cell_type, grade_id, points, schema_v
 def create_task_cell(source, cell_type, grade_id, points, schema_version=SCHEMA_VERSION):
     if cell_type == "markdown":
         cell = new_markdown_cell(source=source)
+    elif cell_type == "code":
+        cell = new_code_cell(source=source)
     else:
         raise ValueError("invalid cell type: {}".format(cell_type))
 

--- a/nbgrader/tests/nbgraderformat/test_v1.py
+++ b/nbgrader/tests/nbgraderformat/test_v1.py
@@ -1,7 +1,16 @@
-from ...nbgraderformat.v1 import MetadataValidatorV1
+import os
+import pytest
+import tempfile
+from nbformat import current_nbformat, read
+from nbformat.v4 import new_notebook
+from ...nbgraderformat.common import SchemaMismatchError, ValidationError
+from ...nbgraderformat.v1 import (
+    MetadataValidatorV1, read_v1, reads_v1, write_v1, writes_v1)
 from .. import (
+    create_code_cell,
     create_grade_cell,
-    create_solution_cell)
+    create_solution_cell,
+    create_regular_cell)
 
 
 def test_set_false():
@@ -69,3 +78,138 @@ def test_schema_version():
     del cell.metadata.nbgrader["schema_version"]
     MetadataValidatorV1().upgrade_cell_metadata(cell)
     assert cell.metadata.nbgrader["schema_version"] == 1
+
+
+def test_read():
+    currdir = os.path.split(__file__)[0]
+    path = os.path.join(currdir, "..", "apps", "files", "test-v1.ipynb")
+    read_v1(path, current_nbformat)
+
+
+def test_reads():
+    currdir = os.path.split(__file__)[0]
+    path = os.path.join(currdir, "..", "apps", "files", "test-v1.ipynb")
+    contents = open(path, "r").read()
+    reads_v1(contents, current_nbformat)
+
+
+def test_write():
+    currdir = os.path.split(__file__)[0]
+    path = os.path.join(currdir, "..", "apps", "files", "test-v1.ipynb")
+    nb = read_v1(path, current_nbformat)
+    with tempfile.TemporaryFile(mode="w") as fh:
+        write_v1(nb, fh)
+
+
+def test_writes():
+    currdir = os.path.split(__file__)[0]
+    path = os.path.join(currdir, "..", "apps", "files", "test-v1.ipynb")
+    nb = read_v1(path, current_nbformat)
+    writes_v1(nb)
+
+
+def test_too_old():
+    currdir = os.path.split(__file__)[0]
+    path = os.path.join(currdir, "..", "apps", "files", "test-v0.ipynb")
+    with pytest.raises(SchemaMismatchError):
+        read_v1(path, current_nbformat)
+
+
+def test_too_new():
+    currdir = os.path.split(__file__)[0]
+    path = os.path.join(currdir, "..", "apps", "files", "test.ipynb")
+    with pytest.raises(SchemaMismatchError):
+        read_v1(path, current_nbformat)
+
+
+def test_upgrade_notebook_metadata():
+    currdir = os.path.split(__file__)[0]
+    path = os.path.join(currdir, "..", "apps", "files", "test-v0.ipynb")
+    with open(path, "r") as fh:
+        nb = read(fh, current_nbformat)
+    nb = MetadataValidatorV1().upgrade_notebook_metadata(nb)
+
+
+def test_upgrade_cell_metadata():
+    cell = create_grade_cell("", "code", "foo", 5, 0)
+    MetadataValidatorV1().upgrade_cell_metadata(cell)
+
+    cell = create_grade_cell("", "code", "foo", 5, 1)
+    MetadataValidatorV1().upgrade_cell_metadata(cell)
+
+    cell = create_grade_cell("", "code", "foo", 5, 2)
+    MetadataValidatorV1().upgrade_cell_metadata(cell)
+
+
+def test_regular_cells():
+    validator = MetadataValidatorV1()
+
+    # code cell without nbgrader metadata
+    cell = create_code_cell()
+    validator.validate_cell(cell)
+    validator.upgrade_cell_metadata(cell)
+
+    # code cell with metadata, but not an nbgrader cell
+    cell = create_regular_cell("", "code", schema_version=1)
+    del cell.metadata.nbgrader["task"]
+    validator.validate_cell(cell)
+
+    nb = new_notebook()
+    cell1 = create_code_cell()
+    cell2 = create_regular_cell("", "code", schema_version=1)
+    del cell2.metadata.nbgrader["task"]
+    nb.cells = [cell1, cell2]
+    validator.validate_nb(nb)
+
+
+def test_invalid_metadata():
+    validator = MetadataValidatorV1()
+
+    # make sure the default cell works ok
+    cell = create_grade_cell("", "code", "foo", 5, 1)
+    del cell.metadata.nbgrader["task"]
+    validator.validate_cell(cell)
+
+    # missing grade_id
+    cell = create_grade_cell("", "code", "foo", 5, 1)
+    del cell.metadata.nbgrader["task"]
+    del cell.metadata.nbgrader["grade_id"]
+    with pytest.raises(ValidationError):
+        validator.validate_cell(cell)
+
+    # grade_id is empty
+    cell = create_grade_cell("", "code", "", 5, 1)
+    del cell.metadata.nbgrader["task"]
+    with pytest.raises(ValidationError):
+        validator.validate_cell(cell)
+
+    # missing points
+    cell = create_grade_cell("", "code", "foo", 5, 1)
+    del cell.metadata.nbgrader["task"]
+    del cell.metadata.nbgrader["points"]
+    with pytest.raises(ValidationError):
+        validator.validate_cell(cell)
+
+    # markdown grade cell not marked as a solution cell
+    cell = create_grade_cell("", "markdown", "foo", 5, 1)
+    del cell.metadata.nbgrader["task"]
+    with pytest.raises(ValidationError):
+        validator.validate_cell(cell)
+
+    # markdown solution cell not marked as a grade cell
+    cell = create_solution_cell("", "markdown", "foo", 1)
+    del cell.metadata.nbgrader["task"]
+    with pytest.raises(ValidationError):
+        validator.validate_cell(cell)
+
+
+def test_duplicate_cells():
+    validator = MetadataValidatorV1()
+    nb = new_notebook()
+    cell1 = create_grade_cell("", "code", "foo", 5, 1)
+    del cell1.metadata.nbgrader["task"]
+    cell2 = create_grade_cell("", "code", "foo", 5, 1)
+    del cell2.metadata.nbgrader["task"]
+    nb.cells = [cell1, cell2]
+    with pytest.raises(ValidationError):
+        validator.validate_nb(nb)

--- a/nbgrader/tests/nbgraderformat/test_v2.py
+++ b/nbgrader/tests/nbgraderformat/test_v2.py
@@ -1,7 +1,16 @@
-from ...nbgraderformat.v2 import MetadataValidatorV2
+import os
+import pytest
+import tempfile
+from nbformat import current_nbformat, read
+from nbformat.v4 import new_notebook
+from ...nbgraderformat.common import SchemaMismatchError, ValidationError
+from ...nbgraderformat.v2 import (
+    MetadataValidatorV2, read_v2, reads_v2, write_v2, writes_v2)
 from .. import (
+    create_code_cell,
     create_grade_cell,
-    create_solution_cell)
+    create_solution_cell,
+    create_regular_cell)
 
 
 def test_set_false():
@@ -97,3 +106,152 @@ def test_cell_type():
     cell.metadata.nbgrader["cell_type"] = "code"
     MetadataValidatorV2().upgrade_cell_metadata(cell)
     assert cell.metadata.nbgrader['cell_type'] == "code"
+
+
+def test_read():
+    currdir = os.path.split(__file__)[0]
+    path = os.path.join(currdir, "..", "apps", "files", "test-v2.ipynb")
+    read_v2(path, current_nbformat)
+
+
+def test_reads():
+    currdir = os.path.split(__file__)[0]
+    path = os.path.join(currdir, "..", "apps", "files", "test-v2.ipynb")
+    contents = open(path, "r").read()
+    reads_v2(contents, current_nbformat)
+
+
+def test_write():
+    currdir = os.path.split(__file__)[0]
+    path = os.path.join(currdir, "..", "apps", "files", "test-v2.ipynb")
+    nb = read_v2(path, current_nbformat)
+    with tempfile.TemporaryFile(mode="w") as fh:
+        write_v2(nb, fh)
+
+
+def test_writes():
+    currdir = os.path.split(__file__)[0]
+    path = os.path.join(currdir, "..", "apps", "files", "test-v2.ipynb")
+    nb = read_v2(path, current_nbformat)
+    writes_v2(nb)
+
+
+def test_too_old():
+    currdir = os.path.split(__file__)[0]
+    path = os.path.join(currdir, "..", "apps", "files", "test-v0.ipynb")
+    with pytest.raises(SchemaMismatchError):
+        read_v2(path, current_nbformat)
+
+
+def test_too_new():
+    currdir = os.path.split(__file__)[0]
+    path = os.path.join(currdir, "..", "apps", "files", "test.ipynb")
+    with pytest.raises(SchemaMismatchError):
+        read_v2(path, current_nbformat)
+
+
+def test_upgrade_notebook_metadata():
+    currdir = os.path.split(__file__)[0]
+    path = os.path.join(currdir, "..", "apps", "files", "test-v0.ipynb")
+    with open(path, "r") as fh:
+        nb = read(fh, current_nbformat)
+    nb = MetadataValidatorV2().upgrade_notebook_metadata(nb)
+
+
+def test_upgrade_cell_metadata():
+    cell = create_grade_cell("", "code", "foo", 5, 0)
+    MetadataValidatorV2().upgrade_cell_metadata(cell)
+
+    cell = create_grade_cell("", "code", "foo", 5, 2)
+    MetadataValidatorV2().upgrade_cell_metadata(cell)
+
+    cell = create_grade_cell("", "code", "foo", 5, 3)
+    MetadataValidatorV2().upgrade_cell_metadata(cell)
+
+
+def test_regular_cells():
+    validator = MetadataValidatorV2()
+
+    # code cell without nbgrader metadata
+    cell = create_code_cell()
+    validator.validate_cell(cell)
+    validator.upgrade_cell_metadata(cell)
+
+    # code cell with metadata, but not an nbgrader cell
+    cell = create_regular_cell("", "code", schema_version=2)
+    del cell.metadata.nbgrader["task"]
+    validator.validate_cell(cell)
+
+    nb = new_notebook()
+    cell1 = create_code_cell()
+    cell2 = create_regular_cell("", "code", schema_version=2)
+    del cell2.metadata.nbgrader["task"]
+    nb.cells = [cell1, cell2]
+    validator.validate_nb(nb)
+
+
+def test_invalid_metadata():
+    validator = MetadataValidatorV2()
+
+    # make sure the default cell works ok
+    cell = create_grade_cell("", "code", "foo", 5, 2)
+    del cell.metadata.nbgrader["task"]
+    validator.validate_cell(cell)
+
+    # missing grade_id
+    cell = create_grade_cell("", "code", "foo", 5, 2)
+    del cell.metadata.nbgrader["task"]
+    del cell.metadata.nbgrader["grade_id"]
+    with pytest.raises(ValidationError):
+        validator.validate_cell(cell)
+
+    # grade_id is empty
+    cell = create_grade_cell("", "code", "", 5, 2)
+    del cell.metadata.nbgrader["task"]
+    with pytest.raises(ValidationError):
+        validator.validate_cell(cell)
+
+    # missing points
+    cell = create_grade_cell("", "code", "foo", 5, 2)
+    del cell.metadata.nbgrader["task"]
+    del cell.metadata.nbgrader["points"]
+    with pytest.raises(ValidationError):
+        validator.validate_cell(cell)
+
+    # markdown grade cell not marked as a solution cell
+    cell = create_grade_cell("", "markdown", "foo", 5, 2)
+    del cell.metadata.nbgrader["task"]
+    with pytest.raises(ValidationError):
+        validator.validate_cell(cell)
+
+    # markdown solution cell not marked as a grade cell
+    cell = create_solution_cell("", "markdown", "foo", 2)
+    del cell.metadata.nbgrader["task"]
+    with pytest.raises(ValidationError):
+        validator.validate_cell(cell)
+
+
+def test_duplicate_cells():
+    validator = MetadataValidatorV2()
+    nb = new_notebook()
+    cell1 = create_grade_cell("", "code", "foo", 5, 2)
+    del cell1.metadata.nbgrader["task"]
+    cell2 = create_grade_cell("", "code", "foo", 5, 2)
+    del cell2.metadata.nbgrader["task"]
+    nb.cells = [cell1, cell2]
+    with pytest.raises(ValidationError):
+        validator.validate_nb(nb)
+
+
+def test_celltype_changed(caplog):
+    cell = create_solution_cell("", "code", "foo", 2)
+    del cell.metadata.nbgrader["task"]
+    cell.metadata.nbgrader["cell_type"] = "code"
+    MetadataValidatorV2().validate_cell(cell)
+    assert "Cell type has changed from markdown to code!" not in caplog.text
+
+    cell = create_solution_cell("", "code", "foo", 2)
+    del cell.metadata.nbgrader["task"]
+    cell.metadata.nbgrader["cell_type"] = "markdown"
+    MetadataValidatorV2().validate_cell(cell)
+    assert "Cell type has changed from markdown to code!" in caplog.text

--- a/nbgrader/tests/nbgraderformat/test_v3.py
+++ b/nbgrader/tests/nbgraderformat/test_v3.py
@@ -1,8 +1,18 @@
-from ...nbgraderformat.v3 import MetadataValidatorV3
+import json
+import os
+import pytest
+import tempfile
+from nbformat import current_nbformat, read
+from nbformat.v4 import new_notebook
+from ...nbgraderformat.common import SchemaMismatchError, ValidationError
+from ...nbgraderformat.v3 import (
+    MetadataValidatorV3, read_v3, reads_v3, write_v3, writes_v3)
 from .. import (
-    create_task_cell,
+    create_code_cell,
     create_grade_cell,
-    create_solution_cell)
+    create_solution_cell,
+    create_task_cell,
+    create_regular_cell)
 
 
 def test_set_false():
@@ -107,13 +117,165 @@ def test_cell_type():
 
 def test_task_value():
     cell = create_task_cell("this is a task cell", "markdown", "foo", 0)
-    assert cell.metadata.nbgrader['task'] == True
+    assert cell.metadata.nbgrader['task']
 
     cell = create_grade_cell("", "code", "foo", "")
-    assert cell.metadata.nbgrader['task'] == False
+    assert not cell.metadata.nbgrader['task']
 
     cell = create_grade_cell("", "code", "foo", "")
-    assert cell.metadata.nbgrader['task'] == False
+    assert not cell.metadata.nbgrader['task']
 
     cell = create_solution_cell("", "code", "foo")
-    assert cell.metadata.nbgrader['task'] == False
+    assert not cell.metadata.nbgrader['task']
+
+
+def test_read():
+    currdir = os.path.split(__file__)[0]
+    path = os.path.join(currdir, "..", "apps", "files", "test.ipynb")
+    read_v3(path, current_nbformat)
+
+
+def test_reads():
+    currdir = os.path.split(__file__)[0]
+    path = os.path.join(currdir, "..", "apps", "files", "test.ipynb")
+    contents = open(path, "r").read()
+    reads_v3(contents, current_nbformat)
+
+
+def test_write():
+    currdir = os.path.split(__file__)[0]
+    path = os.path.join(currdir, "..", "apps", "files", "test.ipynb")
+    nb = read_v3(path, current_nbformat)
+    with tempfile.TemporaryFile(mode="w") as fh:
+        write_v3(nb, fh)
+
+
+def test_writes():
+    currdir = os.path.split(__file__)[0]
+    path = os.path.join(currdir, "..", "apps", "files", "test.ipynb")
+    nb = read_v3(path, current_nbformat)
+    writes_v3(nb)
+
+
+def test_too_old():
+    currdir = os.path.split(__file__)[0]
+    path = os.path.join(currdir, "..", "apps", "files", "test-v0.ipynb")
+    with pytest.raises(SchemaMismatchError):
+        read_v3(path, current_nbformat)
+
+
+def test_too_new():
+    currdir = os.path.split(__file__)[0]
+    path = os.path.join(currdir, "..", "apps", "files", "test.ipynb")
+    nb = read_v3(path, current_nbformat)
+    for cell in nb.cells:
+        if hasattr(cell.metadata, "nbgrader"):
+            cell.metadata.nbgrader.schema_version += 1
+    nb = json.dumps(nb)
+    with pytest.raises(SchemaMismatchError):
+        reads_v3(nb, current_nbformat)
+
+
+def test_upgrade_notebook_metadata():
+    currdir = os.path.split(__file__)[0]
+    path = os.path.join(currdir, "..", "apps", "files", "test-v0.ipynb")
+    with open(path, "r") as fh:
+        nb = read(fh, current_nbformat)
+    nb = MetadataValidatorV3().upgrade_notebook_metadata(nb)
+
+
+def test_upgrade_cell_metadata():
+    cell = create_grade_cell("", "code", "foo", 5, 0)
+    MetadataValidatorV3().upgrade_cell_metadata(cell)
+
+    cell = create_grade_cell("", "code", "foo", 5, 3)
+    MetadataValidatorV3().upgrade_cell_metadata(cell)
+
+    cell = create_grade_cell("", "code", "foo", 5, 4)
+    MetadataValidatorV3().upgrade_cell_metadata(cell)
+
+
+def test_regular_cells():
+    validator = MetadataValidatorV3()
+
+    # code cell without nbgrader metadata
+    cell = create_code_cell()
+    validator.validate_cell(cell)
+    validator.upgrade_cell_metadata(cell)
+
+    # code cell with metadata, but not an nbgrader cell
+    cell = create_regular_cell("", "code", schema_version=3)
+    validator.validate_cell(cell)
+
+    nb = new_notebook()
+    cell1 = create_code_cell()
+    cell2 = create_regular_cell("", "code", schema_version=3)
+    nb.cells = [cell1, cell2]
+    validator.validate_nb(nb)
+
+
+def test_invalid_metadata():
+    validator = MetadataValidatorV3()
+
+    # make sure the default cell works ok
+    cell = create_grade_cell("", "code", "foo", 5, 3)
+    validator.validate_cell(cell)
+
+    # missing grade_id
+    cell = create_grade_cell("", "code", "foo", 5, 3)
+    del cell.metadata.nbgrader["grade_id"]
+    with pytest.raises(ValidationError):
+        validator.validate_cell(cell)
+
+    # grade_id is empty
+    cell = create_grade_cell("", "code", "", 5, 3)
+    del cell.metadata.nbgrader["task"]
+    with pytest.raises(ValidationError):
+        validator.validate_cell(cell)
+
+    # missing points
+    cell = create_grade_cell("", "code", "foo", 5, 3)
+    del cell.metadata.nbgrader["points"]
+    with pytest.raises(ValidationError):
+        validator.validate_cell(cell)
+
+    # markdown grade cell not marked as a solution cell
+    cell = create_grade_cell("", "markdown", "foo", 5, 3)
+    with pytest.raises(ValidationError):
+        validator.validate_cell(cell)
+
+    # markdown solution cell not marked as a grade cell
+    cell = create_solution_cell("", "markdown", "foo", 3)
+    with pytest.raises(ValidationError):
+        validator.validate_cell(cell)
+
+    # task cell shouldn't be a code cell
+    cell = create_task_cell("", "markdown", "foo", 5, 3)
+    validator.validate_cell(cell)
+
+    # task cell shouldn't be able to be a code cell
+    cell = create_task_cell("", "code", "foo", 5, 3)
+    with pytest.raises(ValidationError):
+        validator.validate_cell(cell)
+
+
+def test_duplicate_cells():
+    validator = MetadataValidatorV3()
+    nb = new_notebook()
+    cell1 = create_grade_cell("", "code", "foo", 5, 3)
+    cell2 = create_grade_cell("", "code", "foo", 5, 3)
+    nb.cells = [cell1, cell2]
+    with pytest.raises(ValidationError):
+        validator.validate_nb(nb)
+
+
+def test_celltype_changed(caplog):
+    cell = create_solution_cell("", "code", "foo", 3)
+    cell.metadata.nbgrader["cell_type"] = "code"
+    MetadataValidatorV3().validate_cell(cell)
+    assert "Cell type has changed from markdown to code!" not in caplog.text
+
+    cell = create_solution_cell("", "code", "foo", 3)
+    cell.metadata.nbgrader["cell_type"] = "markdown"
+    MetadataValidatorV3().validate_cell(cell)
+    assert "Cell type has changed from markdown to code!" in caplog.text


### PR DESCRIPTION
First PR of several aimed at addressing #1142

This updates the outdated .coveragerc file, and adds a bunch of tests for the nbgraderformat code. I found a few bugs in the process (for example, you couldn't actually use the read and write functions for older versions of the nbgraderformat), so this is clearly a worthwhile exercise 🙂 