### PR TITLE
docs/index: Move setup-related topics to configuration section

### DIFF
--- a/nbgrader/docs/source/index.rst
+++ b/nbgrader/docs/source/index.rst
@@ -17,9 +17,7 @@ For additional resources on using Jupyter in educational contexts, see the `jupy
     :caption: User Documentation
 
     user_guide/highlights
-    user_guide/installation
     user_guide/philosophy
-    user_guide/what_is_nbgrader
     user_guide/creating_and_grading_assignments
     user_guide/managing_the_database
     user_guide/managing_assignment_files
@@ -31,8 +29,10 @@ For additional resources on using Jupyter in educational contexts, see the `jupy
 
 .. toctree::
     :maxdepth: 1
-    :caption: Configuration
+    :caption: Setup and Configuration
 
+    user_guide/installation
+    user_guide/what_is_nbgrader
     configuration/student_version
     configuration/nbgrader_config
     configuration/config_options


### PR DESCRIPTION
- Rename the "Configuration" section to "Setup and Configuration" -
  this section is focused on the ones administrating a nbgrader
  install for others (or themselves).
- Move the "Installation" and "What is nbgrader?" pages to this new
  section.
- The motivation is to keep the "User guide" focused on people using
  nbgrader, something we might send to a instructor or student who
  needs to get started.  The next section starts on things that
  administrators might need to know.  Unlike a lot of software, we
  expect a bigger difference between users and admins here, at least
  for hub-based setups.
- I have not moved the pages, so they are still in the `user_guide/`
  section, not `configuration/`.  While not idea, I consider this less
  bad than moving - for now.  They can be rearranged later.
- Review: does this make sense?  It would be fine to say no.
