### PR TITLE
Only add extra_template_basedirs if it has not been set

### DIFF
--- a/nbgrader/converters/generate_feedback.py
+++ b/nbgrader/converters/generate_feedback.py
@@ -57,9 +57,11 @@ class GenerateFeedback(BaseConverter):
         c = Config()
         if 'template_name' not in self.config.HTMLExporter:
             c.HTMLExporter.template_name = 'feedback'
-
-        template_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'server_extensions', 'formgrader', 'templates'))
-        c.HTMLExporter.extra_template_basedirs = [template_path]
+            
+        if 'extra_template_basedirs' not in self.config.HTMLExporter:
+            template_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'server_extensions', 'formgrader', 'templates'))
+            c.HTMLExporter.extra_template_basedirs = [template_path]
+        
         extra_static_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'server_extensions', 'formgrader', 'static', 'components', 'bootstrap', 'css'))
         c.HTMLExporter.extra_template_paths = [extra_static_path]
 


### PR DESCRIPTION
In nbgrader v0.6.x we only set the `template_path` option if it is not already in the config (see [here](https://github.com/jupyter/nbgrader/blob/0.6.x/nbgrader/converters/generate_feedback.py#L60)). 
In nbgrader v0.7.x we should also only set the the `extra_template_basedirs` conditionally in order to not break any custom exporters.