### PR TITLE
Make format_path behave the same for absolute paths

### DIFF
--- a/nbgrader/coursedir.py
+++ b/nbgrader/coursedir.py
@@ -276,9 +276,12 @@ class CourseDirectory(LoggingConfigurable):
         )
 
         if escape:
-            base = re.escape(self.root)
             structure = [x.format(**kwargs) for x in full_split(self.directory_structure)]
-            path = re.escape(os.path.sep).join([base] + structure)
+            if len(structure) == 0 or not structure[0].startswith(os.sep):
+                base = [re.escape(self.root)]
+            else:
+                base = []
+            path = re.escape(os.path.sep).join(base + structure)
         else:
             path = os.path.join(self.root, self.directory_structure.format(**kwargs))
 


### PR DESCRIPTION
The CourseDirectory.format_path method behaves differently depending on whether escape is set to True or not. This is because when no escape is needed, the method uses os.path.join, but when escape is set to True, it uses str.join. For most cases this does not matter, but when the path supplied to format_path is absolute, it causes the escaped version to return a different path than the non-escaped one. This is because format_path bases the paths it returns on CourseDirectory.root (it returns join(root, supplied_path_formatted)), and os.path.join will discard all paths before the last absolute path (so os.path.join("/some/path", "/other/path") will return "/other/path"). The str.join version, however, does not work this way.

There're two ways this inconsistency could be solved. Either make the escaped version behave like os.path.join or make the not-escaped version behave like str.join. As os.path.join is the standard way to concatenate paths, it seems sensible to make both return according to os.path.join. I think there is some argument to be made for forcing format_path to respect CourseDirectory.root, though. Then we could be sure that all paths passed through format_path is in the same sub-directory (I don't know if this is an issue anyone is concerned with?) and since the arguments to format_path might be regular expressions, it's hard to say for certain whether a particular path is absolute or not. 

With the experience I've had implementing a custom exchange that uses the format_path method, having both behave as os.join.path seems like the better option. Therefore I've submitted an implementation that tries to mimic os.path.join's behaviour in the escaped version.