### PR TITLE
nbextensions CI: update selinium function to get further

### DIFF
--- a/nbgrader/tests/nbextensions/formgrade_utils.py
+++ b/nbgrader/tests/nbextensions/formgrade_utils.py
@@ -79,7 +79,7 @@ def _wait_for_gradebook_page(browser, port, url):
 def _switch_to_window(browser, index):
     handle_exists = lambda browser: index < len(browser.window_handles)
     WebDriverWait(browser, 10).until(handle_exists)
-    browser.switch_to_window(browser.window_handles[index])
+    browser.switch_to.window(browser.window_handles[index])
 
 
 def _get(browser, url, retries=5):


### PR DESCRIPTION
This updates selelium for the nbextension tests, as seen in this question: https://stackoverflow.com/questions/61299653/attributeerror-webdriver-object-has-no-attribute-switch-to-window-handles

In my test, there are still errors, but at least the error changes now.  I'm opening this PR to document the work and try to inspire people to get a bit further.  I might not merge unless someone knows this is a good change, or there's a PR that makes the full test pass.