### PR TITLE
Fix various SQLAlchemy errors and warnings

### DIFF
--- a/nbgrader/alembic/versions/167914646830_added_task_cells.py
+++ b/nbgrader/alembic/versions/167914646830_added_task_cells.py
@@ -19,7 +19,7 @@ depends_on = None
 def _get_or_create_table(*args):
     ctx = op.get_context()
     con = op.get_bind()
-    table_exists = ctx.dialect.has_table(con.engine, args[0])
+    table_exists = ctx.dialect.has_table(con, args[0])
 
     if not table_exists:
         table = op.create_table(*args)

--- a/nbgrader/alembic/versions/e43177bfe90b_added_course_table_and_relationships.py
+++ b/nbgrader/alembic/versions/e43177bfe90b_added_course_table_and_relationships.py
@@ -19,7 +19,7 @@ depends_on = None
 def _get_or_create_table(*args):
     ctx = op.get_context()
     con = op.get_bind()
-    table_exists = ctx.dialect.has_table(con.engine, args[0])
+    table_exists = ctx.dialect.has_table(con, args[0])
 
     if not table_exists:
         table = op.create_table(*args)

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -7,7 +7,7 @@ import subprocess as sp
 
 from sqlalchemy import (create_engine, ForeignKey, Column, String, Text,
                         DateTime, Interval, Float, Enum, UniqueConstraint,
-                        Boolean)
+                        Boolean, inspect)
 from sqlalchemy.orm import (sessionmaker, scoped_session, relationship,
                             column_property)
 from sqlalchemy.orm.exc import NoResultFound, FlushError
@@ -1283,7 +1283,7 @@ class Gradebook(object):
         self.db = scoped_session(sessionmaker(autoflush=True, bind=self.engine))
 
         # this creates all the tables in the database if they don't already exist
-        db_exists = len(self.engine.table_names()) > 0
+        db_exists = len(inspect(self.engine).get_table_names()) > 0
         Base.metadata.create_all(bind=self.engine)
 
         # set the alembic version if it doesn't exist

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -22,6 +22,7 @@ from .dbutil import _temp_alembic_ini
 from typing import List, Any, Optional, Union
 from .auth import Authenticator
 
+
 Base = declarative_base()
 
 
@@ -951,14 +952,16 @@ Notebook.needs_manual_grade = column_property(
 SubmittedNotebook.score = column_property(
     select([func.coalesce(func.sum(Grade.score), 0.0)])
     .where(Grade.notebook_id == SubmittedNotebook.id)
-    .correlate_except(Grade), deferred=True)
+    .correlate_except(Grade)
+    .scalar_subquery(), deferred=True)
 
 SubmittedAssignment.score = column_property(
     select([func.coalesce(func.sum(Grade.score), 0.0)])
     .where(and_(
         SubmittedNotebook.assignment_id == SubmittedAssignment.id,
         Grade.notebook_id == SubmittedNotebook.id))
-    .correlate_except(Grade), deferred=True)
+    .correlate_except(Grade)
+    .scalar_subquery(), deferred=True)
 
 Student.score = column_property(
     select([func.coalesce(func.sum(Grade.score), 0.0)])
@@ -966,7 +969,8 @@ Student.score = column_property(
         SubmittedAssignment.student_id == Student.id,
         SubmittedNotebook.assignment_id == SubmittedAssignment.id,
         Grade.notebook_id == SubmittedNotebook.id))
-    .correlate_except(Grade), deferred=True)
+    .correlate_except(Grade)
+    .scalar_subquery(), deferred=True)
 
 
 # Overall max scores
@@ -975,13 +979,15 @@ Grade.max_score_gradecell = column_property(
     select([func.coalesce(GradeCell.max_score, 0.0)])
     .select_from(GradeCell)
     .where(Grade.cell_id == GradeCell.id)
-    .correlate_except(GradeCell), deferred=True)
+    .correlate_except(GradeCell)
+    .scalar_subquery(), deferred=True)
 
 Grade.max_score_taskcell = column_property(
     select([func.coalesce(TaskCell.max_score, 0.0)])
     .select_from(TaskCell)
     .where(Grade.cell_id == TaskCell.id)
-    .correlate_except(TaskCell), deferred=True)
+    .correlate_except(TaskCell)
+    .scalar_subquery(), deferred=True)
 # a grade is either from a grade cell or a task cell , so only one will not be none
 Grade.max_score = column_property(func.coalesce(Grade.max_score_gradecell, Grade.max_score_taskcell, 0.0), deferred=True)
 
@@ -992,16 +998,19 @@ Grade.cell_type_from_taskcell = column_property(
     select([TaskCell.cell_type])
     .select_from(TaskCell)
     .where(Grade.cell_id == TaskCell.id)
-    .correlate_except(TaskCell), deferred=True)
+    .correlate_except(TaskCell)
+    .scalar_subquery(), deferred=True)
 
 Grade.cell_type_from_gradecell = column_property(
     select([GradeCell.cell_type])
     .select_from(GradeCell)
     .where(Grade.cell_id == GradeCell.id)
-    .correlate_except(GradeCell), deferred=True)
+    .correlate_except(GradeCell)
+    .scalar_subquery(), deferred=True)
 
 Grade.cell_type = column_property(
     select([func.coalesce(Grade.cell_type_from_gradecell, Grade.cell_type_from_taskcell)])
+    .scalar_subquery()
 )
 
 
@@ -1009,13 +1018,15 @@ Notebook.max_score_gradecell = column_property(
     select([func.coalesce(func.sum(GradeCell.max_score), 0.0)])
         .select_from(GradeCell)
         .where(GradeCell.notebook_id == Notebook.id)
-        .correlate_except(GradeCell), deferred=True)
+        .correlate_except(GradeCell)
+    .scalar_subquery(), deferred=True)
 
 Notebook.max_score_taskcell = column_property(
     select([func.coalesce(func.sum(TaskCell.max_score), 0.0)])
         .select_from(TaskCell)
         .where(TaskCell.notebook_id == Notebook.id)
-        .correlate_except(TaskCell), deferred=True)
+        .correlate_except(TaskCell)
+    .scalar_subquery(), deferred=True)
 
 Notebook.max_score = column_property(
     Notebook.max_score_gradecell + Notebook.max_score_taskcell
@@ -1024,7 +1035,8 @@ Notebook.max_score = column_property(
 SubmittedNotebook.max_score = column_property(
     select([Notebook.max_score])
     .where(SubmittedNotebook.notebook_id == Notebook.id)
-    .correlate_except(Notebook), deferred=True)
+    .correlate_except(Notebook)
+    .scalar_subquery(), deferred=True)
 
 Assignment.max_score_gradecell = column_property(
     select([func.coalesce(func.sum(GradeCell.max_score), 0.0)])
@@ -1032,7 +1044,8 @@ Assignment.max_score_gradecell = column_property(
     .where(and_(
         Notebook.assignment_id == Assignment.id,
         GradeCell.notebook_id == Notebook.id))
-    .correlate_except(GradeCell), deferred=True)
+    .correlate_except(GradeCell)
+    .scalar_subquery(), deferred=True)
 
 Assignment.max_score_taskcell = column_property(
     select([func.coalesce(func.sum(TaskCell.max_score), 0.0)])
@@ -1040,7 +1053,8 @@ Assignment.max_score_taskcell = column_property(
     .where(and_(
         Notebook.assignment_id == Assignment.id,
         TaskCell.notebook_id == Notebook.id))
-    .correlate_except(TaskCell), deferred=True)
+    .correlate_except(TaskCell)
+    .scalar_subquery(), deferred=True)
 
 Assignment.max_score = column_property(
     Assignment.max_score_gradecell + Assignment.max_score_taskcell
@@ -1050,11 +1064,13 @@ Assignment.max_score = column_property(
 SubmittedAssignment.max_score = column_property(
     select([Assignment.max_score])
     .where(SubmittedAssignment.assignment_id == Assignment.id)
-    .correlate_except(Assignment), deferred=True)
+    .correlate_except(Assignment)
+    .scalar_subquery(), deferred=True)
 
 Student.max_score = column_property(
     select([func.coalesce(func.sum(Assignment.max_score), 0.0)])
-    .correlate_except(Assignment), deferred=True)
+    .correlate_except(Assignment)
+    .scalar_subquery(), deferred=True)
 
 
 # Written scores
@@ -1065,7 +1081,8 @@ SubmittedNotebook.written_score = column_property(
         Grade.notebook_id == SubmittedNotebook.id,
         GradeCell.id == Grade.cell_id,
         GradeCell.cell_type == "markdown"))
-    .correlate_except(Grade), deferred=True)
+    .correlate_except(Grade)
+    .scalar_subquery(), deferred=True)
 
 SubmittedAssignment.written_score = column_property(
     select([func.coalesce(func.sum(Grade.score), 0.0)])
@@ -1074,7 +1091,8 @@ SubmittedAssignment.written_score = column_property(
         Grade.notebook_id == SubmittedNotebook.id,
         GradeCell.id == Grade.cell_id,
         GradeCell.cell_type == "markdown"))
-    .correlate_except(Grade), deferred=True)
+    .correlate_except(Grade)
+    .scalar_subquery(), deferred=True)
 
 
 # Written max scores
@@ -1085,12 +1103,14 @@ Notebook.max_written_score = column_property(
     .where(and_(
         GradeCell.notebook_id == Notebook.id,
         GradeCell.cell_type == "markdown"))
-    .correlate_except(GradeCell), deferred=True)
+    .correlate_except(GradeCell)
+    .scalar_subquery(), deferred=True)
 
 SubmittedNotebook.max_written_score = column_property(
     select([Notebook.max_written_score])
     .where(Notebook.id == SubmittedNotebook.notebook_id)
-    .correlate_except(Notebook), deferred=True)
+    .correlate_except(Notebook)
+    .scalar_subquery(), deferred=True)
 
 Assignment.max_written_score = column_property(
     select([func.coalesce(func.sum(GradeCell.max_score), 0.0)])
@@ -1099,12 +1119,14 @@ Assignment.max_written_score = column_property(
         Notebook.assignment_id == Assignment.id,
         GradeCell.notebook_id == Notebook.id,
         GradeCell.cell_type == "markdown"))
-    .correlate_except(GradeCell), deferred=True)
+    .correlate_except(GradeCell)
+    .scalar_subquery(), deferred=True)
 
 SubmittedAssignment.max_written_score = column_property(
     select([Assignment.max_written_score])
     .where(Assignment.id == SubmittedAssignment.assignment_id)
-    .correlate_except(Assignment), deferred=True)
+    .correlate_except(Assignment)
+    .scalar_subquery(), deferred=True)
 
 
 # Code scores
@@ -1115,7 +1137,8 @@ SubmittedNotebook.code_score = column_property(
         Grade.notebook_id == SubmittedNotebook.id,
         GradeCell.id == Grade.cell_id,
         GradeCell.cell_type == "code"))
-    .correlate_except(Grade), deferred=True)
+    .correlate_except(Grade)
+    .scalar_subquery(), deferred=True)
 
 SubmittedAssignment.code_score = column_property(
     select([func.coalesce(func.sum(Grade.score), 0.0)])
@@ -1124,7 +1147,8 @@ SubmittedAssignment.code_score = column_property(
         Grade.notebook_id == SubmittedNotebook.id,
         GradeCell.id == Grade.cell_id,
         GradeCell.cell_type == "code"))
-    .correlate_except(Grade), deferred=True)
+    .correlate_except(Grade)
+    .scalar_subquery(), deferred=True)
 
 
 # Code max scores
@@ -1135,12 +1159,14 @@ Notebook.max_code_score = column_property(
         .where(and_(
             GradeCell.notebook_id == Notebook.id,
             GradeCell.cell_type == "code"))
-        .correlate_except(GradeCell), deferred=True)
+        .correlate_except(GradeCell)
+    .scalar_subquery(), deferred=True)
 
 SubmittedNotebook.max_code_score = column_property(
     select([Notebook.max_code_score])
     .where(Notebook.id == SubmittedNotebook.notebook_id)
-    .correlate_except(Notebook), deferred=True)
+    .correlate_except(Notebook)
+    .scalar_subquery(), deferred=True)
 
 Assignment.max_code_score = column_property(
     select([func.coalesce(func.sum(GradeCell.max_score), 0.0)])
@@ -1149,12 +1175,14 @@ Assignment.max_code_score = column_property(
         Notebook.assignment_id == Assignment.id,
         GradeCell.notebook_id == Notebook.id,
         GradeCell.cell_type == "code"))
-    .correlate_except(GradeCell), deferred=True)
+    .correlate_except(GradeCell)
+    .scalar_subquery(), deferred=True)
 
 SubmittedAssignment.max_code_score = column_property(
     select([Assignment.max_code_score])
     .where(Assignment.id == SubmittedAssignment.assignment_id)
-    .correlate_except(Assignment), deferred=True)
+    .correlate_except(Assignment)
+    .scalar_subquery(), deferred=True)
 
 # task score
 
@@ -1164,7 +1192,8 @@ SubmittedNotebook.task_score = column_property(
         Grade.notebook_id == SubmittedNotebook.id,
         TaskCell.id == Grade.cell_id,
         TaskCell.cell_type == "markdown"))
-    .correlate_except(Grade), deferred=True)
+    .correlate_except(Grade)
+    .scalar_subquery(), deferred=True)
 
 SubmittedAssignment.task_score = column_property(
     select([func.coalesce(func.sum(Grade.score), 0.0)])
@@ -1173,7 +1202,8 @@ SubmittedAssignment.task_score = column_property(
         Grade.notebook_id == SubmittedNotebook.id,
         TaskCell.id == Grade.cell_id,
         TaskCell.cell_type == "markdown"))
-    .correlate_except(Grade), deferred=True)
+    .correlate_except(Grade)
+    .scalar_subquery(), deferred=True)
 
 
 # task max scores
@@ -1184,12 +1214,14 @@ Notebook.max_task_score = column_property(
     .where(and_(
         TaskCell.notebook_id == Notebook.id,
         TaskCell.cell_type == "markdown"))
-    .correlate_except(TaskCell), deferred=True)
+    .correlate_except(TaskCell)
+    .scalar_subquery(), deferred=True)
 
 SubmittedNotebook.max_task_score = column_property(
     select([Notebook.max_task_score])
     .where(Notebook.id == SubmittedNotebook.notebook_id)
-    .correlate_except(Notebook), deferred=True)
+    .correlate_except(Notebook)
+    .scalar_subquery(), deferred=True)
 
 Assignment.max_task_score = column_property(
     select([func.coalesce(func.sum(TaskCell.max_score), 0.0)])
@@ -1198,10 +1230,12 @@ Assignment.max_task_score = column_property(
         Notebook.assignment_id == Assignment.id,
         TaskCell.notebook_id == Notebook.id,
         TaskCell.cell_type == "markdown"))
-    .correlate_except(TaskCell), deferred=True)
+    .correlate_except(TaskCell)
+    .scalar_subquery(), deferred=True)
 
 SubmittedAssignment.max_task_score = column_property(
     select([func.coalesce(Assignment.max_task_score, 0.0)])
+    .scalar_subquery()
 )
 
 # Number of submissions
@@ -1209,12 +1243,14 @@ SubmittedAssignment.max_task_score = column_property(
 Assignment.num_submissions = column_property(
     select([func.count(SubmittedAssignment.id)])
     .where(SubmittedAssignment.assignment_id == Assignment.id)
-    .correlate_except(SubmittedAssignment), deferred=True)
+    .correlate_except(SubmittedAssignment)
+    .scalar_subquery(), deferred=True)
 
 Notebook.num_submissions = column_property(
     select([func.count(SubmittedNotebook.id)])
     .where(SubmittedNotebook.notebook_id == Notebook.id)
-    .correlate_except(SubmittedNotebook), deferred=True)
+    .correlate_except(SubmittedNotebook)
+    .scalar_subquery(), deferred=True)
 
 
 # Cell type
@@ -1223,13 +1259,15 @@ Grade.cell_type_gradecell = column_property(
     select([GradeCell.cell_type])
     .select_from(GradeCell)
     .where(Grade.cell_id == GradeCell.id)
-    .correlate_except(GradeCell), deferred=True)
+    .correlate_except(GradeCell)
+    .scalar_subquery(), deferred=True)
 
 Grade.cell_type_taskcell = column_property(
     select([TaskCell.cell_type])
     .select_from(TaskCell)
     .where(Grade.cell_id == TaskCell.id)
-    .correlate_except(TaskCell), deferred=True)
+    .correlate_except(TaskCell)
+    .scalar_subquery(), deferred=True)
 
 
 # Failed tests
@@ -1250,7 +1288,8 @@ SubmittedNotebook.failed_tests = column_property(
 SubmittedAssignment.late_submission_penalty = column_property(
     select([func.coalesce(func.sum(SubmittedNotebook.late_submission_penalty), 0.0)])
     .where(SubmittedNotebook.assignment_id == SubmittedAssignment.id)
-    .correlate_except(SubmittedNotebook), deferred=True)
+    .correlate_except(SubmittedNotebook)
+    .scalar_subquery(), deferred=True)
 
 
 

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import (sessionmaker, scoped_session, relationship,
 from sqlalchemy.orm.exc import NoResultFound, FlushError
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.associationproxy import association_proxy
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, StatementError
 from sqlalchemy.sql import and_, or_
 from sqlalchemy import select, func, exists, case, literal_column, union_all
 from sqlalchemy.ext.declarative import declared_attr
@@ -264,7 +264,7 @@ class GradedMixin():
     #: The cell type, either "code" or "markdown"
     @declared_attr
     def cell_type(cls):
-        return Column(Enum("code", "markdown", name="grade_cell_type"), nullable=False)
+        return Column(Enum("code", "markdown", name="grade_cell_type", validate_strings=True), nullable=False)
 
     #: A collection of  assigned to submitted versions of this grade cell,
     #: represented by :class:`~nbgrader.api.Grade` objects
@@ -386,7 +386,7 @@ class SourceCell(Base):
     name = Column(String(128), nullable=False)
 
     #: The cell type, either "code" or "markdown"
-    cell_type = Column(Enum("code", "markdown", name="source_cell_type"), nullable=False)
+    cell_type = Column(Enum("code", "markdown", name="source_cell_type", validate_strings=True), nullable=False)
 
     #: Whether the cell is locked (e.g. the source saved in the database should
     #: be used to overwrite the source of students' cells)
@@ -1408,7 +1408,7 @@ class Gradebook(object):
 
         try:
             self.db.commit()
-        except (IntegrityError, FlushError) as e:
+        except (IntegrityError, FlushError, StatementError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)
         return course
@@ -1444,7 +1444,7 @@ class Gradebook(object):
         self.db.add(student)
         try:
             self.db.commit()
-        except (IntegrityError, FlushError) as e:
+        except (IntegrityError, FlushError, StatementError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)
 
@@ -1504,7 +1504,7 @@ class Gradebook(object):
                 setattr(student, attr, kwargs[attr])
             try:
                 self.db.commit()
-            except (IntegrityError, FlushError) as e:
+            except (IntegrityError, FlushError, StatementError) as e:
                 self.db.rollback()
                 raise InvalidEntry(*e.args)
 
@@ -1533,7 +1533,7 @@ class Gradebook(object):
 
         try:
             self.db.commit()
-        except (IntegrityError, FlushError) as e:
+        except (IntegrityError, FlushError, StatementError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)
 
@@ -1569,7 +1569,7 @@ class Gradebook(object):
         self.db.add(assignment)
         try:
             self.db.commit()
-        except (IntegrityError, FlushError) as e:
+        except (IntegrityError, FlushError, StatementError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)
         return assignment
@@ -1625,7 +1625,7 @@ class Gradebook(object):
                     setattr(assignment, attr, kwargs[attr])
             try:
                 self.db.commit()
-            except (IntegrityError, FlushError) as e:
+            except (IntegrityError, FlushError, StatementError) as e:
                 self.db.rollback()
                 raise InvalidEntry(*e.args)
 
@@ -1653,7 +1653,7 @@ class Gradebook(object):
 
         try:
             self.db.commit()
-        except (IntegrityError, FlushError) as e:
+        except (IntegrityError, FlushError, StatementError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)
 
@@ -1682,7 +1682,7 @@ class Gradebook(object):
         self.db.add(notebook)
         try:
             self.db.commit()
-        except (IntegrityError, FlushError) as e:
+        except (IntegrityError, FlushError, StatementError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)
         return notebook
@@ -1740,7 +1740,7 @@ class Gradebook(object):
                 setattr(notebook, attr, kwargs[attr])
             try:
                 self.db.commit()
-            except (IntegrityError, FlushError) as e:
+            except (IntegrityError, FlushError, StatementError) as e:
                 self.db.rollback()
                 raise InvalidEntry(*e.args)
 
@@ -1775,7 +1775,7 @@ class Gradebook(object):
 
         try:
             self.db.commit()
-        except (IntegrityError, FlushError) as e:
+        except (IntegrityError, FlushError, StatementError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)
 
@@ -1807,7 +1807,7 @@ class Gradebook(object):
         self.db.add(grade_cell)
         try:
             self.db.commit()
-        except (IntegrityError, FlushError) as e:
+        except (IntegrityError, FlushError, StatementError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)
         return grade_cell
@@ -1916,7 +1916,7 @@ class Gradebook(object):
                 setattr(grade_cell, attr, kwargs[attr])
             try:
                 self.db.commit()
-            except (IntegrityError, FlushError) as e:
+            except (IntegrityError, FlushError, StatementError) as e:
                 self.db.rollback()
                 raise InvalidEntry(*e.args)
 
@@ -1950,7 +1950,7 @@ class Gradebook(object):
         self.db.add(solution_cell)
         try:
             self.db.commit()
-        except (IntegrityError, FlushError) as e:
+        except (IntegrityError, FlushError, StatementError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)
         return solution_cell
@@ -2019,7 +2019,7 @@ class Gradebook(object):
                 setattr(solution_cell, attr, kwargs[attr])
             try:
                 self.db.commit()
-            except (IntegrityError, FlushError) as e:
+            except (IntegrityError, FlushError, StatementError) as e:
                 raise InvalidEntry(*e.args)
 
         return solution_cell
@@ -2052,7 +2052,7 @@ class Gradebook(object):
         self.db.add(task_cell)
         try:
             self.db.commit()
-        except (IntegrityError, FlushError) as e:
+        except (IntegrityError, FlushError, StatementError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)
         return task_cell
@@ -2116,7 +2116,7 @@ class Gradebook(object):
                 setattr(task_cell, attr, kwargs[attr])
             try:
                 self.db.commit()
-            except (IntegrityError, FlushError) as e:
+            except (IntegrityError, FlushError, StatementError) as e:
                 raise InvalidEntry(*e.args)
 
         return task_cell
@@ -2149,7 +2149,7 @@ class Gradebook(object):
         self.db.add(source_cell)
         try:
             self.db.commit()
-        except (IntegrityError, FlushError) as e:
+        except (IntegrityError, FlushError, StatementError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)
         return source_cell
@@ -2213,7 +2213,7 @@ class Gradebook(object):
                 setattr(source_cell, attr, kwargs[attr])
             try:
                 self.db.commit()
-            except (IntegrityError, FlushError) as e:
+            except (IntegrityError, FlushError, StatementError) as e:
                 raise InvalidEntry(*e.args)
 
         return source_cell
@@ -2268,7 +2268,7 @@ class Gradebook(object):
             self.db.add(submission)
             self.db.commit()
 
-        except (IntegrityError, FlushError) as e:
+        except (IntegrityError, FlushError, StatementError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)
 
@@ -2336,7 +2336,7 @@ class Gradebook(object):
                     setattr(submission, attr, kwargs[attr])
             try:
                 self.db.commit()
-            except (IntegrityError, FlushError) as e:
+            except (IntegrityError, FlushError, StatementError) as e:
                 self.db.rollback()
                 raise InvalidEntry(*e.args)
 
@@ -2378,7 +2378,7 @@ class Gradebook(object):
                 minutes=minutes, hours=hours, days=days, weeks=weeks)
         try:
             self.db.commit()
-        except (IntegrityError, FlushError) as e:
+        except (IntegrityError, FlushError, StatementError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)
 
@@ -2402,7 +2402,7 @@ class Gradebook(object):
 
         try:
             self.db.commit()
-        except (IntegrityError, FlushError) as e:
+        except (IntegrityError, FlushError, StatementError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)
 
@@ -2429,7 +2429,7 @@ class Gradebook(object):
 
         try:
             self.db.commit()
-        except (IntegrityError, FlushError) as e:
+        except (IntegrityError, FlushError, StatementError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)
 

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -9,7 +9,7 @@ from sqlalchemy import (create_engine, ForeignKey, Column, String, Text,
                         DateTime, Interval, Float, Enum, UniqueConstraint,
                         Boolean)
 from sqlalchemy.orm import (sessionmaker, scoped_session, relationship,
-                            column_property, aliased)
+                            column_property)
 from sqlalchemy.orm.exc import NoResultFound, FlushError
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.associationproxy import association_proxy
@@ -3061,7 +3061,7 @@ class Gradebook(object):
          .group_by(SubmittedAssignment.id)\
          .subquery()
 
-        all_scores = aliased(union_all(
+        all_scores = union_all(
             self.db.query(
                 SubmittedAssignment.id.label('id'),
                 func.sum(Grade.score).label("score"),
@@ -3088,7 +3088,6 @@ class Gradebook(object):
             ).join(SubmittedNotebook, Grade, TaskCell)\
             .filter(TaskCell.cell_type == "markdown")\
             .group_by(SubmittedAssignment.id)
-        )
         )
         total_scores = self.db.query(
             func.sum(all_scores.c.score).label("score"),
@@ -3203,7 +3202,7 @@ class Gradebook(object):
          .group_by(SubmittedNotebook.id)\
          .subquery()
 
-        all_scores = aliased(union_all(
+        all_scores = union_all(
             self.db.query(
                 SubmittedNotebook.id.label('id'),
                 func.sum(Grade.score).label("score"),
@@ -3230,7 +3229,6 @@ class Gradebook(object):
             ).join(Grade, TaskCell)\
             .filter(TaskCell.cell_type == "markdown")\
             .group_by(SubmittedNotebook.id)
-        )
         )
         total_scores = self.db.query(
             func.sum(all_scores.c.score).label("score"),

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -65,11 +65,11 @@ class Assignment(Base):
 
     #: A collection of notebooks contained in this assignment, represented
     #: by :class:`~nbgrader.api.Notebook` objects
-    notebooks = relationship("Notebook", backref="assignment", order_by="Notebook.name")
+    notebooks = relationship("Notebook", back_populates="assignment", order_by="Notebook.name")
 
     #: A collection of submissions of this assignment, represented by
     #: :class:`~nbgrader.api.SubmittedAssignment` objects.
-    submissions = relationship("SubmittedAssignment", backref="assignment")
+    submissions = relationship("SubmittedAssignment", back_populates="assignment")
 
     #: The number of submissions of this assignment
     num_submissions = None
@@ -130,7 +130,7 @@ class Notebook(Base):
 
     #: The :class:`~nbgrader.api.Assignment` object that this notebook is a
     #: part of
-    assignment = None
+    assignment = relationship("Assignment", back_populates="notebooks")
 
     #: Unique id of :attr:`~nbgrader.api.Notebook.assignment`
     assignment_id = Column(String(32), ForeignKey('assignment.id'))
@@ -138,7 +138,7 @@ class Notebook(Base):
     #: The json string representation of the kernelspec for this notebook
     kernelspec = Column(String(1024), nullable=True)
 
-    _base_cells = relationship("BaseCell", backref="notebook")
+    _base_cells = relationship("BaseCell", back_populates="notebook")
 
     #: A collection of grade cells contained within this notebook, represented
     #: by :class:`~nbgrader.api.GradeCell` objects
@@ -160,11 +160,11 @@ class Notebook(Base):
 
     #: A collection of source cells contained within this notebook, represented
     #: by :class:`~nbgrader.api.SourceCell` objects
-    source_cells = relationship("SourceCell", backref="notebook")
+    source_cells = relationship("SourceCell", back_populates="notebook")
 
     #: A collection of submitted versions of this notebook, represented by
     #: :class:`~nbgrader.api.SubmittedNotebook` objects
-    submissions = relationship("SubmittedNotebook", backref="notebook")
+    submissions = relationship("SubmittedNotebook", back_populates="notebook")
 
     #: The number of submissions of this notebook
     num_submissions = None
@@ -221,6 +221,10 @@ class BaseCell(Base):
     #: Unique human-readable name of the cell. This need only be unique
     #: within the notebook, not across notebooks.
     name = Column(String(128), nullable=False)
+
+    #: The notebook that this cell is contained within, represented by a
+    #: :class:`~nbgrader.api.Notebook` object
+    notebook = relationship("Notebook", back_populates="_base_cells")
 
     #: Unique id of the :attr:`~nbgrader.api.BaseCell.notebook`
     notebook_id = Column(String(32), ForeignKey('notebook.id'), nullable=False)
@@ -389,7 +393,7 @@ class SourceCell(Base):
     checksum = Column(String(128))
 
     #: The :class:`~nbgrader.api.Notebook` that this source cell is contained in
-    notebook = None
+    notebook = relationship("Notebook", back_populates="source_cells")
 
     #: Unique id of the :attr:`~nbgrader.api.SourceCell.notebook`
     notebook_id = Column(String(32), ForeignKey('notebook.id'))
@@ -442,7 +446,7 @@ class Student(Base):
 
     #: A collection of assignments submitted by the student, represented as
     #: :class:`~nbgrader.api.SubmittedAssignment` objects
-    submissions = relationship("SubmittedAssignment", backref="student")
+    submissions = relationship("SubmittedAssignment", back_populates="student")
 
     #: The overall score of the student across all assignments, computed
     #: automatically from the :attr:`~nbgrader.api.SubmittedAssignment.score`
@@ -491,14 +495,14 @@ class SubmittedAssignment(Base):
 
     #: The master version of this assignment, represented by a
     #: :class:`~nbgrader.api.Assignment` object
-    assignment = None
+    assignment = relationship("Assignment", back_populates="submissions")
 
     #: Unique id of :attr:`~nbgrader.api.SubmittedAssignment.assignment`
     assignment_id = Column(String(32), ForeignKey('assignment.id'))
 
     #: The student who submitted this assignment, represented by a
     #: :class:`~nbgrader.api.Student` object
-    student = None
+    student = relationship("Student", back_populates="submissions")
 
     #: Unique id of :attr:`~nbgrader.api.SubmittedAssignment.student`
     student_id = Column(String(128), ForeignKey('student.id'))
@@ -513,7 +517,7 @@ class SubmittedAssignment(Base):
 
     #: A collection of notebooks contained within this submitted assignment,
     #: represented by :class:`~nbgrader.api.SubmittedNotebook` objects
-    notebooks = relationship("SubmittedNotebook", backref="assignment")
+    notebooks = relationship("SubmittedNotebook", back_populates="assignment")
 
     #: The score assigned to this assignment, automatically calculated from the
     #: :attr:`~nbgrader.api.SubmittedNotebook.score` of each notebook within
@@ -628,25 +632,25 @@ class SubmittedNotebook(Base):
 
     #: The submitted assignment this notebook is a part of, represented by a
     #: :class:`~nbgrader.api.SubmittedAssignment` object
-    assignment = None
+    assignment = relationship("SubmittedAssignment", back_populates="notebooks")
 
     #: Unique id of :attr:`~nbgrader.api.SubmittedNotebook.assignment`
     assignment_id = Column(String(32), ForeignKey('submitted_assignment.id'))
 
     #: The master version of this notebook, represented by a
     #: :class:`~nbgrader.api.Notebook` object
-    notebook = None
+    notebook = relationship("Notebook", back_populates="submissions")
 
     #: Unique id of :attr:`~nbgrader.api.SubmittedNotebook.notebook`
     notebook_id = Column(String(32), ForeignKey('notebook.id'))
 
     #: Collection of associated with this submitted notebook, represented
     #: by :class:`~nbgrader.api.Grade` objects
-    grades = relationship("Grade", backref="notebook")
+    grades = relationship("Grade", back_populates="notebook")
 
     #: Collection of comments associated with this submitted notebook, represented
     #: by :class:`~nbgrader.api.Comment` objects
-    comments = relationship("Comment", backref="notebook")
+    comments = relationship("Comment", back_populates="notebook")
 
     #: The student who submitted this notebook, represented by a
     #: :class:`~nbgrader.api.Student` object
@@ -747,7 +751,7 @@ class Grade(Base):
 
     #: The submitted notebook that this grade is assigned to, represented by a
     #: :class:`~nbgrader.api.SubmittedNotebook` object
-    notebook = None
+    notebook = relationship("SubmittedNotebook", back_populates="grades")
 
     #: Unique id of :attr:`~nbgrader.api.Grade.notebook`
     notebook_id = Column(String(32), ForeignKey('submitted_notebook.id'))
@@ -855,7 +859,7 @@ class Comment(Base):
 
     #: The submitted notebook that this comment is assigned to, represented by a
     #: :class:`~nbgrader.api.SubmittedNotebook` object
-    notebook = None
+    notebook = relationship("SubmittedNotebook", back_populates="comments")
 
     #: Unique id of :attr:`~nbgrader.api.Comment.notebook`
     notebook_id = Column(String(32), ForeignKey('submitted_notebook.id'))

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -2729,10 +2729,10 @@ class Gradebook(object):
             return 0.0
 
         score_sum_gradecell = self.db.query(func.coalesce(func.sum(Grade.score), 0.0))\
-            .join(GradeCell, Notebook, Assignment)\
+            .join(GradeCell).join(Notebook).join(Assignment)\
             .filter(Assignment.name == assignment_id).scalar()
         score_sum_taskcell = self.db.query(func.coalesce(func.sum(Grade.score), 0.0))\
-            .join(TaskCell, Notebook, Assignment)\
+            .join(TaskCell).join(Notebook).join(Assignment)\
             .filter(Assignment.name == assignment_id).scalar()
         score_sum = score_sum_gradecell + score_sum_taskcell
         return score_sum / assignment.num_submissions
@@ -2757,7 +2757,7 @@ class Gradebook(object):
             return 0.0
 
         score_sum = self.db.query(func.coalesce(func.sum(Grade.score), 0.0))\
-            .join(GradeCell, Notebook, Assignment)\
+            .join(GradeCell).join(Notebook).join(Assignment)\
             .filter(and_(
                 Assignment.name == assignment_id,
                 Notebook.assignment_id == Assignment.id,
@@ -2786,7 +2786,7 @@ class Gradebook(object):
             return 0.0
 
         score_sum = self.db.query(func.coalesce(func.sum(Grade.score), 0.0))\
-            .join(GradeCell, Notebook, Assignment)\
+            .join(GradeCell).join(Notebook).join(Assignment)\
             .filter(and_(
                 Assignment.name == assignment_id,
                 Notebook.assignment_id == Assignment.id,
@@ -2815,7 +2815,7 @@ class Gradebook(object):
             return 0.0
 
         score_sum = self.db.query(func.coalesce(func.sum(Grade.score), 0.0))\
-            .join(TaskCell, Notebook, Assignment)\
+            .join(TaskCell).join(Notebook).join(Assignment)\
             .filter(and_(
                 Assignment.name == assignment_id,
                 Notebook.assignment_id == Assignment.id,
@@ -2846,7 +2846,7 @@ class Gradebook(object):
             return 0.0
 
         score_sum = self.db.query(func.coalesce(func.sum(Grade.score), 0.0))\
-            .join(SubmittedNotebook, Notebook, Assignment)\
+            .join(SubmittedNotebook).join(Notebook).join(Assignment)\
             .filter(and_(
                 Notebook.name == notebook_id,
                 Assignment.name == assignment_id)).scalar()
@@ -2875,7 +2875,7 @@ class Gradebook(object):
             return 0.0
 
         score_sum = self.db.query(func.coalesce(func.sum(Grade.score), 0.0))\
-            .join(GradeCell, Notebook, Assignment)\
+            .join(GradeCell).join(Notebook).join(Assignment)\
             .filter(and_(
                 Notebook.name == notebook_id,
                 Assignment.name == assignment_id,
@@ -2908,7 +2908,7 @@ class Gradebook(object):
             return 0.0
 
         score_sum = self.db.query(func.coalesce(func.sum(Grade.score), 0.0))\
-            .join(GradeCell, Notebook, Assignment)\
+            .join(GradeCell).join(Notebook).join(Assignment)\
             .filter(and_(
                 Notebook.name == notebook_id,
                 Assignment.name == assignment_id,
@@ -2941,7 +2941,7 @@ class Gradebook(object):
             return 0.0
 
         score_sum = self.db.query(func.coalesce(func.sum(Grade.score), 0.0))\
-            .join(TaskCell, Notebook, Assignment)\
+            .join(TaskCell).join(Notebook).join(Assignment)\
             .filter(and_(
                 Notebook.name == notebook_id,
                 Assignment.name == assignment_id,
@@ -2975,7 +2975,7 @@ class Gradebook(object):
             scores = self.db.query(
                 Student.id,
                 func.sum(Grade.score).label("score")
-            ).join(SubmittedAssignment, SubmittedNotebook, Grade)\
+            ).join(SubmittedAssignment).join(SubmittedNotebook).join(Grade)\
              .group_by(Student.id)\
              .subquery()
 
@@ -3021,7 +3021,7 @@ class Gradebook(object):
             func.sum(Grade.score).label("code_score"),
             func.sum(GradeCell.max_score).label("max_code_score"),
         ).select_from(SubmittedAssignment
-        ).join(SubmittedNotebook, Notebook, Assignment, Student, Grade, GradeCell)\
+        ).join(SubmittedNotebook).join(Notebook).join(Assignment).join(Student).join(Grade).join(GradeCell)\
          .filter(GradeCell.cell_type == "code")\
          .group_by(SubmittedAssignment.id)\
          .subquery()
@@ -3032,7 +3032,7 @@ class Gradebook(object):
             func.sum(Grade.score).label("written_score"),
             func.sum(GradeCell.max_score).label("max_written_score"),
         ).select_from(SubmittedAssignment
-        ).join(SubmittedNotebook, Notebook, Assignment, Student, Grade, GradeCell)\
+        ).join(SubmittedNotebook).join(Notebook).join(Assignment).join(Student).join(Grade).join(GradeCell)\
          .filter(GradeCell.cell_type == "markdown")\
          .group_by(SubmittedAssignment.id)\
          .subquery()
@@ -3043,7 +3043,7 @@ class Gradebook(object):
             func.sum(Grade.score).label("task_score"),
             func.sum(TaskCell.max_score).label("max_task_score"),
         ).select_from(SubmittedAssignment
-        ).join(SubmittedNotebook, Notebook, Assignment, Student, Grade, TaskCell)\
+        ).join(SubmittedNotebook).join(Notebook).join(Assignment).join(Student).join(Grade).join(TaskCell)\
          .filter(TaskCell.cell_type == "markdown")\
          .group_by(SubmittedAssignment.id)\
          .subquery()
@@ -3053,7 +3053,7 @@ class Gradebook(object):
             SubmittedAssignment.id,
             exists().where(Grade.needs_manual_grade).label("needs_manual_grade")
         ).select_from(SubmittedAssignment
-        ).join(SubmittedNotebook, Assignment, Notebook)\
+        ).join(SubmittedNotebook).join(Assignment).join(Notebook)\
          .filter(
              SubmittedNotebook.assignment_id == SubmittedAssignment.id,
              Grade.notebook_id == SubmittedNotebook.id,
@@ -3067,7 +3067,7 @@ class Gradebook(object):
                 func.sum(Grade.score).label("score"),
                 func.sum(GradeCell.max_score).label("max_score"),
             ).select_from(SubmittedAssignment
-            ).join(SubmittedNotebook, Grade, GradeCell)
+            ).join(SubmittedNotebook).join(Grade).join(GradeCell)
             .filter(GradeCell.cell_type == "code")
             .group_by(SubmittedAssignment.id),
             # subquery for the written scores
@@ -3076,7 +3076,7 @@ class Gradebook(object):
                 func.sum(Grade.score).label("score"),
                 func.sum(GradeCell.max_score).label("max_score"),
             ).select_from(SubmittedAssignment
-            ).join(SubmittedNotebook, Grade, GradeCell)\
+            ).join(SubmittedNotebook).join(Grade).join(GradeCell)\
             .filter(GradeCell.cell_type == "markdown")\
             .group_by(SubmittedAssignment.id),
 
@@ -3085,7 +3085,7 @@ class Gradebook(object):
                 func.sum(Grade.score).label("score"),
                 func.sum(TaskCell.max_score).label("max_score"),
             ).select_from(SubmittedAssignment
-            ).join(SubmittedNotebook, Grade, TaskCell)\
+            ).join(SubmittedNotebook).join(Grade).join(TaskCell)\
             .filter(TaskCell.cell_type == "markdown")\
             .group_by(SubmittedAssignment.id)
         )
@@ -3112,7 +3112,7 @@ class Gradebook(object):
             func.coalesce(task_scores.c.max_task_score, 0.0),
             _manual_grade
         ).select_from(SubmittedAssignment
-        ).join(SubmittedNotebook, Assignment, Student, Grade)\
+        ).join(SubmittedNotebook).join(Assignment).join(Student).join(Grade)\
          .outerjoin(code_scores, SubmittedAssignment.id == code_scores.c.id)\
          .outerjoin(written_scores, SubmittedAssignment.id == written_scores.c.id)\
          .outerjoin(task_scores, SubmittedAssignment.id == task_scores.c.id)\
@@ -3168,7 +3168,7 @@ class Gradebook(object):
             func.sum(Grade.score).label("code_score"),
             func.sum(GradeCell.max_score).label("max_code_score"),
         ).select_from(SubmittedNotebook
-        ).join(SubmittedAssignment, Notebook, Assignment, Student, Grade, GradeCell)\
+        ).join(SubmittedAssignment).join(Notebook).join(Assignment).join(Student).join(Grade).join(GradeCell)\
          .filter(GradeCell.cell_type == "code")\
          .group_by(SubmittedNotebook.id)\
          .subquery()
@@ -3179,7 +3179,7 @@ class Gradebook(object):
             func.sum(Grade.score).label("written_score"),
             func.sum(GradeCell.max_score).label("max_written_score"),
         ).select_from(SubmittedNotebook
-        ).join(SubmittedAssignment, Notebook, Assignment, Student, Grade, GradeCell)\
+        ).join(SubmittedAssignment).join(Notebook).join(Assignment).join(Student).join(Grade).join(GradeCell)\
          .filter(GradeCell.cell_type == "markdown")\
          .group_by(SubmittedNotebook.id)\
          .subquery()
@@ -3189,7 +3189,7 @@ class Gradebook(object):
             func.coalesce(func.sum(Grade.score), 0.0).label("task_score"),
             func.sum(TaskCell.max_score).label("max_task_score"),
         ).select_from(SubmittedNotebook
-        ).join(SubmittedAssignment, Notebook, Assignment, Student, Grade, TaskCell)\
+        ).join(SubmittedAssignment).join(Notebook).join(Assignment).join(Student).join(Grade).join(TaskCell)\
          .filter(TaskCell.cell_type == "markdown")\
          .group_by(SubmittedNotebook.id)\
          .subquery()
@@ -3198,7 +3198,7 @@ class Gradebook(object):
             SubmittedNotebook.id,
             func.sum(task_scores.c.max_task_score).label("mmmm"),
         ).select_from(SubmittedNotebook
-        ).join(SubmittedAssignment, task_scores)\
+        ).join(SubmittedAssignment).join(task_scores)\
          .group_by(SubmittedNotebook.id)\
          .subquery()
 
@@ -3208,7 +3208,7 @@ class Gradebook(object):
                 func.sum(Grade.score).label("score"),
                 func.sum(GradeCell.max_score).label("max_score"),
             ).select_from(SubmittedNotebook
-            ).join(Grade, GradeCell)
+            ).join(Grade).join(GradeCell)
             .filter(GradeCell.cell_type == "code")
             .group_by(SubmittedNotebook.id),
             # subquery for the written scores
@@ -3217,7 +3217,7 @@ class Gradebook(object):
                 func.sum(Grade.score).label("score"),
                 func.sum(GradeCell.max_score).label("max_score"),
             ).select_from(SubmittedNotebook
-            ).join(Grade, GradeCell)\
+            ).join(Grade).join(GradeCell)\
             .filter(GradeCell.cell_type == "markdown")\
             .group_by(SubmittedNotebook.id),
 
@@ -3226,7 +3226,7 @@ class Gradebook(object):
                 func.sum(Grade.score).label("score"),
                 func.sum(TaskCell.max_score).label("max_score"),
             ).select_from(SubmittedNotebook
-            ).join(Grade, TaskCell)\
+            ).join(Grade).join(TaskCell)\
             .filter(TaskCell.cell_type == "markdown")\
             .group_by(SubmittedNotebook.id)
         )
@@ -3244,7 +3244,7 @@ class Gradebook(object):
             SubmittedNotebook.id,
             exists().where(Grade.needs_manual_grade).label("needs_manual_grade")
         ).select_from(SubmittedNotebook
-        ).join(SubmittedAssignment, Assignment, Notebook)\
+        ).join(SubmittedAssignment).join(Assignment).join(Notebook)\
          .filter(
              Grade.notebook_id == SubmittedNotebook.id,
              Grade.needs_manual_grade)\
@@ -3256,7 +3256,7 @@ class Gradebook(object):
             SubmittedNotebook.id,
             exists().where(Grade.failed_tests).label("failed_tests")
         ).select_from(SubmittedNotebook
-        ).join(SubmittedAssignment, Assignment, Notebook)\
+        ).join(SubmittedAssignment).join(Assignment).join(Notebook)\
          .filter(
              Grade.notebook_id == SubmittedNotebook.id,
              Grade.failed_tests)\
@@ -3279,7 +3279,7 @@ class Gradebook(object):
             func.coalesce(task_scores.c.max_task_score, 0.0),
             _manual_grade, _failed_tests, SubmittedNotebook.flagged
         ).select_from(SubmittedNotebook
-        ).join(SubmittedAssignment, Notebook, Assignment, Student, Grade)\
+        ).join(SubmittedAssignment).join(Notebook).join(Assignment).join(Student).join(Grade)\
          .outerjoin(code_scores, SubmittedNotebook.id == code_scores.c.id)\
          .outerjoin(written_scores, SubmittedNotebook.id == written_scores.c.id)\
          .outerjoin(task_scores, SubmittedNotebook.id == task_scores.c.id)\

--- a/nbgrader/tests/api/test_models.py
+++ b/nbgrader/tests/api/test_models.py
@@ -511,7 +511,7 @@ def test_query_needs_manual_grade_ungraded(submissions):
 
     # do all the assignments need grading?
     a = db.query(api.SubmittedAssignment)\
-        .join(api.SubmittedNotebook, api.Grade)\
+        .join(api.SubmittedNotebook).join(api.Grade)\
         .filter(api.SubmittedNotebook.needs_manual_grade)\
         .order_by(api.SubmittedAssignment.id)\
         .all()
@@ -560,7 +560,7 @@ def test_query_needs_manual_grade_autograded(submissions):
 
     # do all the assignments need grading?
     a = db.query(api.SubmittedAssignment)\
-        .join(api.SubmittedNotebook, api.Grade)\
+        .join(api.SubmittedNotebook).join(api.Grade)\
         .filter(api.SubmittedNotebook.needs_manual_grade)\
         .order_by(api.SubmittedAssignment.id)\
         .all()
@@ -590,7 +590,7 @@ def test_query_needs_manual_grade_autograded(submissions):
 
     # do none of the assignments need grading?
     assert [] == db.query(api.SubmittedAssignment)\
-        .join(api.SubmittedNotebook, api.Grade)\
+        .join(api.SubmittedNotebook).join(api.Grade)\
         .filter(api.SubmittedNotebook.needs_manual_grade)\
         .all()
 
@@ -635,7 +635,7 @@ def test_query_needs_manual_grade_manualgraded(submissions):
 
     # do all the assignments need grading?
     a = db.query(api.SubmittedAssignment)\
-        .join(api.SubmittedNotebook, api.Grade)\
+        .join(api.SubmittedNotebook).join(api.Grade)\
         .filter(api.SubmittedNotebook.needs_manual_grade)\
         .order_by(api.SubmittedAssignment.id)\
         .all()
@@ -665,7 +665,7 @@ def test_query_needs_manual_grade_manualgraded(submissions):
 
     # do none of the assignments need grading?
     assert [] == db.query(api.SubmittedAssignment)\
-        .join(api.SubmittedNotebook, api.Grade)\
+        .join(api.SubmittedNotebook).join(api.Grade)\
         .filter(api.SubmittedNotebook.needs_manual_grade)\
         .all()
 
@@ -1197,7 +1197,7 @@ def test_submittednotebook_to_dict(submissions):
     db = submissions[0]
 
     sn = db.query(api.SubmittedNotebook)\
-        .join(api.Notebook, api.SubmittedAssignment, api.Student)\
+        .join(api.Notebook).join(api.SubmittedAssignment).join(api.Student)\
         .filter(and_(
             api.Student.id == '12345',
             api.Notebook.name == 'blah'))\

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup_args = dict(
         'console_scripts': ['nbgrader=nbgrader.apps.nbgraderapp:main']
     },
     install_requires=[
-        "sqlalchemy",
+        "sqlalchemy>=1.4.1",
         "python-dateutil",
         "jupyter",
         "notebook>=4.2",


### PR DESCRIPTION
Various things seem to have changed in SQLAlchemy, which was causing some test cases to fail as well as many warnings. I have done my best to fix these:

- Ensure enum values are validated
- Remove unnecessary 'aliased' call which was causing errors
- Fix syntax for multiple joins, which was causing errors
- Fix relationships for different types of BaseCells, Grades, and Comments, which was causing warnings
- Use the inspector to get the table names (was causing warnings), and fix this in the alembic migration scripts too
- Use scalar subqueries where appropriate to suppress warnings

This does not fix all of the bugs. There is a strange one that seems to be failing where a submitted notebook doesn't have a student associated with it, and I haven't been able to figure out why. But I am not sure when I will have time to do more work on this so I figured I'd go ahead and make a PR with what I have!