### PR TITLE
Use jupyter css variable in labextension to manage colors with theme

### DIFF
--- a/style/assignment_list.css
+++ b/style/assignment_list.css
@@ -4,7 +4,6 @@
 }
 
 #nbgrader-assignment-list .panel-group .panel .panel-heading {
-  background-color: #eee;
   padding-top: 4px;
   padding-bottom: 4px;
   padding-left: 7px;
@@ -28,11 +27,12 @@
 }
 
 #nbgrader-assignment-list .panel-group .panel .panel-body .list_container .list_item {
-  border-bottom: 1px solid #ddd;
+  border-bottom: 1px solid var(--jp-border-color2);
 }
 
 #nbgrader-assignment-list .panel-group .panel .panel-body .list_container .list_item:last-child {
   border-bottom: 0px;
+  background-color: var(--jp-layout-color0);
 }
 
 #nbgrader-assignment-list .assignment-notebooks .list_item {
@@ -40,7 +40,7 @@
 }
 
 #nbgrader-assignment-list .assignment-notebooks .list_item:hover {
-  background-color: #ddd !important;
+  background-color: var(--jp-border-color2) !important;
 }
 
 #nbgrader-assignment-list .assignment-notebooks .list_item:first-child:hover {
@@ -87,6 +87,7 @@
   padding-bottom: 4px;
   padding-left: 7px;
   padding-right: 7px;
+  background-color: var(--jp-layout-color0);
 }
 
 #assignments_toolbar {

--- a/style/common.css
+++ b/style/common.css
@@ -12,7 +12,7 @@ FOLLOWING RULES REPLACE BOOTSTRAP RULES
   font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
   font-size: 14px;
   line-height: 1.42857143;
-  color: #333;
+  color: var(--jp-ui-font-color1);
   padding-left: 3px;
   padding-right: 3px;
 }
@@ -49,7 +49,7 @@ FOLLOWING RULES REPLACE BOOTSTRAP RULES
 }
 
 .nbgrader-mainarea-widget a {
-  color: #337ab7;
+  color: var(--jp-content-link-color);
   text-decoration: none;
 }
 
@@ -145,15 +145,15 @@ FOLLOWING RULES REPLACE BOOTSTRAP RULES
 }
 
 .btn-default {
-  color: #333;
-  background-color: #fff;
-  border-color: #ccc;
+  color: var(--jp-ui-font-color1);
+  background-color: var(--jp-layout-color0);
+  border-color: var(--jp-layout-color2);
 }
 
 .btn-primary {
-  color: #fff;
-  background-color: #337ab7;
-  border-color: #2e6da4;
+  color: var(--jp-ui-inverse-font-color0);
+  background-color: var(--jp-brand-color1);
+  border-color:  var(--jp-brand-color0);
 }
 
 .btn-group-xs > .btn, .btn-xs {
@@ -200,14 +200,14 @@ FOLLOWING RULES REPLACE BOOTSTRAP RULES
 }
 
 .btn.focus, .btn:focus, .btn:hover {
-  color: #333;
+  color: var(--jp-ui-font-color1);
   text-decoration: none;
 }
 
 .nbgrader-mainarea-widget .btn-primary:hover {
-  color: #fff;
-  background-color: #286090;
-  border-color: #204d74;
+  color: var(--jp-ui-inverse-font-color0);
+  background-color:  var(--jp-brand-color2);
+  border-color: var(--jp-brand-color1);
 }
 
 .dropdown-menu {
@@ -223,13 +223,12 @@ FOLLOWING RULES REPLACE BOOTSTRAP RULES
   font-size: 14px;
   text-align: left;
   list-style: none;
-  background-color: #fff;
+  background-color: var(--jp-layout-color0);
   background-clip: padding-box;
-  border: 1px solid #ccc;
-  border: 1px solid rgba(0,0,0,.15);
+  border: 1px solid var(--jp-layout-color3);
   border-radius: 4px;
-  -webkit-box-shadow: 0 6px 12px rgba(0,0,0,.175);
-  box-shadow: 0 6px 12px rgba(0,0,0,.175);
+  -webkit-box-shadow: 0 6px 12px var(--jp-toolbar-box-shadow);
+  box-shadow: 0 6px 12px var(--jp-toolbar-box-shadow);
 }
 
 .dropdown-menu.open {
@@ -242,14 +241,14 @@ FOLLOWING RULES REPLACE BOOTSTRAP RULES
   clear: both;
   font-weight: 400;
   line-height: 1.42857143;
-  color: #333;
+  color: var(--jp-ui-font-color1);
   white-space: nowrap;
 }
 
 .dropdown-menu > li > a:focus, .dropdown-menu > li > a:hover {
-  color: #262626;
+  color: var(--jp-ui-font-color1);
   text-decoration: none;
-  background-color: #f5f5f5;
+  background-color: var(--jp-layout-color3);
 }
 
 .caret {
@@ -299,8 +298,8 @@ FOLLOWING RULES REPLACE BOOTSTRAP RULES
 }
 
 .alert-danger {
-  color: #a94442;
-  background-color: #f2dede;
+  color: var(--jp-error-color1);
+  background-color: var(--jp-error-color3);
   border-color: #ebccd1;
 }
 
@@ -310,7 +309,7 @@ FOLLOWING RULES REPLACE BOOTSTRAP RULES
 
 .panel {
   margin-bottom: 20px;
-  background-color: #fff;
+  background-color: var(--jp-layout-color0);
   border: 1px solid transparent;
   border-top-color: transparent;
   border-right-color: transparent;
@@ -322,7 +321,7 @@ FOLLOWING RULES REPLACE BOOTSTRAP RULES
 }
 
 .panel-default {
-  border-color: #ddd;
+  border-color: var(--jp-border-color2);
 }
 
 .panel-group .panel-heading {
@@ -331,9 +330,9 @@ FOLLOWING RULES REPLACE BOOTSTRAP RULES
 }
 
 .panel-default > .panel-heading {
-  color: #333;
-  background-color: #f5f5f5;
-  border-color: #ddd;
+  color: var(--jp-ui-font-color1);
+  background-color: var(--jp-layout-color2);
+  border-color: var(--jp-border-color2);
 }
 
 .panel-heading {

--- a/style/course_list.css
+++ b/style/course_list.css
@@ -9,8 +9,8 @@
   margin-bottom: 1rem;
   border: 1px solid transparent;
   border-radius: 0.25rem;
-  color: #721c24;
-  background-color: #f8d7da;
+  color: var(--jp-error-color1);
+  background-color: var(--jp-error-color3);
   border-color: #f5c6cb;
 }
 
@@ -20,7 +20,6 @@
 }
 
 #courses .panel-group .panel .panel-heading {
-    background-color: #eee;
     padding-top: 4px;
     padding-bottom: 4px;
     padding-left: 7px;
@@ -44,7 +43,7 @@
 }
 
 #courses .panel-group .panel .panel-body .list_container .list_item {
-    border-bottom: 1px solid #ddd;
+    border-bottom: 1px solid  var(--jp-border-color2);
 }
 
 #courses .panel-group .panel .panel-body .list_container .list_item:last-child {
@@ -57,6 +56,7 @@
     padding-left: 7px;
     padding-right: 7px;
     line-height: 22px;
+    background-color: var(--jp-layout-color0);
 }
 
 #courses .list_item > div {
@@ -77,5 +77,6 @@
     padding-bottom: 4px;
     padding-left: 7px;
     padding-right: 7px;
+    background-color: var(--jp-layout-color0);
 }
 

--- a/style/create_assignment.css
+++ b/style/create_assignment.css
@@ -112,11 +112,6 @@
   padding: 0 0.5em;
 }
 
-.nbgrader-mod-highlight .nbgrader-CellHeader {
-  background-color: var(--jp-brand-color);
-
-}
-
 .nbgrader-CellHeader>.jp-InputPrompt {
   border-width: 0;
   padding-left: 0;
@@ -126,10 +121,6 @@
 
 .nbgrader-CellHeader>* {
   color: var(--jp-layout-color5);
-}
-
-.nbgrader-mod-highlight .nbgrader-CellHeader>* {
-  color: var(--jp-layout-color0);
 }
 
 .nbgrader-CellHeader>.nbgrader-LockButton {

--- a/style/create_assignment.css
+++ b/style/create_assignment.css
@@ -57,7 +57,7 @@
   padding: 0 12px 0 6px;
   border-style: solid;
   border-width: 0 0 0 6px;
-  border-color: #0000;
+  border-color: var(--jp-ui-font-color0);
 }
 
 .nbgrader-CellWidget.nbgrader-mod-active>div {
@@ -108,12 +108,13 @@
 .nbgrader-CellHeader {
   display: grid;
   grid-template-columns: auto max-content;
-  background-color: #EEE;
+  background-color: var(--jp-layout-color2);
   padding: 0 0.5em;
 }
 
 .nbgrader-mod-highlight .nbgrader-CellHeader {
-  background-color: #337AB7;
+  background-color: var(--jp-brand-color);
+
 }
 
 .nbgrader-CellHeader>.jp-InputPrompt {
@@ -124,11 +125,11 @@
 }
 
 .nbgrader-CellHeader>* {
-  color: black;
+  color: var(--jp-layout-color5);
 }
 
 .nbgrader-mod-highlight .nbgrader-CellHeader>* {
-  color: white;
+  color: var(--jp-layout-color0);
 }
 
 .nbgrader-CellHeader>.nbgrader-LockButton {

--- a/style/validation_message.css
+++ b/style/validation_message.css
@@ -6,7 +6,7 @@
 
 #submission-message pre,
 #validation-message pre {
-    border: solid lightgray 1px;
+    border: solid var(--jp-border-color2) 1px;
     padding: 5px;
     margin: 1em;
 }


### PR DESCRIPTION
Change the hard coded CSS color by Jupyterlab CSS variables in labextension to allow changing theme (light and dark).
Only the formgrader extension remains in light style as it depends on bootstrap.