### PR TITLE
Pin traitlets dependency for 0.7.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ setup_args = dict(
         "qtconsole>=5.2",
         "ipywidgets>=7.6",
         "nbclient>=0.6.1",
+        "traitlets<5.2.0",
     ]
 )
 


### PR DESCRIPTION
The newer version of traitlets is causing the tests to fail, as it does not seem to be using the right log level.