### PR TITLE
Improve CI by running sphinx linkcheck

### DIFF
--- a/nbgrader/docs/source/contributor_guide/database.rst
+++ b/nbgrader/docs/source/contributor_guide/database.rst
@@ -4,7 +4,7 @@ Modifying the Database
 Sometimes new features require modifying the database, such as adding a new
 column. Implementing such changes is fine, but can cause compatibility problems
 for users who are using an older version of the database schema. To resolve
-this issue, we use `alembic <http://alembic.zzzcomputing.com/en/latest/index.html>`_ to handle database migrations.
+this issue, we use `alembic <https://alembic.zzzcomputing.com/en/latest/index.html>`_ to handle database migrations.
 
 To use alembic to migrate the database schema, first run the following
 command::
@@ -26,7 +26,7 @@ called ``extra_credit`` to the ``grade`` table:
         op.drop_column('grade', 'extra_credit')
 
 Please see the `alembic documentation
-<http://alembic.zzzcomputing.com/en/latest/index.html>`_ for further details on
+<https://alembic.zzzcomputing.com/en/latest/index.html>`_ for further details on
 how these files work. Additionally, note that you both need to update the
 database schema in ``nbgrader/api.py`` (this describes how to create **new**
 databases) as well as using alembic to describe what changes need to be made to

--- a/nbgrader/docs/source/contributor_guide/documentation.rst
+++ b/nbgrader/docs/source/contributor_guide/documentation.rst
@@ -10,7 +10,7 @@ Editing source files
 
 * ReStructured Text: The rst files should be fairly straightforward to edit. Here is
   `a quick reference of rst syntax <http://docutils.sourceforge.net/docs/user/rst/quickref.html>`_.
-  Some of the rst files also use `Sphinx autodoc <http://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html>`_.
+  Some of the rst files also use `Sphinx autodoc <https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html>`_.
 
 * Jupyter Notebooks: The Jupyter notebooks are written in Python and should be written so that
   they are compatible with Python 3. If you need
@@ -36,7 +36,7 @@ While the documentation gets built automatically on Read The Docs, the notebooks
 However, executing the notebooks is easy to do!
 
 Our docs are built with `nbconvert <https://nbconvert.readthedocs.io/en/latest/>`_,
-`Pandoc <http://pandoc.org/>`_, and `Sphinx <http://www.sphinx-doc.org/en/master/>`_.
+`Pandoc <https://pandoc.org/>`_, and `Sphinx <http://www.sphinx-doc.org/en/master/>`_.
 To build the docs locally, run the following command::
 
     python tasks.py docs

--- a/nbgrader/docs/source/user_guide/advanced.rst
+++ b/nbgrader/docs/source/user_guide/advanced.rst
@@ -71,7 +71,7 @@ though if you find something that can't be accessed through the API please
 
 In this example, we'll go through how to create a CSV file of grades for each
 student and assignment using nbgrader and `pandas
-<http://pandas.pydata.org/>`__.
+<https://pandas.pydata.org/>`__.
 
 .. versionadded:: 0.4.0
     nbgrader now comes with CSV export functionality out-of-the box using the

--- a/nbgrader/docs/source/user_guide/what_is_nbgrader.rst
+++ b/nbgrader/docs/source/user_guide/what_is_nbgrader.rst
@@ -415,4 +415,4 @@ See also
 * Noteable service, based on nbgrader
 
   * `Student guide <https://noteable.edina.ac.uk/student-guide/>`__
-  * `Instructor guide <https://noteable.edina.ac.uk/nbguide/>`__
+  * `Instructor guide <https://noteable.edina.ac.uk/documentation/nbguide/>`__


### PR DESCRIPTION
Sphinx linkcheck reported one broken link, which caused docs CI to
fail.  This fixes the one broken link, and updates several other
redirects to https.  Other ones *could* be updated but seem reasonable
to leave as well.

Review: general check and merge (other CI is broken, too).  Check if
the docs build group passes, I'm curious if other things are broken.
