### PR TITLE
Improve formatting for high point value questions and assignments.

### DIFF
--- a/nbgrader/nbextensions/create_assignment/create_assignment.css
+++ b/nbgrader/nbextensions/create_assignment/create_assignment.css
@@ -3,7 +3,7 @@ div.nbgrader-points, div.nbgrader-id {
 }
 
 input.nbgrader-points-input {
-    width: 3.5em;
+    width: 8em;
     height: 22px;
     text-align: right;
     line-height: 10px;
@@ -17,12 +17,12 @@ input.nbgrader-id-input {
 }
 
 #nbgrader-total-points {
-    width: 3em;
-    height: 24px;
-    text-align: right;
-    line-height: 10px;
     margin-left: 0.3em;
     margin-right: 0.3em;
+    padding-left: 0.3em;
+    padding-right: 0.3em;
+    display: inline-block;
+    border: 1px solid black;
 }
 
 div.nbgrader-highlight div.celltoolbar {
@@ -41,6 +41,7 @@ div.nbgrader-highlight div.text_cell_render, div.nbgrader-highlight div.input_ar
     cf https://github.com/jupyter/nbgrader/issues/394.
     manual workaround while #370 is not released. */
     display: -webkit-flex;
+    height: auto;
 }
 
 div.lock-cell-container {

--- a/nbgrader/nbextensions/create_assignment/main.js
+++ b/nbgrader/nbextensions/create_assignment/main.js
@@ -46,10 +46,9 @@ define([
                 elem = $("<div />").attr("id", "nbgrader-total-points-group");
                 elem.addClass("btn-group");
                 elem.append($("<span />").text("Total points:"));
-                elem.append($("<input />")
-                            .attr("disabled", "disabled")
-                            .attr("type", "number")
-                            .attr("id", "nbgrader-total-points"));
+                elem.append($("<div />")
+                            .attr("id", "nbgrader-total-points")
+                            .html("0"));
                 $("#maintoolbar-container").append(elem);
             }
             elem.show();
@@ -104,7 +103,8 @@ define([
                 total_points += to_float(cells[i].metadata.nbgrader.points);
             }
         }
-        $("#nbgrader-total-points").attr("value", total_points);
+        var pretty_points = total_points.toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,');
+        $("#nbgrader-total-points").html(pretty_points);
     };
 
     var validate_ids = function() {

--- a/nbgrader/tests/nbextensions/test_create_assignment.py
+++ b/nbgrader/tests/nbextensions/test_create_assignment.py
@@ -215,7 +215,7 @@ def _get_metadata(browser):
 
 def _get_total_points(browser):
     element = browser.find_element_by_id("nbgrader-total-points")
-    return float(element.get_attribute("value"))
+    return float(element.text)
 
 
 def _save(browser):


### PR DESCRIPTION
I have a class in which I'm offering 4.54 billion available points (age of the Earth). Each assignment is then worth a couple hundred million points, which presents a challenge in the nbgrader interface. I've found the point value fields way too small to be useful for this purpose. This pull request does three things:
* Make the input cells wider.
* Improve the point total, by switching it to a `<div>` element with a pretty-formatted number.
* Allow cell headers to expand vertically to fit their content. This improves compatibility with Firefox, where the cell toolbar is otherwise awkwardly small for some reason.
![Screenshot from 2020-02-05 19-57-36](https://user-images.githubusercontent.com/6118266/73905143-31033280-4853-11ea-93aa-07f21c288f99.png)