### PR TITLE
Add Python 3.10 to CI pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,13 +30,15 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-20.04]
         group: ["docs", "nbextensions", "python"]
-        python: ["3.7", "3.8", "3.9"]
+        python: ["3.7", "3.8", "3.9", "3.10"]
         exclude:
           - os: windows-latest
             group: docs
           - python: "3.7"
             group: docs
           - python: "3.8"
+            group: docs
+          - python: "3.9"
             group: docs
           - python: "3.7"
             group: nbextensions


### PR DESCRIPTION
Add Python 3.10 to our testing workflows.