### PR TITLE
Create assignment panel only open if a Notebook is visible on main area

### DIFF
--- a/.github/workflows/test-labextensions.yml
+++ b/.github/workflows/test-labextensions.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install Playwright
         run: |
           npx playwright install
-      - name: Run pytest
+      - name: Run playwright tests
         run: |
           python tasks.py tests --group=labextensions
       - name: Upload Playwright Test report

--- a/src/create_assignment/create_assignment_extension.ts
+++ b/src/create_assignment/create_assignment_extension.ts
@@ -112,7 +112,7 @@ export class CreateAssignmentWidget extends Panel {
 
   private addMainAreaActiveListener(shell: LabShell): void {
     this.mainAreaListener = this.getMainAreaActiveListener();
-    shell.activeChanged.connect(this.mainAreaListener);
+    shell.currentChanged.connect(this.mainAreaListener);
   }
 
   private async addNotebookWidget(

--- a/src/create_assignment/create_assignment_extension.ts
+++ b/src/create_assignment/create_assignment_extension.ts
@@ -1,3 +1,4 @@
+import { ILabShell, LabShell } from '@jupyterlab/application';
 import {
   Dialog,
   Styling
@@ -29,6 +30,8 @@ import {
   IObservableMap,
   IObservableUndoableList
 } from '@jupyterlab/observables';
+
+import { each } from '@lumino/algorithm';
 
 import {
   ReadonlyPartialJSONValue
@@ -87,15 +90,19 @@ export class CreateAssignmentWidget extends Panel {
   private activeNotebook: NotebookPanel;
   private currentNotebookListener: (tracker: INotebookTracker,
                                     panel: NotebookPanel) => void;
+  private mainAreaListener: (shell: LabShell, changed: ILabShell.IChangedArgs) => void;
   private notebookPanelWidgets = new Map<NotebookPanel, NotebookPanelWidget>();
   private notebookTracker: INotebookTracker;
+  private shell: ILabShell;
 
-  constructor(tracker: INotebookTracker) {
+  constructor(tracker: INotebookTracker, shell: ILabShell) {
     super();
     this.addClass(CSS_CREATE_ASSIGNMENT_WIDGET);
     this.addNotebookListeners(tracker);
+    this.addMainAreaActiveListener(shell);
     this.activeNotebook = null;
     this.notebookTracker = tracker;
+    this.shell = shell;
   }
 
   private addNotebookListeners(tracker: INotebookTracker): void {
@@ -103,22 +110,32 @@ export class CreateAssignmentWidget extends Panel {
     tracker.currentChanged.connect(this.currentNotebookListener);
   }
 
-  private async addNotebookWidget(tracker: INotebookTracker,
-                                  panel: NotebookPanel) {
-    await panel.revealed
-    const notebookPanelWidget = new NotebookPanelWidget(panel);
-    this.addWidget(notebookPanelWidget);
-    this.notebookPanelWidgets.set(panel, notebookPanelWidget);
-    panel.disposed.connect(() => {
-      notebookPanelWidget.dispose();
-    });
-    notebookPanelWidget.disposed.connect(() => {
-      this.notebookPanelWidgets.delete(panel);
-    });
-    if (tracker.currentWidget != panel) {
-      notebookPanelWidget.hide();
-    }
-    return panel.revealed;
+  private addMainAreaActiveListener(shell: LabShell): void {
+    this.mainAreaListener = this.getMainAreaActiveListener();
+    shell.activeChanged.connect(this.mainAreaListener);
+  }
+
+  private async addNotebookWidget(
+    tracker: INotebookTracker,
+    panel: NotebookPanel) {
+
+      if (panel === null) return;
+
+      await panel.revealed;
+      const notebookPanelWidget = new NotebookPanelWidget(panel);
+      this.addWidget(notebookPanelWidget);
+      this.notebookPanelWidgets.set(panel, notebookPanelWidget);
+
+      panel.disposed.connect(() => {
+        notebookPanelWidget.dispose();
+      });
+      notebookPanelWidget.disposed.connect(() => {
+        this.notebookPanelWidgets.delete(panel);
+      });
+      if (tracker.currentWidget != panel) {
+        notebookPanelWidget.hide();
+      }
+      return panel.revealed;
   }
 
   dispose(): void {
@@ -152,7 +169,7 @@ export class CreateAssignmentWidget extends Panel {
         if (this.isVisible && this.notebookPanelWidgets.get(panel) == null) {
           await this.addNotebookWidget(tracker, panel);
         }
-        const widget = this.notebookPanelWidgets.get(panel)
+        const widget = this.notebookPanelWidgets.get(panel);
         if (widget != null) {
           widget.show();
         }
@@ -161,15 +178,54 @@ export class CreateAssignmentWidget extends Panel {
     }
   }
 
+  /*
+   * The listener on the main area tab change
+   * to collapse create_assignment widget if the current tab is not a Notebook
+   */
+  private getMainAreaActiveListener(): (
+    shell: ILabShell,
+    changed: ILabShell.IChangedArgs) => void {
+      return async (shell: ILabShell, changed: ILabShell.IChangedArgs) => {
+        if ( !(changed.newValue instanceof NotebookPanel) && this.isVisible) {
+          this.hideRightPanel();
+        }
+    }
+  }
+
   protected onBeforeShow(msg: Message): void {
     super.onBeforeShow(msg);
-    const notebookWidget = this.notebookPanelWidgets.get(this.activeNotebook);
-    if (notebookWidget == null) {
-      this.addNotebookWidget(this.notebookTracker, this.activeNotebook);
+    if (this.activeNotebook != null){
+      const notebookWidget = this.notebookPanelWidgets.get(this.activeNotebook);
+      if (notebookWidget == null) {
+        this.addNotebookWidget(this.notebookTracker, this.activeNotebook);
+      }
+      else {
+        notebookWidget.show();
+      }
+    }
+  }
+
+  /*
+   * Check if the widget must be visible :
+   *  -> is there an active Notebook visible in main panel ?
+   */
+  protected onAfterShow(): void {
+    const widgets = this.shell.widgets('main');
+    if (this.activeNotebook == null){
+      this.hideRightPanel();
     }
     else {
-      notebookWidget.show();
+      each(widgets, w => {
+        if (w.title == this.activeNotebook.title) {
+          if (!w.isVisible) this.hideRightPanel();
+          else w.activate();
+        }
+      });
     }
+  }
+
+  private hideRightPanel(): void {
+    this.shell.collapseRight();
   }
 
   private removeNotebookListeners(tracker: INotebookTracker): void {

--- a/src/create_assignment/index.ts
+++ b/src/create_assignment/index.ts
@@ -1,6 +1,7 @@
 import {
   JupyterFrontEnd,
-  JupyterFrontEndPlugin
+  JupyterFrontEndPlugin,
+  ILabShell
 } from '@jupyterlab/application';
 
 import {
@@ -23,20 +24,21 @@ const PLUGIN_ID = "nbgrader/create-assignment"
 export const create_assignment_extension: JupyterFrontEndPlugin<void> = {
   id: PLUGIN_ID,
   autoStart: true,
-  requires: [INotebookTracker],
+  requires: [INotebookTracker, ILabShell],
   activate: activate_extension
 };
 
-function activate_extension(app: JupyterFrontEnd, tracker: INotebookTracker) {
+function activate_extension(app: JupyterFrontEnd, tracker: INotebookTracker, shell: ILabShell) {
   console.log('Activating extension "create_assignment".');
 
   const panel = new Panel();
   panel.node.style.overflowY = 'auto';
-  const createAssignmentWidget = new CreateAssignmentWidget(tracker);
+  const createAssignmentWidget = new CreateAssignmentWidget(tracker, shell);
   panel.addWidget(createAssignmentWidget);
   panel.id = 'nbgrader-create_assignemnt';
   panel.title.label = 'Create Assignment';
   panel.title.caption = 'nbgrader Create Assignment';
+
   app.shell.add(panel, 'right');
   console.log('Extension "create_assignment" activated.');
 }


### PR DESCRIPTION
This PR improves the behavior of the `create assignment` widget :
- If no Notebook is visible in main area, clicking on the button does not open the right panel (instead of opening an empty one)
- if a notebook is visible, it will be activated (can occur when the main area is split)
- if the selected tab in main area becomes a tab which is not a Notebook, the `create assignment` panel is closed