### PR TITLE
Make converter exporter class configurable

### DIFF
--- a/nbgrader/converters/base.py
+++ b/nbgrader/converters/base.py
@@ -31,7 +31,7 @@ class BaseConverter(LoggingConfigurable):
     assignments = Dict({})
     writer = Instance(FilesWriter)
     exporter = Instance(Exporter)
-    exporter_class = Type(NotebookExporter, klass=Exporter)
+    exporter_class = Type(NotebookExporter, klass=Exporter).tag(config=True)
     preprocessors = List([])
 
     force = Bool(False, help="Whether to overwrite existing assignments/submissions").tag(config=True)


### PR DESCRIPTION
This allows users to set a custom exporter class in each converter. 

Use case:
We want to enrich student feedback with custom information and need custom filters for this. The easiest way to achieve this is is by using a custom exporter as the _GenerateFeedback_ converter.

Any comments are appreciated.