### PR TITLE
Bump pytest required version to 4.5 for custom marker support

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-pytest>=4.4
+pytest>=4.5
 pytest-cov
 pytest-rerunfailures
 pytest-xdist


### PR DESCRIPTION
The tests are broken with pytest 4.4 since https://github.com/jupyter/nbgrader/commit/efc57400b04bb8728d9175b3513a1f3497f004b7