### PR TITLE
add pytest-testmon to allow only affected tests to be rerun

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ gradebook.db
 package-lock.json
 .goutputstream*
 
+.testmondata

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,6 +2,7 @@ pytest>=4.5
 pytest-cov
 pytest-rerunfailures
 pytest-xdist
+pytest-testmon
 coverage
 selenium
 sphinx

--- a/nbgrader/apps/api.py
+++ b/nbgrader/apps/api.py
@@ -49,6 +49,9 @@ class NbGraderAPI(LoggingConfigurable):
             self.log_level = new
         self.log.setLevel(new)
 
+        # TODO: Remove this after Travis build test
+        assert True
+
     def __init__(self, coursedir=None, authenticator=None, **kwargs):
         """Initialize the API.
 

--- a/tasks.py
+++ b/tasks.py
@@ -80,7 +80,7 @@ def _run_tests(mark, skip, junitxml, paralell=False):
 def tests(args):
     if args.group == 'python':
         _run_tests(
-            mark="not nbextensions", skip=args.skip, junitxml=args.junitxml, paralell=True)
+            mark="not nbextensions", skip=args.skip, junitxml=args.junitxml)
 
     elif args.group == 'nbextensions':
         _run_tests(mark="nbextensions", skip=args.skip, junitxml=args.junitxml)

--- a/tasks.py
+++ b/tasks.py
@@ -57,6 +57,7 @@ def _run_tests(mark, skip, junitxml, paralell=False):
         cmd.extend(['--junitxml', junitxml])
     cmd.append('-v')
     cmd.append('-x')
+    cmd.append('--testmon')
     if paralell:
         cmd.extend(['--numprocesses', 'auto'])
     cmd.extend(['--reruns', '4'])


### PR DESCRIPTION
Introducing [Pytest Testmon](https://testmon.org) into the project to improve developer experience in running `pytest`. 

pytest-testmon is a pytest plugin which selects and executes only tests you need to run. It does this by collecting dependencies between tests and all executed code (internally using Coverage.py) and comparing the dependencies against changes. testmon updates its database on each test execution, so it works independently of version control.

This fixes #1252