### PR TITLE
find cell failure when stderr is used

### DIFF
--- a/nbgrader/tests/test_validator.py
+++ b/nbgrader/tests/test_validator.py
@@ -33,6 +33,14 @@ class TestValidator(object):
         ))
         return cell
 
+    def _add_error_2(self, cell):
+        cell.outputs.append(new_output(
+            "stream",
+            name="stderr",
+            text="Error Message"
+        ))
+        return cell
+
     def test_indent(self, validator):
         # test normal indenting
         assert validator._indent("Hello, world!") == "    Hello, world!"
@@ -138,6 +146,31 @@ class TestValidator(object):
             """
         )
 
+        assert stream.getvalue() == expected
+
+    def test_print_error_code_cell_error_2(self, validator, stream):
+        cell = self._add_error_2(create_code_cell())
+        validator.stream = stream
+        validator.width = 20
+        validator._print_error(cell.source.strip(), validator._extract_error(cell))
+
+        expected = dedent(
+            """
+            ====================
+            The following cell failed:
+    
+                print("someth...
+                ### BEGIN SOL...
+                print("hello"...
+                ### END SOLUT...
+    
+            The error was:
+    
+                Error Message
+    
+            """
+        )
+        print(stream.getvalue())
         assert stream.getvalue() == expected
 
     def test_print_error_markdown_cell(self, validator, stream):

--- a/nbgrader/validator.py
+++ b/nbgrader/validator.py
@@ -117,6 +117,8 @@ class Validator(LoggingConfigurable):
             for output in cell.outputs:
                 if output.output_type == "error":
                     errors.append("\n".join(output.traceback))
+                if output.output_type == "stream" and output.name == "stderr":
+                    errors.append(output.text)
 
             if len(errors) == 0:
                 if utils.is_grade(cell):
@@ -256,7 +258,7 @@ class Validator(LoggingConfigurable):
                     failed.append(cell)
             elif self.validate_all and cell.cell_type == 'code':
                 for output in cell.outputs:
-                    if output.output_type == 'error':
+                    if output.output_type == 'error' or output.output_type == "stream" and output.name == "stderr":
                         failed.append(cell)
                         break
 


### PR DESCRIPTION
Recently I came across multiple kernels (eg. kotlin-jupyter or tslab) that do not create cells of type `error` but rather use stream/stderr to indicate a problem. While this was apparently already fixed for grading

https://github.com/jupyter/nbgrader/blob/7f916faaa6fdad35113c0b80e818ebb87f8cf376/nbgrader/utils.py#L116-L119

it was not considered in the validator. Therefore, this PR changes the validator to be aware of this type of error-reporting.