### PR TITLE
Add workflow to enforce GitHub labels

### DIFF
--- a/.github/workflows/enforce-label.yml
+++ b/.github/workflows/enforce-label.yml
@@ -1,0 +1,13 @@
+name: Enforce PR label
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, edited, synchronize]
+jobs:
+  enforce-label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: enforce-triage-label
+        uses: jupyterlab/maintainer-tools/.github/actions/enforce-label@v1


### PR DESCRIPTION
Similar to the workflows used in other Jupyter projects:

- https://github.com/jupyterlab/jupyterlab/blob/master/.github/workflows/enforce-label.yml
- https://github.com/jupyter-server/jupyter_server/blob/main/.github/workflows/enforce-label.yml

This will be useful when adopting the Jupyter Releaser (#1570), so each PR has a label and the changelog be nicely generated.