### PR TITLE
Change default exchange path

### DIFF
--- a/demos/restart_demo.sh
+++ b/demos/restart_demo.sh
@@ -7,7 +7,7 @@ root="/root"
 srv_root="/srv/nbgrader"
 nbgrader_root="/srv/nbgrader/nbgrader"
 jupyterhub_root="/srv/nbgrader/jupyterhub"
-exchange_root="/srv/nbgrader/exchange"
+exchange_root="/usr/local/share/nbgrader/exchange"
 
 # List of possible users, used across all demos.
 possible_users=(

--- a/nbgrader/docs/source/user_guide/advanced.rst
+++ b/nbgrader/docs/source/user_guide/advanced.rst
@@ -49,15 +49,15 @@ example:
 .. code:: bash
 
   $ nbgrader list
-  [ListApp | ERROR] Unwritable directory, please contact your instructor: /srv/nbgrader/exchange
+  [ListApp | ERROR] Unwritable directory, please contact your instructor: /usr/local/share/nbgrader/exchange
 
 This error that the exchange directory isn't writable is an easy mistake to
 make, but also relatively easy to fix. If the exchange directory is at
-``/srv/nbgrader/exchange``, then make sure you have run:
+``/usr/local/share/nbgrader/exchange``, then make sure you have run:
 
 .. code:: bash
 
-  chmod +rw /srv/nbgrader/exchange
+  chmod ugo+rw /usr/local/share/nbgrader/exchange
 
 .. _getting-information-from-db:
 

--- a/nbgrader/docs/source/user_guide/what_is_nbgrader.rst
+++ b/nbgrader/docs/source/user_guide/what_is_nbgrader.rst
@@ -244,7 +244,7 @@ However, this requires a consistent mapping to UIDs across the
 cluster.  This is not difficult to do, but if often not the way that
 "cloud stuff" works by default.
 
-The default filesystem exchange path is ``/srv/nbgrader/exchange``.
+The default filesystem exchange path is ``/usr/local/share/nbgrader/exchange``.
 In a UNIX file system, this is by default owned by the root user, so
 you will need to use a bit of knowledge to set things up properly.
 

--- a/nbgrader/exchange/default/exchange.py
+++ b/nbgrader/exchange/default/exchange.py
@@ -18,7 +18,7 @@ from nbgrader.utils import check_directory, ignore_patterns, self_owned
 
 class Exchange(ABCExchange):
     root = Unicode(
-        "/srv/nbgrader/exchange",
+        "/usr/local/share/nbgrader/exchange",
         help="The nbgrader exchange directory writable to everyone. MUST be preexisting."
     ).tag(config=True)
 


### PR DESCRIPTION
The default exchange directory cannot be created on mac (#1589). This changes the default directory to a location that can be created on both mac and linux. While the exchange is technically not really supported on mac, this makes it less of a headache to test stuff out on mac (because it removes the need to edit config files).

I would appreciate some feedback on this before merging, in case it might cause problems for folks I'm not aware of? @rkdarst @BertR @perllaghu 