### PR TITLE
Update readthedocs-requirements.txt

### DIFF
--- a/readthedocs-requirements.txt
+++ b/readthedocs-requirements.txt
@@ -1,2 +1,1 @@
-sphinx_autodoc_typehints
--e .
+-e .[docs]


### PR DESCRIPTION
Following https://github.com/jupyter/nbgrader/pull/1577/files the RTD builds seem to be broken because myst_parser is not installed: https://readthedocs.org/projects/nbgrader/builds/16942290/ This should fix that by installing the correct set of dependencies.