### PR TITLE
Fix formgrader API

### DIFF
--- a/nbgrader/server_extensions/formgrader/base.py
+++ b/nbgrader/server_extensions/formgrader/base.py
@@ -35,7 +35,7 @@ class BaseHandler(IPythonHandler):
         gb = self.settings['nbgrader_gradebook']
         if gb is None:
             self.log.debug("creating gradebook")
-            gb = Gradebook(self.db_url)
+            gb = Gradebook(self.db_url, self.coursedir.course_id)
             self.settings['nbgrader_gradebook'] = gb
         return gb
 


### PR DESCRIPTION
Formgrader was using the default course id for every call to the Gradebook.
By passing in the course id, every assignment in the gradebook will be created
with the course_id that was set in the config.