### PR TITLE
Fix: Application._load_config_files returns pairs (config, filename)

### DIFF
--- a/nbgrader/server_extensions/assignment_list/handlers.py
+++ b/nbgrader/server_extensions/assignment_list/handlers.py
@@ -40,7 +40,7 @@ class AssignmentList(LoggingConfigurable):
 
         config_found = False
         full_config = Config()
-        for config in NbGrader._load_config_files("nbgrader_config", path=paths, log=self.log):
+        for config, filename in NbGrader._load_config_files("nbgrader_config", path=paths, log=self.log):
             full_config.merge(config)
             config_found = True
 
@@ -60,7 +60,7 @@ class AssignmentList(LoggingConfigurable):
 
         # now cd to the full assignment directory and load the config again
         with chdir(assignment_dir):
-            for new_config in NbGrader._load_config_files("nbgrader_config", path=[os.getcwd()], log=self.log):
+            for new_config, filename in NbGrader._load_config_files("nbgrader_config", path=[os.getcwd()], log=self.log):
                 config.merge(new_config)
             yield config
 

--- a/nbgrader/server_extensions/course_list/handlers.py
+++ b/nbgrader/server_extensions/course_list/handlers.py
@@ -49,7 +49,7 @@ class CourseListHandler(IPythonHandler):
 
         config_found = False
         full_config = Config()
-        for config in NbGrader._load_config_files("nbgrader_config", path=paths, log=self.log):
+        for config, filename in NbGrader._load_config_files("nbgrader_config", path=paths, log=self.log):
             full_config.merge(config)
             config_found = True
 

--- a/nbgrader/server_extensions/validate_assignment/handlers.py
+++ b/nbgrader/server_extensions/validate_assignment/handlers.py
@@ -33,7 +33,7 @@ class ValidateAssignmentHandler(IPythonHandler):
 
         config_found = False
         full_config = Config()
-        for config in NbGrader._load_config_files("nbgrader_config", path=paths, log=self.log):
+        for config, filename in NbGrader._load_config_files("nbgrader_config", path=paths, log=self.log):
             full_config.merge(config)
             config_found = True
 

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup_args = dict(
         "notebook>=4.2",
         "nbconvert>=5.6",
         "nbformat",
-        "traitlets",
+        "traitlets>=4.3.3", # see PR #1239
         "jupyter_core",
         "jupyter_client",
         "tornado",


### PR DESCRIPTION
Steps to reproduce the original bug:
- Put a nbgrader_config.py file somewhere in the configuration path (e.g. /etc/jupyter)
- Run jupyter
- Switch to the Courses or Assignments tabs
- A error is issued with the following chunk of traceback:
        File "/opt/miniconda3/envs/info-114/lib/python3.7/site-packages/nbgrader/server_extensions/assignment_list/handlers.py", line 44, in load_config
          full_config.merge(config)
        File "/opt/miniconda3/envs/info-114/lib/python3.7/site-packages/traitlets/config/loader.py", line 185, in merge
          for k, v in other.items():
        AttributeError: 'tuple' object has no attribute 'items'

Analysis: `Application._load_config_files` from `IPython`'s `traitlets` package yields not config objects but pairs (config object, filename).

I am quite surprised this did not strike anyone earlier, and I did not find any recent change in IPython's traitlets or nbgrader that would cause this to be a recent issue. Weird.

This PR fixes the issue. I am not sure how to add a regression test though. For now I'll use a patched nbgrader in production, but if the PR could be merged, that would be great. Thanks in advance!
