### PR TITLE
Added CLI for generating solution notebooks

### DIFF
--- a/nbgrader/apps/__init__.py
+++ b/nbgrader/apps/__init__.py
@@ -13,6 +13,7 @@ from .collectapp import CollectApp
 from .fetchapp import FetchApp
 from .fetchassignmentapp import FetchAssignmentApp
 from .fetchfeedbackapp import FetchFeedbackApp
+from .generatesolutionapp import GenerateSolutionApp
 from .submitapp import SubmitApp
 from .listapp import ListApp
 from .extensionapp import ExtensionApp
@@ -64,5 +65,6 @@ __all__ = [
     'UpdateApp',
     'ZipCollectApp',
     'GenerateConfigApp',
-    'NbGraderAPI'
+    'NbGraderAPI',
+    'GenerateSolutionApp'
 ]

--- a/nbgrader/apps/api.py
+++ b/nbgrader/apps/api.py
@@ -9,7 +9,7 @@ from traitlets.config import LoggingConfigurable, Config, get_config
 from traitlets import Instance, Enum, Unicode, observe
 
 from ..coursedir import CourseDirectory
-from ..converters import GenerateAssignment, Autograde, GenerateFeedback
+from ..converters import GenerateAssignment, Autograde, GenerateFeedback, GenerateSolution
 from ..exchange import ExchangeFactory, ExchangeError
 from ..api import MissingEntry, Gradebook, Student, SubmittedAssignment
 from ..utils import parse_utc, temp_attrs, capture_log, as_timezone, to_numeric_tz
@@ -1120,7 +1120,7 @@ class NbGraderAPI(LoggingConfigurable):
                     authentictor=self.authenticator,
                     parent=self)
                 return capture_log(app)
-
+    
     def fetch_feedback(self, assignment_id, student_id):
         """Run ``nbgrader fetch_feedback`` for a particular assignment/student.
 

--- a/nbgrader/apps/baseapp.py
+++ b/nbgrader/apps/baseapp.py
@@ -237,6 +237,7 @@ class NbGrader(JupyterApp):
             ("submitted_directory", "submitted_directory"),
             ("autograded_directory", "autograded_directory"),
             ("feedback_directory", "feedback_directory"),
+            ("solution_directory", "solution_directory"),
             ("db_url", "db_url"),
             ("course_directory", "root"),
             ("ignore", "ignore")

--- a/nbgrader/apps/generatesolutionapp.py
+++ b/nbgrader/apps/generatesolutionapp.py
@@ -1,0 +1,90 @@
+# coding: utf-8
+
+import sys
+
+from traitlets import default
+
+from .baseapp import NbGrader, nbgrader_aliases, nbgrader_flags
+from ..converters import BaseConverter, GenerateSolution, NbGraderException
+from traitlets.traitlets import MetaHasTraits
+from typing import List, Any
+from traitlets.config.loader import Config
+
+aliases = {
+    'course': 'CourseDirectory.course_id'
+}
+aliases.update(nbgrader_aliases)
+del aliases['student']
+aliases.update({
+})
+
+flags = {}
+flags.update(nbgrader_flags)
+flags.update({
+    'force': (
+        {'BaseConverter': {'force': True}},
+        "Overwrite the solution if it already exists."
+    ),
+    'f': (
+        {'BaseConverter': {'force': True}},
+        "Overwrite the solution if it already exists."
+    ),
+})
+
+
+class GenerateSolutionApp(NbGrader):
+
+    name = u'nbgrader-generate-solution'
+    description = u'Produce the solution of an assignment to be released to students.'
+
+    aliases = aliases
+    flags = flags
+
+    examples = """
+        Produce the solution of the assignment that is intended to be released to
+        students. This performs several modifications to the original assignment:
+
+            1. It ...
+
+        `nbgrader generate_solution` takes one argument (the name of the assignment), and
+        looks for notebooks in the 'source' directory by default, according to
+        the directory structure specified in `CourseDirectory.directory_structure`.
+        The student version is then saved into the 'solution' directory.
+
+        Note that the directory structure requires the `student_id` to be given;
+        however, there is no student ID at this point in the process. Instead,
+        `nbgrader generate_assignment` sets the student ID to be '.' so by default, files are
+        read in according to:
+
+            source/./{assignment_id}/{notebook_id}.ipynb
+
+        and saved according to:
+
+            solution/./{assignment_id}/{notebook_id}.ipynb
+
+        """
+
+    @default("classes")
+    def _classes_default(self) -> List[MetaHasTraits]:
+        classes = super(GenerateSolutionApp, self)._classes_default()
+        classes.extend([BaseConverter, GenerateSolution])
+        return classes
+
+
+    def start(self) -> None:
+        super().start()
+
+        if len(self.extra_args) > 1:
+            self.fail("Only one argument (the assignment id) may be specified")
+        elif len(self.extra_args) == 1 and self.coursedir.assignment_id != "":
+            self.fail("The assignment cannot both be specified in config and as an argument")
+        elif len(self.extra_args) == 0 and self.coursedir.assignment_id == "":
+            self.fail("An assignment id must be specified, either as an argument or with --assignment")
+        elif len(self.extra_args) == 1:
+            self.coursedir.assignment_id = self.extra_args[0]
+
+        converter = GenerateSolution(coursedir=self.coursedir, parent=self)
+        try:
+            converter.start()
+        except NbGraderException:
+            sys.exit(1)

--- a/nbgrader/apps/generatesolutionapp.py
+++ b/nbgrader/apps/generatesolutionapp.py
@@ -42,9 +42,8 @@ class GenerateSolutionApp(NbGrader):
 
     examples = """
         Produce the solution of the assignment that is intended to be released to
-        students. This performs several modifications to the original assignment:
-
-            1. It ...
+        students. This essentially cleans up the assignment and runs all the cells providing
+        the solution conceived by the instructor.
 
         `nbgrader generate_solution` takes one argument (the name of the assignment), and
         looks for notebooks in the 'source' directory by default, according to
@@ -52,8 +51,8 @@ class GenerateSolutionApp(NbGrader):
         The student version is then saved into the 'solution' directory.
 
         Note that the directory structure requires the `student_id` to be given;
-        however, there is no student ID at this point in the process. Instead,
-        `nbgrader generate_assignment` sets the student ID to be '.' so by default, files are
+        however, there is no student ID also at this point in the process. Instead,
+        `nbgrader generate_solution` sets the student ID to be '.' so by default, files are
         read in according to:
 
             source/./{assignment_id}/{notebook_id}.ipynb

--- a/nbgrader/apps/generatesolutionapp.py
+++ b/nbgrader/apps/generatesolutionapp.py
@@ -70,7 +70,6 @@ class GenerateSolutionApp(NbGrader):
         classes.extend([BaseConverter, GenerateSolution])
         return classes
 
-
     def start(self) -> None:
         super().start()
 

--- a/nbgrader/apps/nbgraderapp.py
+++ b/nbgrader/apps/nbgraderapp.py
@@ -36,7 +36,8 @@ from . import (
     DbApp,
     UpdateApp,
     ZipCollectApp,
-    GenerateConfigApp
+    GenerateConfigApp,
+    GenerateSolutionApp
 )
 from traitlets.traitlets import MetaHasTraits
 from typing import List
@@ -290,6 +291,14 @@ class NbGraderApp(NbGrader):
             dedent(
                 """
                 Generates a default nbgrader_config.py file.
+                """
+            ).strip()
+        ),
+        generate_solution=(
+            GenerateSolutionApp,
+            dedent(
+                """
+                Generates the solution for the given assignment.
                 """
             ).strip()
         ),

--- a/nbgrader/converters/__init__.py
+++ b/nbgrader/converters/__init__.py
@@ -4,6 +4,7 @@ from .generate_assignment import GenerateAssignment
 from .autograde import Autograde
 from .feedback import Feedback
 from .generate_feedback import GenerateFeedback
+from .generate_solution import GenerateSolution
 
 __all__ = [
     "BaseConverter",
@@ -12,5 +13,6 @@ __all__ = [
     "GenerateAssignment",
     "Autograde",
     "Feedback",
-    "GenerateFeedback"
+    "GenerateFeedback",
+    "GenerateSolution"
 ]

--- a/nbgrader/converters/generate_solution.py
+++ b/nbgrader/converters/generate_solution.py
@@ -47,7 +47,6 @@ class GenerateSolution(BaseConverter):
         IncludeHeaderFooter,
         LockCells,
         ClearOutput,
-        SaveCells,
         ClearMarkScheme,
         Execute
     ])

--- a/nbgrader/converters/generate_solution.py
+++ b/nbgrader/converters/generate_solution.py
@@ -1,0 +1,66 @@
+import os
+import re
+from textwrap import dedent
+
+from traitlets import List, Bool, default
+
+from ..api import Gradebook, MissingEntry
+from .base import BaseConverter, NbGraderException
+from ..preprocessors import (
+    IncludeHeaderFooter,
+    LockCells,
+    SaveCells,
+    ClearOutput,
+    ClearMarkScheme,
+    Execute,
+)
+from traitlets.config.loader import Config
+from typing import Any
+from ..coursedir import CourseDirectory
+
+
+class GenerateSolution(BaseConverter):
+
+    create_assignment = Bool(
+        True,
+        help=dedent(
+            """
+            Whether to create the assignment at runtime if it does not
+            already exist.
+            """
+        )
+    ).tag(config=True)
+
+    @default("permissions")
+    def _permissions_default(self) -> int:
+        return 664 if self.coursedir.groupshared else 644
+
+    @property
+    def _input_directory(self) -> str:
+        return self.coursedir.source_directory
+
+    @property
+    def _output_directory(self):
+        return self.coursedir.solution_directory
+
+    preprocessors = List([
+        IncludeHeaderFooter,
+        LockCells,
+        ClearOutput,
+        SaveCells,
+        ClearMarkScheme,
+        Execute
+    ])
+    # NB: ClearHiddenTests must come after ComputeChecksums and SaveCells.
+    # ComputerChecksums must come again after ClearHiddenTests.
+
+    def __init__(self, coursedir: CourseDirectory = None, **kwargs: Any) -> None:
+        super(GenerateSolution, self).__init__(coursedir=coursedir, **kwargs)
+
+    def start(self) -> None:
+        old_student_id = self.coursedir.student_id
+        self.coursedir.student_id = '.'
+        try:
+            super(GenerateSolution, self).start()
+        finally:
+            self.coursedir.student_id = old_student_id

--- a/nbgrader/converters/generate_solution.py
+++ b/nbgrader/converters/generate_solution.py
@@ -56,6 +56,16 @@ class GenerateSolution(BaseConverter):
     def __init__(self, coursedir: CourseDirectory = None, **kwargs: Any) -> None:
         super(GenerateSolution, self).__init__(coursedir=coursedir, **kwargs)
 
+    def init_assignment(self, assignment_id: str, student_id: str) -> None:
+        super(GenerateSolution, self).init_assignment(assignment_id, student_id)
+        with Gradebook(self.coursedir.db_url, self.coursedir.course_id) as gb:
+            try:
+                gb.find_assignment(assignment_id)
+            except MissingEntry:
+                msg = "No assignment with ID '%s' exists in the database" % assignment_id
+                self.log.error(msg)
+                raise NbGraderException(msg)
+
     def start(self) -> None:
         old_student_id = self.coursedir.student_id
         self.coursedir.student_id = '.'

--- a/nbgrader/coursedir.py
+++ b/nbgrader/coursedir.py
@@ -175,6 +175,17 @@ class CourseDirectory(LoggingConfigurable):
         )
     ).tag(config=True)
 
+    solution_directory = Unicode(
+        'solution',
+        help=dedent(
+            """
+            The name of the directory that contains the assignment solution after
+            grading has been completed. This corresponds to the `nbgrader_step`
+            variable in the `directory_structure` config option.
+            """
+        )
+    ).tag(config=True)
+
     db_url = Unicode(
         "",
         help=dedent(

--- a/nbgrader/docs/source/api/high_level_api.rst
+++ b/nbgrader/docs/source/api/high_level_api.rst
@@ -78,3 +78,4 @@ For details on how to configure the API, see :doc:`/configuration/config_options
     .. automethod:: release_feedback
 
     .. automethod:: fetch_feedback
+

--- a/nbgrader/docs/source/command_line_tools/index.rst
+++ b/nbgrader/docs/source/command_line_tools/index.rst
@@ -22,6 +22,7 @@ Instructor commands
     nbgrader-update
     nbgrader-autograde
     nbgrader-generate-feedback
+    nbgrader-generate-solution
     nbgrader-export
 
 The following commands are used to manage the database:

--- a/nbgrader/docs/source/exchange/exchange_api.rst
+++ b/nbgrader/docs/source/exchange/exchange_api.rst
@@ -12,6 +12,7 @@ Defined directories
 - ``submitted_directory`` - Where student submissions are copied to, when an instructor *collects* (defaults to ``submitted``)
 - ``autograded_directory`` - Where student submissions are copied to, having been *autograded* (defaults to ``autograded``)
 - ``feedback_directory`` - Where feedback is copied to, when Instructors *generate feedback* (defaults to ``feedback``)
+- ``solution_directory`` - Where solution is copied to, when Istructors *generate solution* (defaults to ``solution``)
 
 Also, taken from the nbgrader help::
 

--- a/nbgrader/tests/apps/test_nbgrader_generate_solution.py
+++ b/nbgrader/tests/apps/test_nbgrader_generate_solution.py
@@ -1,0 +1,142 @@
+import os
+import sys
+import pytest
+import traitlets
+
+from os.path import join
+from sqlalchemy.exc import InvalidRequestError
+from textwrap import dedent
+
+from ...api import Gradebook
+from .. import run_nbgrader
+from .base import BaseTestApp
+
+
+class TestNbGraderGenerateSolution(BaseTestApp):
+
+    def test_help(self):
+        """Does the help display without error?"""
+        run_nbgrader(["generate_solution", "--help-all"])
+
+    def test_no_args(self):
+        """Is there an error if no arguments are given?"""
+        run_nbgrader(["generate_solution"], retcode=1)
+
+    def test_conflicting_args(self):
+        """Is there an error if assignment is specified both in config and as an argument?"""
+        run_nbgrader(["generate_solution", "--assignment", "foo", "foo"], retcode=1)
+
+    def test_multiple_args(self):
+        """Is there an error if multiple arguments are given?"""
+        run_nbgrader(["generate_solution", "foo", "bar"], retcode=1)
+
+    def test_no_assignment(self, course_dir):
+        """Is an assignment does not exists it fails"""
+        self._empty_notebook(join(course_dir, 'source', 'ps1', 'foo.ipynb'))
+        run_nbgrader(["generate_solution", "ps1"], retcode=1)
+
+    def test_assignment(self, course_dir):
+        self._empty_notebook(join(course_dir, 'source', 'ps1', 'foo.ipynb'))
+        run_nbgrader(["db", "assignment", "add", "ps1"])
+        run_nbgrader(["generate_solution", "ps1"])
+        assert os.path.isfile(join(course_dir, "solution", "ps1", "foo.ipynb"))
+
+    def test_single_file_bad_assignment_name(self, course_dir, temp_cwd):
+        """Test that an error is thrown when the assignment name is invalid."""
+        self._empty_notebook(join(course_dir, 'source', 'foo+bar', 'foo.ipynb'))
+        with pytest.raises(traitlets.TraitError):
+            run_nbgrader(["generate_solution", "foo+bar"])
+        assert not os.path.isfile(join(course_dir, "solution", "foo+bar", "foo.ipynb"))
+
+    def test_multiple_files(self, course_dir):
+        """Can multiple files be assigned?"""
+        self._empty_notebook(join(course_dir, 'source', 'ps1', 'foo.ipynb'))
+        self._empty_notebook(join(course_dir, 'source', 'ps1', 'bar.ipynb'))
+        run_nbgrader(["db", "assignment", "add", "ps1"])
+        run_nbgrader(["generate_solution", "ps1"])
+        assert os.path.isfile(join(course_dir, 'solution', 'ps1', 'foo.ipynb'))
+        assert os.path.isfile(join(course_dir, 'solution', 'ps1', 'bar.ipynb'))
+
+    def test_dependent_files(self, course_dir):
+        """Are dependent files properly linked?"""
+        self._make_file(join(course_dir, 'source', 'ps1', 'data', 'foo.csv'), 'foo')
+        self._make_file(join(course_dir, 'source', 'ps1', 'data', 'bar.csv'), 'bar')
+        self._empty_notebook(join(course_dir, 'source', 'ps1', 'foo.ipynb'))
+        self._empty_notebook(join(course_dir, 'source', 'ps1', 'bar.ipynb'))
+        run_nbgrader(["db", "assignment", "add", "ps1"])
+        run_nbgrader(["generate_solution", "ps1"])
+
+        assert os.path.isfile(join(course_dir, 'solution', 'ps1', 'foo.ipynb'))
+        assert os.path.isfile(join(course_dir, 'solution', 'ps1', 'bar.ipynb'))
+        assert os.path.isfile(join(course_dir, 'solution', 'ps1', 'data', 'foo.csv'))
+        assert os.path.isfile(join(course_dir, 'solution', 'ps1', 'data', 'bar.csv'))
+
+        with open(join(course_dir, 'solution', 'ps1', 'data', 'foo.csv'), 'r') as fh:
+            assert fh.read() == 'foo'
+        with open(join(course_dir, 'solution', 'ps1', 'data', 'bar.csv'), 'r') as fh:
+             assert fh.read() == 'bar'
+
+    def test_force(self, course_dir):
+        """Ensure the force option works properly"""
+        self._copy_file(join('files', 'test.ipynb'), join(course_dir, 'source', 'ps1', 'test.ipynb'))
+        self._make_file(join(course_dir, 'source', 'ps1', 'foo.txt'), "foo")
+        self._make_file(join(course_dir, 'source', 'ps1', 'data', 'bar.txt'), "bar")
+        self._make_file(join(course_dir, 'source', 'ps1', 'blah.pyc'), "asdf")
+        run_nbgrader(["db", "assignment", "add", "ps1"])
+        run_nbgrader(["generate_solution", "ps1"])
+        assert os.path.isfile(join(course_dir, 'solution', 'ps1', 'test.ipynb'))
+        assert os.path.isfile(join(course_dir, 'solution', 'ps1', 'foo.txt'))
+        assert os.path.isfile(join(course_dir, 'solution', 'ps1', 'data', 'bar.txt'))
+        assert not os.path.isfile(join(course_dir, 'solution', 'ps1', 'blah.pyc'))
+
+        # check that it skips the existing directory
+        os.remove(join(course_dir, 'solution', 'ps1', 'foo.txt'))
+        run_nbgrader(["generate_solution", "ps1"])
+        assert not os.path.isfile(join(course_dir, 'solution', 'ps1', 'foo.txt'))
+
+        # force overwrite the supplemental files
+        run_nbgrader(["generate_solution", "ps1", "--force"])
+        assert os.path.isfile(join(course_dir, 'solution', 'ps1', 'foo.txt'))
+
+        # force overwrite
+        os.remove(join(course_dir, 'source', 'ps1', 'foo.txt'))
+        run_nbgrader(["generate_solution", "ps1", "--force"])
+        assert os.path.isfile(join(course_dir, "solution", "ps1", "test.ipynb"))
+        assert os.path.isfile(join(course_dir, "solution", "ps1", "data", "bar.txt"))
+        assert not os.path.isfile(join(course_dir, "solution", "ps1", "foo.txt"))
+        assert not os.path.isfile(join(course_dir, "solution", "ps1", "blah.pyc"))
+
+    def test_force_f(self, course_dir):
+        """Ensure the force option works properly"""
+        self._copy_file(join('files', 'test.ipynb'), join(course_dir, 'source', 'ps1', 'test.ipynb'))
+        self._make_file(join(course_dir, 'source', 'ps1', 'foo.txt'), "foo")
+        self._make_file(join(course_dir, 'source', 'ps1', 'data', 'bar.txt'), "bar")
+        self._make_file(join(course_dir, 'source', 'ps1', 'blah.pyc'), "asdf")
+        run_nbgrader(["db", "assignment", "add", "ps1"])
+        run_nbgrader(["generate_solution", "ps1"])
+        assert os.path.isfile(join(course_dir, 'solution', 'ps1', 'test.ipynb'))
+        assert os.path.isfile(join(course_dir, 'solution', 'ps1', 'foo.txt'))
+        assert os.path.isfile(join(course_dir, 'solution', 'ps1', 'data', 'bar.txt'))
+        assert not os.path.isfile(join(course_dir, 'solution', 'ps1', 'blah.pyc'))
+
+        # check that it skips the existing directory
+        os.remove(join(course_dir, 'solution', 'ps1', 'foo.txt'))
+        run_nbgrader(["generate_solution", "ps1"])
+        assert not os.path.isfile(join(course_dir, 'solution', 'ps1', 'foo.txt'))
+
+        # force overwrite the supplemental files
+        run_nbgrader(["generate_solution", "ps1", "-f"])
+        assert os.path.isfile(join(course_dir, 'solution', 'ps1', 'foo.txt'))
+
+        # force overwrite
+        os.remove(join(course_dir, 'source', 'ps1', 'foo.txt'))
+        run_nbgrader(["generate_solution", "ps1", "-f"])
+        assert os.path.isfile(join(course_dir, "solution", "ps1", "test.ipynb"))
+        assert os.path.isfile(join(course_dir, "solution", "ps1", "data", "bar.txt"))
+        assert not os.path.isfile(join(course_dir, "solution", "ps1", "foo.txt"))
+        assert not os.path.isfile(join(course_dir, "solution", "ps1", "blah.pyc"))
+
+    def test_fail_no_notebooks(self):
+        run_nbgrader(["db", "assignment", "add", "ps1"])
+        run_nbgrader(["generate_solution", "ps1"], retcode=1)
+

--- a/nbgrader/tests/apps/test_nbgrader_generate_solution.py
+++ b/nbgrader/tests/apps/test_nbgrader_generate_solution.py
@@ -31,7 +31,7 @@ class TestNbGraderGenerateSolution(BaseTestApp):
         run_nbgrader(["generate_solution", "foo", "bar"], retcode=1)
 
     def test_no_assignment(self, course_dir):
-        """Is an assignment does not exists it fails"""
+        """If an assignment does not exists it fails"""
         self._empty_notebook(join(course_dir, 'source', 'ps1', 'foo.ipynb'))
         run_nbgrader(["generate_solution", "ps1"], retcode=1)
 


### PR DESCRIPTION
Following issue #1311, I added a few classes for generating the notebooks that contain the solutions to the given assignments. Currently they're available only in the command line interface (I am currently teaching and, unfortunately, I do not have time to get into the details of the Jupyter interface) as an additional subcommand `nbgrader generate_solution <assignment_id>`.
The subcommand creates a solution directory with the notebook containing the solution.
Also I added essential documentation of the new subcommand.