### PR TITLE
More informative error messages in ClearSolutions

### DIFF
--- a/nbgrader/preprocessors/clearsolutions.py
+++ b/nbgrader/preprocessors/clearsolutions.py
@@ -98,6 +98,7 @@ class ClearSolutions(NbGraderPreprocessor):
                 # check to make sure this isn't a nested BEGIN
                 # SOLUTION region
                 if in_solution:
+                    self.log.error("Encountered nested begin solution statements. Cell contents are: \n%s", cell.source)
                     raise RuntimeError(
                         "encountered nested begin solution statements")
 
@@ -120,6 +121,7 @@ class ClearSolutions(NbGraderPreprocessor):
         # we finished going through all the lines, but didn't find a
         # matching END SOLUTION statment
         if in_solution:
+            self.log.error("No end solution statement found. Cell contents are: \n%s", cell.source)
             raise RuntimeError("no end solution statement found")
 
         # replace the cell source
@@ -146,6 +148,7 @@ class ClearSolutions(NbGraderPreprocessor):
                         cell_index: int
                         ) -> Tuple[NotebookNode, ResourcesDict]:
         # replace solution regions with the relevant stubs
+        orig_cell_source = cell.source
         language = resources["language"]
         replaced_solution = self._replace_solution_region(cell, language)
 
@@ -157,6 +160,10 @@ class ClearSolutions(NbGraderPreprocessor):
         # to be given an id
         if not is_solution and replaced_solution:
             if self.enforce_metadata:
+                self.log.error(
+                    "Solution region detected in a non-solution cell; please make sure "
+                    "all solution regions are within solution cells. Cell contents are: \n%s", orig_cell_source
+                )
                 raise RuntimeError(
                     "Solution region detected in a non-solution cell; please make sure "
                     "all solution regions are within solution cells."


### PR DESCRIPTION
Prints out the cell contents in the error messages to make it easier to identify the cell that has a problem.

Closes #1605