### PR TITLE
checking timestamp_format for working with dateutil.parser.parse

### DIFF
--- a/nbgrader/apps/baseapp.py
+++ b/nbgrader/apps/baseapp.py
@@ -244,16 +244,6 @@ class NbGrader(JupyterApp):
             cfg.CourseDirectory.course_id = cfg.Exchange.course_id
             del cfg.Exchange.course_id
 
-        # check for dateutil parse errors
-        if "timestamp_format" in cfg.Exchange:
-            try:
-                from dateutil.parse import parse
-                import datetime
-                ts = datetime.datetime.now().strftime(cfg.Exchange.timestamp_format)
-                ts = parse(ts)
-            except ValueError:
-                self.fail("Invalid timestamp_format: {} - could not be parsed by dateutil".format(cfg.Exchange.timestamp_format))
-
         exchange_options = [
             ("timezone", "timezone"),
             ("timestamp_format", "timestamp_format"),
@@ -277,6 +267,16 @@ class NbGrader(JupyterApp):
             )
             cfg.Exchange.merge(cfg.TransferApp)
             del cfg.TransferApp
+
+        # check for dateutil parse errors
+        if "timestamp_format" in cfg.Exchange:
+            try:
+                from dateutil.parse import parse
+                import datetime
+                ts = datetime.datetime.now().strftime(cfg.Exchange.timestamp_format)
+                ts = parse(ts)
+            except ValueError:
+                self.fail("Invalid timestamp_format: {} - could not be parsed by dateutil".format(cfg.Exchange.timestamp_format))
 
         if 'BaseNbConvertApp' in cfg:
             self.log.warning(

--- a/nbgrader/apps/baseapp.py
+++ b/nbgrader/apps/baseapp.py
@@ -244,6 +244,16 @@ class NbGrader(JupyterApp):
             cfg.CourseDirectory.course_id = cfg.Exchange.course_id
             del cfg.Exchange.course_id
 
+        # check for dateutil parse errors
+        if "timestamp_format" in cfg.Exchange:
+            try:
+                from dateutil.parse import parse
+                import datetime
+                ts = datetime.datetime.now().strftime(cfg.Exchange.timestamp_format)
+                ts = parse(ts)
+            except ValueError:
+                self.fail("Invalid timestamp_format: {} - could not be parsed by dateutil".format(cfg.Exchange.timestamp_format))
+
         exchange_options = [
             ("timezone", "timezone"),
             ("timestamp_format", "timestamp_format"),


### PR DESCRIPTION
It is allowed to change the timestamp format in nbgrader_config.py. But e.g. c.Exchange.timestamp_format = "%Y-%m-%d-%H-%M-%S-%f" will raise a ValueError('Unknown string format:', '2019-10-24-20-25-53-460007') in dateutil.parser.parse during collect of submissions. This is due to the new dependency of dateutil.parser.parse in parse_utc().
To avoid this during collection of submission, the above code will check the timestamp_format against dateutils parsing algorithm and raises an configuration error.