### PR TITLE
Downgrade traitlets to avoid installation errors with v5.0.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup_args = dict(
         "notebook>=4.2",
         "nbconvert==5.6.1",
         "nbformat",
-        "traitlets==5.0.5",
+        "traitlets==4.3.3",
         "jupyter_core",
         "jupyter_client",
         "tornado",


### PR DESCRIPTION
Downgrades the `traitlets` package to `v4.3.3` to remove errors when running the `pip install .` command. For some reason, `pip` cannot resolve version `5.0.5` [even though it does appear as a valid version in PyPi](https://pypi.org/project/traitlets/).