### PR TITLE
[converters/autograde] Fix autograded notebook permission

### DIFF
--- a/nbgrader/converters/autograde.py
+++ b/nbgrader/converters/autograde.py
@@ -39,6 +39,10 @@ class Autograde(BaseConverter):
 
     _sanitizing = True
 
+    @default("permissions")
+    def _permissions_default(self) -> int:
+        return 444
+
     @property
     def _input_directory(self) -> str:
         if self._sanitizing:


### PR DESCRIPTION
When groupshared is enabled (`c.CourseDirectory.groupshared = True`), the default permission in `BaseConverter` class will be changed to `664`, which is expected. However, since `autograde.py` is also inherited from `BaseConverter` class in `convertes/base.py`, this will make permission of autograded notebooks to be `664` as well, which is not wanted, because those files should be read-only (444) to grader as it's when `groupshared = False`.

This PR will set the default permission of `Autograde` class to `444`, regardless of whether the groupshared is True or False.