### PR TITLE
Move away from using the internal Traitles API to load default configuration.

### DIFF
--- a/nbgrader/server_extensions/assignment_list/handlers.py
+++ b/nbgrader/server_extensions/assignment_list/handlers.py
@@ -38,16 +38,11 @@ class AssignmentList(LoggingConfigurable):
         paths = jupyter_config_path()
         paths.insert(0, os.getcwd())
 
-        config_found = False
-        full_config = Config()
-        for config in NbGrader._load_config_files("nbgrader_config", path=paths, log=self.log):
-            full_config.merge(config)
-            config_found = True
+        app = NbGrader()
+        app.config_file_paths.append(paths)
+        app.load_config_file()
 
-        if not config_found:
-            self.log.warning("No nbgrader_config.py file found. Rerun with DEBUG log level to see where nbgrader is looking.")
-
-        return full_config
+        return app.config
 
     @contextlib.contextmanager
     def get_assignment_dir_config(self):
@@ -60,9 +55,12 @@ class AssignmentList(LoggingConfigurable):
 
         # now cd to the full assignment directory and load the config again
         with chdir(assignment_dir):
-            for new_config in NbGrader._load_config_files("nbgrader_config", path=[os.getcwd()], log=self.log):
-                config.merge(new_config)
-            yield config
+
+            app = NbGrader()
+            app.config_file_paths.append(os.getcwd())
+            app.load_config_file()
+
+            yield app.config
 
     def list_released_assignments(self, course_id=None):
         with self.get_assignment_dir_config() as config:

--- a/nbgrader/server_extensions/course_list/handlers.py
+++ b/nbgrader/server_extensions/course_list/handlers.py
@@ -47,16 +47,11 @@ class CourseListHandler(IPythonHandler):
         paths = jupyter_config_path()
         paths.insert(0, os.getcwd())
 
-        config_found = False
-        full_config = Config()
-        for config in NbGrader._load_config_files("nbgrader_config", path=paths, log=self.log):
-            full_config.merge(config)
-            config_found = True
+        app = NbGrader()
+        app.config_file_paths.append(paths)
+        app.load_config_file()
 
-        if not config_found:
-            self.log.warning("No nbgrader_config.py file found. Rerun with DEBUG log level to see where nbgrader is looking.")
-
-        return full_config
+        return app.config
 
     @gen.coroutine
     def check_for_local_formgrader(self, config):

--- a/nbgrader/server_extensions/validate_assignment/handlers.py
+++ b/nbgrader/server_extensions/validate_assignment/handlers.py
@@ -31,16 +31,11 @@ class ValidateAssignmentHandler(IPythonHandler):
         paths = jupyter_config_path()
         paths.insert(0, os.getcwd())
 
-        config_found = False
-        full_config = Config()
-        for config in NbGrader._load_config_files("nbgrader_config", path=paths, log=self.log):
-            full_config.merge(config)
-            config_found = True
+        app = NbGrader()
+        app.config_file_paths.append(paths)
+        app.load_config_file()
 
-        if not config_found:
-            self.log.warning("No nbgrader_config.py file found. Rerun with DEBUG log level to see where nbgrader is looking.")
-
-        return full_config
+        return app.config
 
     def validate_notebook(self, path):
         fullpath = os.path.join(self.notebook_dir, path)


### PR DESCRIPTION
As discovered by @nthiery, the changed internal API in https://github.com/ipython/traitlets
broke the nbgrader build.

This PR implements the change proposed by @minrk, based on the change
to went into ipython here https://github.com/ipython/ipython/pull/10676/files