### PR TITLE
Fix mathjax in formgrade templates

### DIFF
--- a/nbgrader/server_extensions/formgrader/handlers.py
+++ b/nbgrader/server_extensions/formgrader/handlers.py
@@ -107,7 +107,7 @@ class SubmissionHandler(BaseHandler):
             'index': ix,
             'total': len(indices),
             'base_url': self.base_url,
-            'mathjax_url': self.mathjax_url,
+            'my_mathjax_url': self.base_url + '/' + self.mathjax_url,
             'student': student_id,
             'last_name': submission.student.last_name,
             'first_name': submission.student.first_name,

--- a/nbgrader/server_extensions/formgrader/templates/formgrade/index.html.j2
+++ b/nbgrader/server_extensions/formgrader/templates/formgrade/index.html.j2
@@ -15,7 +15,7 @@
 {% endfor %}
 
 <!-- Loading mathjax macro -->
-{{ mathjax( resources.mathjax_url + '?config=TeX-AMS-MML_HTMLorMML-full') }}
+{{ mathjax( resources.my_mathjax_url + '?config=TeX-AMS-MML_HTMLorMML-full') }}
 
 <link rel="stylesheet" href="{{ resources.base_url }}/formgrader/static/css/formgrade.css" />
 


### PR DESCRIPTION
This PR fix an error when loading MathJax in formgrade template.
*HTMLExporter* in `nbconvert>6` replace the variable `resources['mathjax_url']` with https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/latest.js?config=TeX-AMS_CHTML-full,Safe.
That was breaking the loading of *MathJax* in formgrade template.