### PR TITLE
ExchangeFetchAssignment deleting the wrong config

### DIFF
--- a/nbgrader/exchange/fetch_assignment.py
+++ b/nbgrader/exchange/fetch_assignment.py
@@ -17,11 +17,11 @@ class ExchangeFetchAssignment(Exchange):
                 "Use ExchangeFetchAssignment in config, not ExchangeFetch. Outdated config:\n%s",
                 '\n'.join(
                     'ExchangeFetch.{key} = {value!r}'.format(key=key, value=value)
-                    for key, value in cfg.ExchangeFetchAssignment.items()
+                    for key, value in cfg.ExchangeFetch.items()
                 )
             )
             cfg.ExchangeFetchAssignment.merge(cfg.ExchangeFetch)
-            del cfg.ExchangeFetchAssignment
+            del cfg.ExchangeFetch
 
         super(ExchangeFetchAssignment, self)._load_config(cfg, **kwargs)
 


### PR DESCRIPTION
The logic for displaying warning and updating config when a user supplied configuration using the old ExchangeFetch class has a couple of errors in it.

These errors mean that the ExchangeFetchAssignment ignores all configuration passed to it, if there's configurations for the ExchangeFetch class in the config file.

This is especially bad if someone has partially updated an old config file and accidentally left some references to ExchangeFetch in it, while correctly updating other references.

(The ExchangeReleaseAssignment is correct as it is.)