### PR TITLE
docs: update highlights to introduce the notebook format

### DIFF
--- a/nbgrader/docs/source/user_guide/highlights.rst
+++ b/nbgrader/docs/source/user_guide/highlights.rst
@@ -39,11 +39,11 @@ example of an instructor's notebook:
 
 We see that this is a perfectly normal notebook, with cell metadata
 tagging cells and some ``###`` markup indicating lines to be
-changed/removed in the student version.  Validating the assignment
+changed/removed in the student version.  Testing the assignment
 assignment is as simple as running the entire notebook and looking for
 errors.
 
-The student version is generated from the above to get:
+The student version is **generated** from the above to get:
 
 .. code:: python
 
@@ -60,14 +60,15 @@ The student version is generated from the above to get:
 
 We see that this is also a valid notebook, with the assignment parts
 replaced with a placeholder.  The student can attempt to do the
-assignment, and student validation is as simple as "Run all cells" and
-look for errors.
+assignment, and checking their work is as simple as "Restart kernel and
+run all cells" and looking for errors (which the **validate** button
+implements automatically).
 
 When the instructor receives the assignment back from the students,
 Cell 2 is restored to its initial values (restoring the hidden test
-while leaving the student solution), and autograding is as simple as
-"Run all cells" and look for error output in the autograded-tests
-cells.
+while leaving the student solution), and the **autograding**
+implementation is as simple as "Run all cells" and looking for error
+output in the autograded-tests cells).
 
 
 

--- a/nbgrader/docs/source/user_guide/highlights.rst
+++ b/nbgrader/docs/source/user_guide/highlights.rst
@@ -1,8 +1,38 @@
-Interface highlights
-====================
+Highlights
+==========
+
+Broadly speaking, nbgrader implements:
+
+* A **Jupyter notebook format** for assignments, completely normal
+  Jupyter notebooks with metadata to make them useful for teaching.
+
+* A **student interface** as Jupyter interface extensions.
+
+* An **instructor interface** as Jupyter interface extensions.
+
+* A method of exchanging files between instructors and students.
+
+
+Student interface
+-----------------
+
+Student assignment list extension for Jupyter notebooks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Using the **assignment list extension**, students may conveniently view, fetch,
+submit, and validate their assignments. This is also where they recieve and
+review any feedback on those submissions:
+
+.. image:: images/student_assignment.gif
+   :alt: nbgrader assignment list
+
+
+
+Instructor interface
+--------------------
 
 Instructor toolbar extension for Jupyter notebooks
---------------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The **nbgrader toolbar extension** for Jupyter notebooks guides the instructor
 through assignment and grading tasks using the familiar Jupyter notebook
@@ -12,7 +42,7 @@ interface. For example, creating an assignment has the following workflow:
    :alt: Creating assignment
 
 Instructor "formgrader" extension for Jupyter notebooks
--------------------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The **formgrader extension** for the Jupyter notebook allows instructors to use
 the core functionality of nbgrader---generating the student version of an
@@ -22,15 +52,6 @@ autograding submissions, and manually grading submissions.
 .. image:: images/formgrader.gif
     :alt: Formgrader extension
 
-Student assignment list extension for Jupyter notebooks
--------------------------------------------------------
-
-Using the **assignment list extension**, students may conveniently view, fetch,
-submit, and validate their assignments. This is also where they recieve and
-review any feedback on those submissions:
-
-.. image:: images/student_assignment.gif
-   :alt: nbgrader assignment list
 
 The command line tools of nbgrader
 ----------------------------------

--- a/nbgrader/docs/source/user_guide/highlights.rst
+++ b/nbgrader/docs/source/user_guide/highlights.rst
@@ -3,14 +3,72 @@ Highlights
 
 Broadly speaking, nbgrader implements:
 
-* A **Jupyter notebook format** for assignments, completely normal
+* A **Jupyter notebook format** for assignments: completely normal
   Jupyter notebooks with metadata to make them useful for teaching.
 
-* A **student interface** as Jupyter interface extensions.
+* **Student interface** as Jupyter extensions.
 
-* An **instructor interface** as Jupyter interface extensions.
+* **Instructor interface** as Jupyter extensions.
 
 * A method of exchanging files between instructors and students.
+
+Notebook format
+---------------
+
+Nbgrader actually doesn't have its own notebook format: it is
+completely standard Jupyter, so you don't have to learn anything new
+or need to put code into a teaching-only format.  Let's look at an
+example of an instructor's notebook:
+
+.. code:: python
+
+   # Cell 1, cell metadata=autograded-answer
+   def add(a, b):
+       ### BEGIN SOLUTION
+       c = a + b
+       ### END SOLUTION
+       return c
+
+.. code:: python
+
+   # Cell 2, cell metadata=autograder-tests
+   assert add(1, 2) == 3
+   ### BEGIN HIDDEN TESTS
+   assert add(-1, 2) == 1
+   ### END HIDDEN TESTS
+
+We see that this is a perfectly normal notebook, with cell metadata
+tagging cells and some ``###`` markup indicating lines to be
+changed/removed in the student version.  Validating the assignment
+assignment is as simple as running the entire notebook and looking for
+errors.
+
+The student version is generated from the above to get:
+
+.. code:: python
+
+   # Cell 1
+   def add(a, b):
+       # YOUR CODE HERE
+       raise NotImplementedError()
+       return c
+
+.. code:: python
+
+   # Cell 2
+   assert add(1, 2) == 3
+
+We see that this is also a valid notebook, with the assignment parts
+replaced with a placeholder.  The student can attempt to do the
+assignment, and student validation is as simple as "Run all cells" and
+look for errors.
+
+When the instructor receives the assignment back from the students,
+Cell 2 is restored to its initial values (restoring the hidden test
+while leaving the student solution), and autograding is as simple as
+"Run all cells" and look for error output in the autograded-tests
+cells.
+
 
 
 Student interface


### PR DESCRIPTION
Rearrange the highlights page into three sections, and introduce a section giving a minimal example of the notebook format.  This introduces some of the changes discussed in #1491.  I recommend looking at the commits separately, to easily understand what is going on and see more about each change.

To review: general text and all, also the general clarity and message of the change.