### PR TITLE
Fix Issue with Courses tab on Multi courses

### DIFF
--- a/nbgrader/server_extensions/course_list/handlers.py
+++ b/nbgrader/server_extensions/course_list/handlers.py
@@ -61,7 +61,7 @@ class CourseListHandler(IPythonHandler):
         http_client = AsyncHTTPClient()
         try:
             response = yield http_client.fetch(url, headers=header)
-        except HTTPError:
+        except (HTTPError, ConnectionRefusedError):
             # local formgrader isn't running
             self.log.warning("Local formgrader does not seem to be running")
             raise gen.Return([])


### PR DESCRIPTION
When using multiple courses multiple instructors the courses tab will crash with an Unauthorized error. This happens when it tries to find local form graders without a token.

The fix is to just add `ConnectionRefusedError` exception handler. In which case it will gracefully continue to looking for Jupyter hub formgraders instead of erroring out.

Fixes: #1292 
