### PR TITLE
Ensure html files aren't copied over from documentation

### DIFF
--- a/nbgrader/apps/quickstartapp.py
+++ b/nbgrader/apps/quickstartapp.py
@@ -119,7 +119,8 @@ class QuickStartApp(NbGrader):
         self.log.info("Copying example from the user guide...")
         example = os.path.abspath(os.path.join(
             os.path.dirname(__file__), '..', 'docs', 'source', 'user_guide', 'source'))
-        shutil.copytree(example, os.path.join(course_path, "source"))
+        ignore_html = shutil.ignore_patterns("*.html")
+        shutil.copytree(example, os.path.join(course_path, "source"), ignore=ignore_html)
 
         # create the config file
         self.log.info("Generating example config file...")


### PR DESCRIPTION
If one had generated the documentation before running `nbgrader quickstart`, then the autogenerated html files would be copied into the quickstart folder which later caused issues when running `nbgrader feedback` (since the relevant html files already existed, and due to the way permissions are set, were not writeable). This just ensures that quickstart won't copy over the html files.