### PR TITLE
timestamp_format raises an exception

### DIFF
--- a/nbgrader/apps/baseapp.py
+++ b/nbgrader/apps/baseapp.py
@@ -244,16 +244,6 @@ class NbGrader(JupyterApp):
             cfg.CourseDirectory.course_id = cfg.Exchange.course_id
             del cfg.Exchange.course_id
 
-        # check for dateutil parse errors
-        if "timestamp_format" in cfg.Exchange:
-            try:
-                from dateutil.parse import parse
-                import datetime
-                ts = datetime.datetime.now().strftime(cfg.Exchange.timestamp_format)
-                ts = parse(ts)
-            except ValueError:
-                self.fail("Invalid timestamp_format: {} - could not be parsed by dateutil".format(cfg.Exchange.timestamp_format))
-
         exchange_options = [
             ("timezone", "timezone"),
             ("timestamp_format", "timestamp_format"),

--- a/nbgrader/apps/baseapp.py
+++ b/nbgrader/apps/baseapp.py
@@ -244,16 +244,6 @@ class NbGrader(JupyterApp):
             cfg.CourseDirectory.course_id = cfg.Exchange.course_id
             del cfg.Exchange.course_id
 
-        # check for dateutil parse errors
-        if "timestamp_format" in cfg.Exchange:
-            try:
-                from dateutil.parse import parse
-                import datetime
-                ts = datetime.datetime.now().strftime(cfg.Exchange.timestamp_format)
-                ts = parse(ts)
-            except ValueError:
-                self.fail("Invalid timestamp_format: {} - could not be parsed by dateutil".format(cfg.Exchange.timestamp_format))
-
         exchange_options = [
             ("timezone", "timezone"),
             ("timestamp_format", "timestamp_format"),
@@ -277,6 +267,16 @@ class NbGrader(JupyterApp):
             )
             cfg.Exchange.merge(cfg.TransferApp)
             del cfg.TransferApp
+
+        # check for dateutil parse errors
+        if "timestamp_format" in cfg.Exchange:
+            try:
+                from dateutil.parse import parse
+                import datetime
+                ts = datetime.datetime.now().strftime(cfg.Exchange.timestamp_format)
+                ts = parse(ts)
+            except ValueError:
+                self.fail("Invalid timestamp_format: {} - could not be parsed by dateutil".format(cfg.Exchange.timestamp_format))
 
         if 'BaseNbConvertApp' in cfg:
             self.log.warning(

--- a/nbgrader/apps/baseapp.py
+++ b/nbgrader/apps/baseapp.py
@@ -244,6 +244,16 @@ class NbGrader(JupyterApp):
             cfg.CourseDirectory.course_id = cfg.Exchange.course_id
             del cfg.Exchange.course_id
 
+        # check for dateutil parse errors
+        if "timestamp_format" in cfg.Exchange:
+            try:
+                from dateutil.parse import parse
+                import datetime
+                ts = datetime.datetime.now().strftime(cfg.Exchange.timestamp_format)
+                ts = parse(ts)
+            except ValueError:
+                self.fail("Invalid timestamp_format: {} - could not be parsed by dateutil".format(cfg.Exchange.timestamp_format))
+
         exchange_options = [
             ("timezone", "timezone"),
             ("timestamp_format", "timestamp_format"),
@@ -267,16 +277,6 @@ class NbGrader(JupyterApp):
             )
             cfg.Exchange.merge(cfg.TransferApp)
             del cfg.TransferApp
-
-        # check for dateutil parse errors
-        if "timestamp_format" in cfg.Exchange:
-            try:
-                from dateutil.parse import parse
-                import datetime
-                ts = datetime.datetime.now().strftime(cfg.Exchange.timestamp_format)
-                ts = parse(ts)
-            except ValueError:
-                self.fail("Invalid timestamp_format: {} - could not be parsed by dateutil".format(cfg.Exchange.timestamp_format))
 
         if 'BaseNbConvertApp' in cfg:
             self.log.warning(

--- a/nbgrader/apps/baseapp.py
+++ b/nbgrader/apps/baseapp.py
@@ -244,6 +244,16 @@ class NbGrader(JupyterApp):
             cfg.CourseDirectory.course_id = cfg.Exchange.course_id
             del cfg.Exchange.course_id
 
+        # check for dateutil parse errors
+        if "timestamp_format" in cfg.Exchange:
+            try:
+                from dateutil.parse import parse
+                import datetime
+                ts = datetime.datetime.now().strftime(cfg.Exchange.timestamp_format)
+                ts = parse(ts)
+            except ValueError:
+                self.fail("Invalid timestamp_format: {} - could not be parsed by dateutil".format(cfg.Exchange.timestamp_format))
+
         exchange_options = [
             ("timezone", "timezone"),
             ("timestamp_format", "timestamp_format"),

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -42,6 +42,17 @@ class Exchange(LoggingConfigurable):
         help="Format string for timestamps"
     ).tag(config=True)
 
+    @validate('timestamp_format')
+    def _valid_timestamp_format(self, proposal):
+        try:
+            from dateutil.parse import parse
+            import datetime
+            ts = datetime.datetime.now().strftime(proposal['value'])
+            ts = parse(ts)
+        except ValueError:
+            raise TraitError('Invalid timestamp_format: {} - could not be parsed by dateutil'.format(proposal['value']))
+        return proposal['value']
+    
     root = Unicode(
         "/srv/nbgrader/exchange",
         help="The nbgrader exchange directory writable to everyone. MUST be preexisting."

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -7,8 +7,9 @@ import glob
 from textwrap import dedent
 
 from dateutil.tz import gettz
+from dateutil.parse import parse
 from traitlets.config import LoggingConfigurable
-from traitlets import Unicode, Bool, Instance, Type, default, validate
+from traitlets import Unicode, Bool, Instance, Type, default, validate, TraitError
 from jupyter_core.paths import jupyter_data_dir
 
 from ..utils import check_directory, ignore_patterns, self_owned
@@ -45,8 +46,6 @@ class Exchange(LoggingConfigurable):
     @validate('timestamp_format')
     def _valid_timestamp_format(self, proposal):
         try:
-            from dateutil.parse import parse
-            import datetime
             ts = datetime.datetime.now().strftime(proposal['value'])
             ts = parse(ts)
         except ValueError:

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -7,7 +7,7 @@ import glob
 from textwrap import dedent
 
 from dateutil.tz import gettz
-from dateutil.parse import parse
+from dateutil.parser import parse
 from traitlets.config import LoggingConfigurable
 from traitlets import Unicode, Bool, Instance, Type, default, validate, TraitError
 from jupyter_core.paths import jupyter_data_dir


### PR DESCRIPTION
timestamp_format e.g. "%Y-%m-%d-%H-%M-%S-%f" raises an exception ValueError('Unknown string format:', '2019-10-24-20-25-53-460007') in dateutil.parser.parse during collect of submissions. This is due to the dependency of dateutil.parser.parse in parse_utc(). To avoid this during collection of submission, this PR will validate the timestamp_format against dateutils parsing algorithm and raises a TraitError if a ValueError in dateutil.parser.parse occurs.