### PR TITLE
Add nbgrader collect --before-duedate option

### DIFF
--- a/nbgrader/apps/collectapp.py
+++ b/nbgrader/apps/collectapp.py
@@ -20,7 +20,7 @@ flags.update({
         {'ExchangeCollect' : {'update': True}},
         "Update existing submissions with ones that have newer timestamps."
     ),
-    'before_duedate': (
+    'before-duedate': (
         {'ExchangeCollect' : {'before_duedate': True}},
         "Collect the last submission before due date or the last submission if no submission before due date."
     ),

--- a/nbgrader/apps/collectapp.py
+++ b/nbgrader/apps/collectapp.py
@@ -20,6 +20,10 @@ flags.update({
         {'ExchangeCollect' : {'update': True}},
         "Update existing submissions with ones that have newer timestamps."
     ),
+    'before_duedate': (
+        {'ExchangeCollect' : {'before_duedate': True}},
+        "Collect the last submission before due date or the last submission if no submission before due date."
+    ),
 })
 
 class CollectApp(NbGrader):


### PR DESCRIPTION
This feature was requested and implemented by one of our users,
@aleksanderilin.

- By default, nbgrader will collect assignments submitted after the
  due date (which might get zero points for being late), while there
  was something submitted before which would get points.

- This adds a --before-duedate option, which uses the due date in the
  gradebook to select.

- Controlled with the "nbgrader collect --before-duedate".  In the
  future there could be a "--before=TIMESTAMP" option.

- If there are no assignments submitted before the due date, take the
  latest assignment, even after the due date.

- There could be partial credit for things after the due date, so the
  it makes sense to take something better after the due date than
  worse before.  But, nbgrader can only store one submission and the
  evaluation is separate from the collection, so we can't support that
  easily yet.

- The initial patch was designed, developed, and contributed by our
  great contributor @aleksanderilin (everyone should say thanks!).  He
  agreed to the nbgrader license.