### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/nbgrader/converters/base.py
+++ b/nbgrader/converters/base.py
@@ -5,6 +5,7 @@ import shutil
 import sqlalchemy
 import traceback
 
+from rapidfuzz import fuzz
 from traitlets.config import LoggingConfigurable, Config
 from traitlets import Bool, List, Dict, Integer, Instance, Type
 from traitlets import default
@@ -120,11 +121,6 @@ class BaseConverter(LoggingConfigurable):
             assignment_glob2 = self._format_source("*", self.coursedir.student_id)
             found = glob.glob(assignment_glob2)
             if found:
-                # Normally it is a bad idea to put imports in the middle of
-                # a function, but we do this here because otherwise fuzzywuzzy
-                # prints an annoying message about python-Levenshtein every
-                # time nbgrader is run.
-                from fuzzywuzzy import fuzz
                 scores = sorted([(fuzz.ratio(assignment_glob, x), x) for x in found])
                 self.log.error("Did you mean: %s", scores[-1][1])
 

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -8,6 +8,7 @@ from textwrap import dedent
 
 from dateutil.tz import gettz
 from dateutil.parser import parse
+from rapidfuzz import fuzz
 from traitlets.config import LoggingConfigurable
 from traitlets import Unicode, Bool, Instance, Type, default, validate, TraitError
 from jupyter_core.paths import jupyter_data_dir
@@ -177,11 +178,6 @@ class Exchange(LoggingConfigurable):
         self.log.fatal(msg)
         found = glob.glob(other_path)
         if found:
-            # Normally it is a bad idea to put imports in the middle of
-            # a function, but we do this here because otherwise fuzzywuzzy
-            # prints an annoying message about python-Levenshtein every
-            # time nbgrader is run.
-            from fuzzywuzzy import fuzz
             scores = sorted([(fuzz.ratio(self.src_path, x), x) for x in found])
             self.log.error("Did you mean: %s", scores[-1][1])
 

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup_args = dict(
         "requests",
         "jsonschema",
         "alembic",
-        "fuzzywuzzy"
+        "rapidfuzz"
     ]
 )
 


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy. (actually even faster since python-Levenshtein was not used)