### PR TITLE
Add requirements for readthedocs

### DIFF
--- a/readthedocs-requirements.txt
+++ b/readthedocs-requirements.txt
@@ -1,0 +1,2 @@
+sphinx_autodoc_typehints
+-e .

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -1,6 +1,6 @@
 name: nbgrader
 type: sphinx
-requirements_file: requirements.txt
+requirements_file: readthedocs-requirements.txt
 python:
   version: 3
   setup_py_install: true


### PR DESCRIPTION
readthedocs doesn't know about sphinx_autodoc_typehints, but we don't want to add it into the regular dependencies, so I'm creating a special dependencies file for readthedocs specifically.