### PR TITLE
docs: revise "Managing assignment files" pages

### DIFF
--- a/nbgrader/docs/source/user_guide/managing_assignment_files.ipynb
+++ b/nbgrader/docs/source/user_guide/managing_assignment_files.ipynb
@@ -11,7 +11,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Distributing assignments to students and collecting them can be a logistical nightmare. If you are running nbgrader on a server, some of this pain can be relieved by relying on nbgrader's built-in functionality for releasing and collecting assignments on the instructor's side, and fetching and submitting assignments on the student's side. This is implemented as an **exchange directory** coupled with instructor and student interfaces - both integrated in the Jupyter interface and via the command line."
+    "Distributing assignments to students and collecting them can be a logistical nightmare. If you are running nbgrader on a server, some of this pain can be relieved by relying on nbgrader's built-in functionality for releasing and collecting assignments on the instructor's side, and fetching and submitting assignments on the student's side. \n",
+    "\n",
+    "This page describes the built-in implementation of an **exchange directory** coupled with instructor and student interfaces - both integrated in the Jupyter interface and via the command line.  Since nbgrader 0.7.0, the exchange is modular, and a different implementation could be used (with the same user interface as below)."
    ]
   },
   {

--- a/nbgrader/docs/source/user_guide/managing_assignment_files.ipynb
+++ b/nbgrader/docs/source/user_guide/managing_assignment_files.ipynb
@@ -4,14 +4,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Managing assignment files"
+    "# Exchanging assignment files"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Distributing assignments to students and collecting them can be a logistical nightmare. If you are running nbgrader on a server, some of this pain can be relieved by relying on nbgrader's built-in functionality for releasing and collecting assignments on the instructor's side, and fetching and submitting assignments on the student's side."
+    "Distributing assignments to students and collecting them can be a logistical nightmare. If you are running nbgrader on a server, some of this pain can be relieved by relying on nbgrader's built-in functionality for releasing and collecting assignments on the instructor's side, and fetching and submitting assignments on the student's side. This is implemented as an **exchange directory** coupled with instructor and student interfaces - both integrated in the Jupyter interface and via the command line."
    ]
   },
   {

--- a/nbgrader/docs/source/user_guide/managing_assignment_files_manually.ipynb
+++ b/nbgrader/docs/source/user_guide/managing_assignment_files_manually.ipynb
@@ -4,14 +4,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Managing assignment files manually"
+    "# Exchanging assignment files manually"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Distributing assignments to students and collecting them can be a logistical nightmare. If you are relying on distributing the release version of the assignment to the students using your institution's existing learning management system the process of downloading the students submissions from the learning management system and then getting them back into ``nbgrader`` can be simplified by relying on some of nbgrader's built-in functionality."
+    "After an assignment has been created using `nbgrader generate_assignment`, the instructor must actually release that assignment to students. This section of the documentation assumes you are using your institution's existing learning management system for distributing the release version of the assignment. It is also assumed that the students will fetch the assignments from - and submit their assignments to - the learning management system.\n",
+    "\n",
+    "If this is not the case and you are using nbgrader in a shared server environment, you can do this with the ``nbgrader release_assignment`` command (see :doc:`managing_assignment_files`)\n",
+    "\n",
+    "\n",
+    "Distributing assignments to students and collecting them can be a logistical nightmare. The previous page discussed the built-in exchange directory, but that is not the only option (and in fact, was not the first way of doing things).  One can also distribute and collect files by other means, such as though your institution's learning management system.  If you are relying on your institution's learning management system to get the submitted versions of notebooks back from students, ``nbgrader`` has some built-in functionality to make theat easier (putting the files in the right place into the course directory via an importer).\n",
+    "\n",
+    "One can also do this fully manually, by sending files around.  This may be useful during the testing phase."
    ]
   },
   {
@@ -26,21 +33,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Releasing and fetching assignments"
+    "## Releasing assignments\n",
+    "\n",
+    "In short, to release an assignment, send the files at ``release/{assignment_id}/*`` to your students.  For example, you might post the files on your course page."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "After an assignment has been created using `nbgrader generate_assignment`, the instructor must actually release that assignment to students. This section of the documentation assumes you are using your institution's existing learning management system for distributing the release version of the assignment. It is also assumed that the students will fetch the assignments from - and submit their assignments to - the learning management system."
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "If this is not the case and you are using nbgrader in a shared server environment, you can do this with the ``nbgrader release_assignment`` command (see :doc:`managing_assignment_files`)"
+    "## Submitting assignments\n",
+    "\n",
+    "When an assignment is submitted, it needs to be placed in ``submitted/{student_id}/{assignment_id}/*``.  The rest of this page describes the built-in ways to do this, if students upload them to a learning management system and you can download them all at once in an archive.  This is called **collecting** the assignment.\n"
    ]
   },
   {

--- a/nbgrader/docs/source/user_guide/managing_assignment_files_manually.ipynb
+++ b/nbgrader/docs/source/user_guide/managing_assignment_files_manually.ipynb
@@ -11,12 +11,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "After an assignment has been created using `nbgrader generate_assignment`, the instructor must actually release that assignment to students. This section of the documentation assumes you are using your institution's existing learning management system for distributing the release version of the assignment. It is also assumed that the students will fetch the assignments from - and submit their assignments to - the learning management system.\n",
+    "After an assignment has been created using `nbgrader generate_assignment`, the instructor must actually release that assignment to students. This page describes how to do that using your institution's existing learning management system, assuming that the students will fetch the assignments from - and submit their assignments to - the learning management system.\n",
     "\n",
-    "If this is not the case and you are using nbgrader in a shared server environment, you can do this with the ``nbgrader release_assignment`` command (see :doc:`managing_assignment_files`)\n",
+    "If this is not the case and you are using nbgrader in a shared server environment (e.g. JupyterHub), you can do this with an exchange implementation (see :doc:`managing_assignment_files`).\n",
     "\n",
-    "\n",
-    "Distributing assignments to students and collecting them can be a logistical nightmare. The previous page discussed the built-in exchange directory, but that is not the only option (and in fact, was not the first way of doing things).  One can also distribute and collect files by other means, such as though your institution's learning management system.  If you are relying on your institution's learning management system to get the submitted versions of notebooks back from students, ``nbgrader`` has some built-in functionality to make theat easier (putting the files in the right place into the course directory via an importer).\n",
+    "Distributing assignments to students and collecting them can be a logistical nightmare. The previous page discussed the built-in exchange directory, but that is not the only option (and in fact, was added later on).  One can also distribute and collect files by other means, such as though your institution's learning management system.  If you are relying on your institution's learning management system to get the submitted versions of notebooks back from students, ``nbgrader`` has some built-in functionality to make theat easier (putting the files in the right place into the course directory via an importer).\n",
     "\n",
     "One can also do this fully manually, by sending files around.  This may be useful during the testing phase."
    ]


### PR DESCRIPTION
- Rename to "Exchanging assignment files" - the previous name could
  mean almost anything related to nbgrader, and uses the standard
  terminology.

- Adjust the introduction sections so that each page describes the
  reason you would read it.  For the 'manual' page, there are more
  rearrangements here, since the focus has changed a lot.  But nothing
  is completely lost (though maybe it should be, to reduce redundancy)

- There is more to do to improve, but I am trying to start small and
  get some basic stuff done.

- Review: General check, but not too much, we should keep iterating.
