### PR TITLE
Remove continuous integration for python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,18 +30,14 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-20.04]
         group: ["docs", "nbextensions", "python"]
-        python: ["3.6", "3.7", "3.8", "3.9"]
+        python: ["3.7", "3.8", "3.9"]
         exclude:
           - os: windows-latest
-            group: docs
-          - python: "3.6"
             group: docs
           - python: "3.7"
             group: docs
           - python: "3.8"
             group: docs
-          - python: "3.6"
-            group: nbextensions
           - python: "3.7"
             group: nbextensions
     steps:

--- a/setup.py
+++ b/setup.py
@@ -69,8 +69,6 @@ setup_args = dict(
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
     ],
     packages=find_packages(),
     package_data={


### PR DESCRIPTION
Traitlets v5 (see #1442) no longer supports python 3.6, so we will need to drop support for it as well.