### PR TITLE
Use NBGRADER_VALIDATING env var during autograding

### DIFF
--- a/nbgrader/converters/autograde.py
+++ b/nbgrader/converters/autograde.py
@@ -189,6 +189,6 @@ class Autograde(BaseConverter):
         self._init_preprocessors()
         try:
             with utils.setenv(NBGRADER_EXECUTION='autograde'):
-                super(Autograde, self).convert_sinfgle_notebook(notebook_filename)
+                super(Autograde, self).convert_single_notebook(notebook_filename)
         finally:
             self._sanitizing = True

--- a/nbgrader/converters/autograde.py
+++ b/nbgrader/converters/autograde.py
@@ -188,6 +188,7 @@ class Autograde(BaseConverter):
         self._sanitizing = False
         self._init_preprocessors()
         try:
-            super(Autograde, self).convert_single_notebook(notebook_filename)
+            with utils.setenv(NBGRADER_EXECUTION='autograde'):
+                super(Autograde, self).convert_sinfgle_notebook(notebook_filename)
         finally:
             self._sanitizing = True

--- a/nbgrader/docs/source/user_guide/faq.rst
+++ b/nbgrader/docs/source/user_guide/faq.rst
@@ -197,3 +197,11 @@ Can tests be only temporarily hidden, so that students can reveal them?
 No, the tests are either present in the student version of the notebook or they
 are not. However, there exist extensions such as
 https://github.com/kirbs-/hide_code which can assist in hiding code cells.
+
+Can I modify the notebook behavior during autograding or validation?
+--------------------------------------------------------------------
+
+Yes, when running the autograder or validator, nbgrader sets the ``NBGRADER_EXECUTION``
+environment variable, either to ``'autograde'`` or ``'validate'``. You can check whether
+this variable is set and then modify the logic in the notebook accordingly. For example,
+you could use this to skip executing some cells during autograding only.

--- a/nbgrader/tests/apps/files/validating-environment-variable.ipynb
+++ b/nbgrader/tests/apps/files/validating-environment-variable.ipynb
@@ -1,0 +1,55 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "nbgrader": {
+     "grade": true,
+     "grade_id": "cell-bfbdf1784663b6b6",
+     "locked": true,
+     "points": 1,
+     "schema_version": 3,
+     "solution": false,
+     "task": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "if os.getenv('NBGRADER_EXECUTION'):\n",
+    "    assert False"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Create Assignment",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/nbgrader/tests/apps/test_nbgrader_validate.py
+++ b/nbgrader/tests/apps/test_nbgrader_validate.py
@@ -121,3 +121,9 @@ class TestNbGraderValidate(BaseTestApp):
         run_nbgrader(["validate", "nb1.ipynb", "nb2.ipynb"])
         run_nbgrader(["validate", "nb1.ipynb", "nb2.ipynb", "nb3.ipynb"])
         run_nbgrader(["validate"], retcode=1)
+
+    def test_validate_with_validating_envvar(self, db, course_dir):
+        self._copy_file(join("files", "validating-environment-variable.ipynb"), "nb1.ipynb")
+        output = run_nbgrader(["validate", "nb1.ipynb"], stdout=True)
+        assert output.splitlines()[0] == "VALIDATION FAILED ON 1 CELL(S)! If you submit your assignment as it is, you WILL NOT"
+

--- a/nbgrader/validator.py
+++ b/nbgrader/validator.py
@@ -284,7 +284,7 @@ class Validator(LoggingConfigurable):
 
     def _preprocess(self, nb: NotebookNode) -> NotebookNode:
         resources = {}
-        with utils.setenv(NBGRADER_VALIDATING='1'):
+        with utils.setenv(NBGRADER_VALIDATING='1', NBGRADER_EXECUTION='validate'):
             for preprocessor in self.preprocessors:
                 # https://github.com/jupyter/nbgrader/pull/1075
                 # It seemes that without the self.config passed below,


### PR DESCRIPTION
This also sets the NBGRADER_VALIDATING environment variable during autograding, which notebooks can use to selectively choose to not run certain cells if desired. This also adds a test for this, both for the autograder and for the validator.

Fixes #1415 
