### PR TITLE
Fix broken windows tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
           sudo apt-get install pandoc
       - name: Install Python dependencies
         run: |
-          pip install -U pip wheel setuptools
+          python -m pip install --upgrade pip wheel setuptools
           python tasks.py install --group="$GROUP"
           pip freeze
       - name: Run pytest


### PR DESCRIPTION
Use `python -m pip install --upgrade` rather than `pip install -U`, which causes a permission error on Windows.