### PR TITLE
CourseDir.format_path: supports absolute paths in nbgrader_step

### DIFF
--- a/nbgrader/coursedir.py
+++ b/nbgrader/coursedir.py
@@ -310,7 +310,7 @@ class CourseDirectory(LoggingConfigurable):
             structure = [x.format(**kwargs) for x in full_split(self.directory_structure)]
             path = re.escape(os.path.sep).join([base] + structure)
         else:
-            path = os.path.join(self.root, self.directory_structure).format(**kwargs)
+            path = os.path.join(self.root, self.directory_structure.format(**kwargs))
 
         return path
 

--- a/nbgrader/tests/apps/test_config.py
+++ b/nbgrader/tests/apps/test_config.py
@@ -1,0 +1,15 @@
+from traitlets.config import Config
+from ...coursedir import CourseDirectory
+from .base import BaseTestApp
+from .conftest import notwindows
+
+class TestCourseDirectory(BaseTestApp):
+
+    @notwindows
+    def test_submit_rectoryget_source_assignments(self):
+        config = Config()
+        config.Exchange.course_id = "abc101"
+        config.CourseDirectory.root = "/root"
+        coursedir = CourseDirectory(config=config)
+        assert coursedir.format_path("submitted", "alice", "HW1") == "/root/submitted/alice/HW1"
+        assert coursedir.format_path("/bar/submitted", "alice", "HW1") == "/bar/submitted/alice/HW1"

--- a/nbgrader/tests/apps/test_config.py
+++ b/nbgrader/tests/apps/test_config.py
@@ -6,7 +6,7 @@ from .conftest import notwindows
 class TestCourseDirectory(BaseTestApp):
 
     @notwindows
-    def test_submit_rectoryget_source_assignments(self):
+    def test_format_path(self):
         config = Config()
         config.Exchange.course_id = "abc101"
         config.CourseDirectory.root = "/root"

--- a/nbgrader/tests/apps/test_config.py
+++ b/nbgrader/tests/apps/test_config.py
@@ -11,5 +11,7 @@ class TestCourseDirectory(BaseTestApp):
         config.Exchange.course_id = "abc101"
         config.CourseDirectory.root = "/root"
         coursedir = CourseDirectory(config=config)
+        # Test the support for both absolute paths and paths relative to the root directory
+        # See #1222
         assert coursedir.format_path("submitted", "alice", "HW1") == "/root/submitted/alice/HW1"
         assert coursedir.format_path("/bar/submitted", "alice", "HW1") == "/bar/submitted/alice/HW1"


### PR DESCRIPTION
This enables configuring absolute paths -- and in particular paths
outside of the main course directory for e.g.
c.CourseDirectory.submitted_directory.

Use case: for our course here, we have two separate shared folders (actually git repositories) among instructors. One for the course material, including the source notebooks, which is public. Another for everything involving student submissions, which is private and deleted every year. This PR gives more flexibility in the layout of the two shared folders.