### PR TITLE
Ensure errors are written to cell outputs to prevent the autograder from awarding points for failed tests

### DIFF
--- a/nbgrader/tests/apps/files/submitted-cheat-attempt-alternative.ipynb
+++ b/nbgrader/tests/apps/files/submitted-cheat-attempt-alternative.ipynb
@@ -1,0 +1,158 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "deletable": false,
+    "nbgrader": {
+     "cell_type": "code",
+     "checksum": "3d6aac4236f8e1ec85380e692dcc51b1",
+     "grade": false,
+     "grade_id": "set_a",
+     "locked": false,
+     "schema_version": 3,
+     "solution": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# YOUR CODE HERE\n",
+    "import IPython.core.interactiveshell\n",
+    "IPython.core.interactiveshell.InteractiveShell.showtraceback = None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "deletable": false,
+    "nbgrader": {
+     "cell_type": "code",
+     "checksum": "8bb5c7c6f388fae724e5ef53dc4deeb2",
+     "grade": true,
+     "grade_id": "foo",
+     "locked": false,
+     "points": 1.0,
+     "schema_version": 3,
+     "solution": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print(\"Success!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "deletable": false,
+    "nbgrader": {
+     "cell_type": "code",
+     "checksum": "75d78cdf605a339809ceaace462c5f33",
+     "grade": true,
+     "grade_id": "bar",
+     "locked": false,
+     "points": 1.0,
+     "schema_version": 3,
+     "solution": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "assert a == 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": false,
+    "nbgrader": {
+     "cell_type": "markdown",
+     "checksum": "9e51fd0022c24c4105e38369d2f9d751",
+     "grade": true,
+     "grade_id": "baz",
+     "locked": false,
+     "points": 2.0,
+     "schema_version": 3,
+     "solution": true
+    }
+   },
+   "source": [
+    "An answer!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "nbgrader": {
+     "cell_type": "code",
+     "checksum": "5a193c164d7b444efe9a3612bee09f4c",
+     "grade": true,
+     "grade_id": "quux",
+     "locked": false,
+     "points": 3.0,
+     "schema_version": 3,
+     "solution": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# YOUR CODE HERE\n",
+    "b = 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "nbgrader": {
+     "cell_type": "code",
+     "checksum": "86f5f877fe95faac003fcd4b8d43d093",
+     "grade": false,
+     "grade_id": "ro1",
+     "locked": true,
+     "schema_version": 3,
+     "solution": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print(\"Don't change this cell!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nbgrader": {
+     "cell_type": "markdown",
+     "checksum": "0122b50e5eaf367b9874d07ebaf80521",
+     "grade": false,
+     "grade_id": "ro2",
+     "locked": true,
+     "schema_version": 3,
+     "solution": false
+    }
+   },
+   "source": [
+    "This cell shouldn't be changed."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python",
+   "language": "python",
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/nbgrader/tests/apps/files/submitted-cheat-attempt.ipynb
+++ b/nbgrader/tests/apps/files/submitted-cheat-attempt.ipynb
@@ -1,0 +1,158 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "deletable": false,
+    "nbgrader": {
+     "cell_type": "code",
+     "checksum": "3d6aac4236f8e1ec85380e692dcc51b1",
+     "grade": false,
+     "grade_id": "set_a",
+     "locked": false,
+     "schema_version": 3,
+     "solution": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# YOUR CODE HERE\n",
+    "import IPython.core.interactiveshell\n",
+    "IPython.core.interactiveshell.InteractiveShell.showtraceback = lambda *args, **kwargs : None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "deletable": false,
+    "nbgrader": {
+     "cell_type": "code",
+     "checksum": "8bb5c7c6f388fae724e5ef53dc4deeb2",
+     "grade": true,
+     "grade_id": "foo",
+     "locked": false,
+     "points": 1.0,
+     "schema_version": 3,
+     "solution": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print(\"Success!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "deletable": false,
+    "nbgrader": {
+     "cell_type": "code",
+     "checksum": "75d78cdf605a339809ceaace462c5f33",
+     "grade": true,
+     "grade_id": "bar",
+     "locked": false,
+     "points": 1.0,
+     "schema_version": 3,
+     "solution": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "assert a == 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": false,
+    "nbgrader": {
+     "cell_type": "markdown",
+     "checksum": "9e51fd0022c24c4105e38369d2f9d751",
+     "grade": true,
+     "grade_id": "baz",
+     "locked": false,
+     "points": 2.0,
+     "schema_version": 3,
+     "solution": true
+    }
+   },
+   "source": [
+    "An answer!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "nbgrader": {
+     "cell_type": "code",
+     "checksum": "5a193c164d7b444efe9a3612bee09f4c",
+     "grade": true,
+     "grade_id": "quux",
+     "locked": false,
+     "points": 3.0,
+     "schema_version": 3,
+     "solution": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# YOUR CODE HERE\n",
+    "b = 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "nbgrader": {
+     "cell_type": "code",
+     "checksum": "86f5f877fe95faac003fcd4b8d43d093",
+     "grade": false,
+     "grade_id": "ro1",
+     "locked": true,
+     "schema_version": 3,
+     "solution": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print(\"Don't change this cell!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nbgrader": {
+     "cell_type": "markdown",
+     "checksum": "0122b50e5eaf367b9874d07ebaf80521",
+     "grade": false,
+     "grade_id": "ro2",
+     "locked": true,
+     "schema_version": 3,
+     "solution": false
+    }
+   },
+   "source": [
+    "This cell shouldn't be changed."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python",
+   "language": "python",
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/nbgrader/tests/apps/test_nbgrader_autograde.py
+++ b/nbgrader/tests/apps/test_nbgrader_autograde.py
@@ -57,18 +57,26 @@ class TestNbGraderAutograde(BaseTestApp):
         run_nbgrader(["db", "assignment", "add", "ps1", "--db", db, "--duedate", "2015-02-02 14:58:23.948203 America/Los_Angeles"])
         run_nbgrader(["db", "student", "add", "foo", "--db", db])
         run_nbgrader(["db", "student", "add", "bar", "--db", db])
+        run_nbgrader(["db", "student", "add", "spam", "--db", db])
+        run_nbgrader(["db", "student", "add", "eggs", "--db", db])
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         run_nbgrader(["generate_assignment", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "bar", "ps1", "p1.ipynb"))
+        self._copy_file(join("files", "submitted-cheat-attempt.ipynb"), join(course_dir, "submitted", "spam", "ps1", "p1.ipynb"))
+        self._copy_file(join("files", "submitted-cheat-attempt-alternative.ipynb"), join(course_dir, "submitted", "eggs", "ps1", "p1.ipynb"))
         run_nbgrader(["autograde", "ps1", "--db", db])
 
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "timestamp.txt"))
         assert os.path.isfile(join(course_dir, "autograded", "bar", "ps1", "p1.ipynb"))
         assert not os.path.isfile(join(course_dir, "autograded", "bar", "ps1", "timestamp.txt"))
+        assert os.path.isfile(join(course_dir, "autograded", "spam", "ps1", "p1.ipynb"))
+        assert not os.path.isfile(join(course_dir, "autograded", "spam", "ps1", "timestamp.txt"))
+        assert os.path.isfile(join(course_dir, "autograded", "eggs", "ps1", "p1.ipynb"))
+        assert not os.path.isfile(join(course_dir, "autograded", "eggs", "ps1", "timestamp.txt"))
 
         with Gradebook(db) as gb:
             notebook = gb.find_submission_notebook("p1", "ps1", "foo")
@@ -91,6 +99,28 @@ class TestNbGraderAutograde(BaseTestApp):
             comment1 = gb.find_comment("set_a", "p1", "ps1", "bar")
             comment2 = gb.find_comment("baz", "p1", "ps1", "bar")
             comment2 = gb.find_comment("quux", "p1", "ps1", "bar")
+            assert comment1.comment == None
+            assert comment2.comment == None
+
+            notebook = gb.find_submission_notebook("p1", "ps1", "spam")
+            assert notebook.score == 1
+            assert notebook.max_score == 7
+            assert notebook.needs_manual_grade == True
+
+            comment1 = gb.find_comment("set_a", "p1", "ps1", "spam")
+            comment2 = gb.find_comment("baz", "p1", "ps1", "spam")
+            comment2 = gb.find_comment("quux", "p1", "ps1", "spam")
+            assert comment1.comment == None
+            assert comment2.comment == None
+
+            notebook = gb.find_submission_notebook("p1", "ps1", "eggs")
+            assert notebook.score == 1
+            assert notebook.max_score == 7
+            assert notebook.needs_manual_grade == True
+
+            comment1 = gb.find_comment("set_a", "p1", "ps1", "eggs")
+            comment2 = gb.find_comment("baz", "p1", "ps1", "eggs")
+            comment2 = gb.find_comment("quux", "p1", "ps1", "eggs")
             assert comment1.comment == None
             assert comment2.comment == None
 

--- a/nbgrader/tests/apps/test_nbgrader_autograde.py
+++ b/nbgrader/tests/apps/test_nbgrader_autograde.py
@@ -57,6 +57,48 @@ class TestNbGraderAutograde(BaseTestApp):
         run_nbgrader(["db", "assignment", "add", "ps1", "--db", db, "--duedate", "2015-02-02 14:58:23.948203 America/Los_Angeles"])
         run_nbgrader(["db", "student", "add", "foo", "--db", db])
         run_nbgrader(["db", "student", "add", "bar", "--db", db])
+
+        self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
+        run_nbgrader(["generate_assignment", "ps1", "--db", db])
+
+        self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
+        self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "bar", "ps1", "p1.ipynb"))
+        run_nbgrader(["autograde", "ps1", "--db", db])
+
+        assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
+        assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "timestamp.txt"))
+        assert os.path.isfile(join(course_dir, "autograded", "bar", "ps1", "p1.ipynb"))
+        assert not os.path.isfile(join(course_dir, "autograded", "bar", "ps1", "timestamp.txt"))
+
+        with Gradebook(db) as gb:
+            notebook = gb.find_submission_notebook("p1", "ps1", "foo")
+            assert notebook.score == 1
+            assert notebook.max_score == 7
+            assert notebook.needs_manual_grade == False
+
+            comment1 = gb.find_comment("set_a", "p1", "ps1", "foo")
+            comment2 = gb.find_comment("baz", "p1", "ps1", "foo")
+            comment3 = gb.find_comment("quux", "p1", "ps1", "foo")
+            assert comment1.comment == "No response."
+            assert comment2.comment == "No response."
+            assert comment3.comment == "No response."
+
+            notebook = gb.find_submission_notebook("p1", "ps1", "bar")
+            assert notebook.score == 2
+            assert notebook.max_score == 7
+            assert notebook.needs_manual_grade == True
+
+            comment1 = gb.find_comment("set_a", "p1", "ps1", "bar")
+            comment2 = gb.find_comment("baz", "p1", "ps1", "bar")
+            comment2 = gb.find_comment("quux", "p1", "ps1", "bar")
+            assert comment1.comment == None
+            assert comment2.comment == None
+
+    def test_showtraceback_exploit(self, db, course_dir):
+        """Can students exploit showtraceback to hide errors from all future cell outputs to receive free points for incorrect cells?"""
+        run_nbgrader(["db", "assignment", "add", "ps1", "--db", db, "--duedate", "2015-02-02 14:58:23.948203 America/Los_Angeles"])
+        run_nbgrader(["db", "student", "add", "foo", "--db", db])
+        run_nbgrader(["db", "student", "add", "bar", "--db", db])
         run_nbgrader(["db", "student", "add", "spam", "--db", db])
         run_nbgrader(["db", "student", "add", "eggs", "--db", db])
 
@@ -84,45 +126,20 @@ class TestNbGraderAutograde(BaseTestApp):
             assert notebook.max_score == 7
             assert notebook.needs_manual_grade == False
 
-            comment1 = gb.find_comment("set_a", "p1", "ps1", "foo")
-            comment2 = gb.find_comment("baz", "p1", "ps1", "foo")
-            comment3 = gb.find_comment("quux", "p1", "ps1", "foo")
-            assert comment1.comment == "No response."
-            assert comment2.comment == "No response."
-            assert comment3.comment == "No response."
-
             notebook = gb.find_submission_notebook("p1", "ps1", "bar")
             assert notebook.score == 2
             assert notebook.max_score == 7
             assert notebook.needs_manual_grade == True
-
-            comment1 = gb.find_comment("set_a", "p1", "ps1", "bar")
-            comment2 = gb.find_comment("baz", "p1", "ps1", "bar")
-            comment2 = gb.find_comment("quux", "p1", "ps1", "bar")
-            assert comment1.comment == None
-            assert comment2.comment == None
 
             notebook = gb.find_submission_notebook("p1", "ps1", "spam")
             assert notebook.score == 1
             assert notebook.max_score == 7
             assert notebook.needs_manual_grade == True
 
-            comment1 = gb.find_comment("set_a", "p1", "ps1", "spam")
-            comment2 = gb.find_comment("baz", "p1", "ps1", "spam")
-            comment2 = gb.find_comment("quux", "p1", "ps1", "spam")
-            assert comment1.comment == None
-            assert comment2.comment == None
-
             notebook = gb.find_submission_notebook("p1", "ps1", "eggs")
             assert notebook.score == 1
             assert notebook.max_score == 7
             assert notebook.needs_manual_grade == True
-
-            comment1 = gb.find_comment("set_a", "p1", "ps1", "eggs")
-            comment2 = gb.find_comment("baz", "p1", "ps1", "eggs")
-            comment2 = gb.find_comment("quux", "p1", "ps1", "eggs")
-            assert comment1.comment == None
-            assert comment2.comment == None
 
     def test_student_id_exclude(self, db, course_dir):
         """Does --CourseDirectory.student_id_exclude=X exclude students?"""


### PR DESCRIPTION
If a student disables showtraceback by including:
```python
import IPython.core.interactiveshell
IPython.core.interactiveshell.InteractiveShell.showtraceback = lambda *args, **kwargs : None
```
somewhere in their code, errors won't be recorded in cell outputs, therefore passing and receiving points for those test cases.

If the student provides attempted solutions for each answer that look plausible, this would be hard to notice during manual grading. They could further obfuscate this by representing this exploit as an integer, fetch it from elsewhere using urllib, etc then running it with exec(). The easiest way an instructor could detect this now without having to update nbgrader would probably be to grep all their submissions for "showtraceback" or "exec".
