### PR TITLE
Fix migration, grade cells were looking for a non-existing column

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 pytest>=4.5
 pytest-cov
 pytest-rerunfailures
-pytest-xdist
+pytest-xdist==1.34.0
 #pytest-mypy
 coverage
 selenium

--- a/nbgrader/alembic/versions/167914646830_added_task_cells.py
+++ b/nbgrader/alembic/versions/167914646830_added_task_cells.py
@@ -98,7 +98,7 @@ def upgrade():
     grade_cells = [
         {
             'id': cellid,
-            'type': celltype,
+            'cell_type': celltype,
             'max_score': max_score,
         } for _, cellid, celltype, _, max_score in results]
 


### PR DESCRIPTION
Gradebook migrations between 0.5.5 and 0.6.1 were failing, due to a mistyped column name in
one of the migrations.