### PR TITLE
Fix version bumping for pre-releases

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -19,7 +19,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - name: Install Dependencies
         run: |
-          pip install -e .
+          pip install -e ".[dev]"
       - name: Check Release
         if: ${{ matrix.group == 'check_release' }}
         uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v1

--- a/demos/restart_demo.sh
+++ b/demos/restart_demo.sh
@@ -48,7 +48,7 @@ install_nbgrader () {
     git pull
 
     # Install requirements and nbgrader.
-    pip3 install -e ".[docs,tests]"
+    pip3 install -e ".[dev,docs,tests]"
 
     # Install global extensions, and disable them globally. We will re-enable
     # specific ones for different user accounts in each demo.

--- a/nbgrader/_version.py
+++ b/nbgrader/_version.py
@@ -1,2 +1,2 @@
-version_info = (0, 8, 0, "dev")
-__version__ = '.'.join(map(str, version_info[:3])) + (("." + version_info[3]) if version_info[3] else "")
+version_info = (0, 8, 0, ".dev", "0")
+__version__ = ".".join(map(str, version_info[:3])) + "".join(version_info[3:])

--- a/nbgrader/docs/source/contributor_guide/installation_developer.rst
+++ b/nbgrader/docs/source/contributor_guide/installation_developer.rst
@@ -20,7 +20,7 @@ We recommand using `conda environment <https://docs.conda.io/en/latest/miniconda
     # activate the environment
     mamba activate nbgrader
 
-    pip install -e ".[docs,tests]"
+    pip install -e ".[dev,docs,tests]"
 
 Installing Jupyter labextensions
 --------------------------------

--- a/nbgrader/nbextensions/assignment_list/main.js
+++ b/nbgrader/nbextensions/assignment_list/main.js
@@ -6,7 +6,7 @@ define([
 ], function(Jupyter, $, utils, AssignmentList) {
     "use strict";
 
-    var nbgrader_version = "0.8.0.dev";
+    var nbgrader_version = "0.8.0.dev0";
 
     var ajax = utils.ajax || $.ajax;
     // Notebook v4.3.1 enabled xsrf so use notebooks ajax that includes the

--- a/nbgrader/nbextensions/course_list/main.js
+++ b/nbgrader/nbextensions/course_list/main.js
@@ -6,7 +6,7 @@ define([
 ], function(Jupyter, $, utils, CourseList) {
     "use strict";
 
-    var nbgrader_version = "0.8.0.dev";
+    var nbgrader_version = "0.8.0.dev0";
 
     var ajax = utils.ajax || $.ajax;
     // Notebook v4.3.1 enabled xsrf so use notebooks ajax that includes the

--- a/nbgrader/nbextensions/validate_assignment/main.js
+++ b/nbgrader/nbextensions/validate_assignment/main.js
@@ -7,7 +7,7 @@ define([
 ], function ($, Jupyter, dialog, utils) {
     "use strict";
 
-    var nbgrader_version = "0.8.0.dev";
+    var nbgrader_version = "0.8.0.dev0";
 
     var ajax = utils.ajax || $.ajax;
     // Notebook v4.3.1 enabled xsrf so use notebooks ajax that includes the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,10 @@ npm = ["jlpm"]
 ignore = ["nbgrader/labextension/**", "yarn.lock"]
 
 [tool.tbump.version]
-current = "0.8.0.dev"
+current = "0.8.0.dev0"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
-  ((?P<channel>a|b|rc|dev)(?P<release>\d+))?
+  ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?
 '''
 
 [tool.tbump.git]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,3 +64,7 @@ src = "src/validate_assignment/index.ts"
 [[tool.tbump.field]]
 name = "channel"
 default = ""
+
+[[tool.tbump.field]]
+name = "release"
+default = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ ignore = ["nbgrader/labextension/**", "yarn.lock"]
 current = "0.8.0.dev"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
-  ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?
+  ((?P<channel>a|b|rc|dev)(?P<release>\d+))?
 '''
 
 [tool.tbump.git]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ cmd = "grep -q {new_version} CHANGELOG.md"
 
 [[tool.tbump.file]]
 src = "nbgrader/_version.py"
-version_template = '({major}, {minor}, {patch}, "{channel}")'
+version_template = '({major}, {minor}, {patch}, "{channel}", "{release}")'
 
 [[tool.tbump.file]]
 src = "pyproject.toml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ ignore = ["nbgrader/labextension/**", "yarn.lock"]
 [tool.tbump.version]
 current = "0.8.0.dev"
 regex = '''
-  (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<channel>dev))?
+  (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
+  ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?
 '''
 
 [tool.tbump.git]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ npm = ["jlpm"]
 [tool.check-manifest]
 ignore = ["nbgrader/labextension/**", "yarn.lock"]
 
+[tool.jupyter-releaser.hooks]
+after-bump-version = ["python tools/post-bump.py"]
+
 [tool.tbump.version]
 current = "0.8.0.dev0"
 regex = '''
@@ -37,11 +40,6 @@ version_template = '({major}, {minor}, {patch}, "{channel}", "{release}")'
 
 [[tool.tbump.file]]
 src = "pyproject.toml"
-
-[[tool.tbump.file]]
-src = "package.json"
-version_template = "{major}.{minor}.{patch}"
-search = '"version": "{current_version}"'
 
 [[tool.tbump.file]]
 src = "nbgrader/nbextensions/assignment_list/main.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,15 @@ src = "nbgrader/nbextensions/course_list/main.js"
 [[tool.tbump.file]]
 src = "nbgrader/nbextensions/validate_assignment/main.js"
 
+[[tool.tbump.file]]
+src = "src/assignment_list/index.ts"
+
+[[tool.tbump.file]]
+src = "src/course_list/index.ts"
+
+[[tool.tbump.file]]
+src = "src/validate_assignment/index.ts"
+
 [[tool.tbump.field]]
 name = "channel"
 default = ""

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,9 @@ tests =
     nbval
     requests-mock
     wheel
+dev =
     tbump
+    toml
 
 [options.entry_points]
 console_scripts =

--- a/src/assignment_list/index.ts
+++ b/src/assignment_list/index.ts
@@ -150,7 +150,7 @@ class AssignmentListWidget extends Widget {
   checkNbGraderVersion() {
     var warning = this.node.getElementsByClassName('version_error')[0] as HTMLDivElement;
     warning.hidden=false;
-    requestAPI<any>('nbgrader_version?version='+"0.8.0.dev")
+    requestAPI<any>('nbgrader_version?version='+"0.8.0.dev0")
     .then(response => {
         if (!response['success']) {
           warning.innerText = response['message'];

--- a/src/course_list/index.ts
+++ b/src/course_list/index.ts
@@ -80,7 +80,7 @@ class CourseListWidget extends Widget {
     }
 
     checkNbGraderVersion() {
-        let nbgrader_version = '0.8.0.dev';
+        let nbgrader_version = '0.8.0.dev0';
         requestAPI<any>('nbgrader_version?version='+nbgrader_version)
             .then(response => {
                 if (!response['success']) {

--- a/src/validate_assignment/index.ts
+++ b/src/validate_assignment/index.ts
@@ -23,7 +23,7 @@ import { requestAPI } from './validateassignment';
 
 import { showNbGraderDialog, validate } from '../common/validate';
 
-var nbgrader_version = "0.8.0.dev"; // TODO: hardcoded value
+var nbgrader_version = "0.8.0.dev0"; // TODO: hardcoded value
 
 const PLUGIN_ID = "nbgrader/validate-assignment"
 

--- a/tools/post-bump.py
+++ b/tools/post-bump.py
@@ -17,7 +17,7 @@ def main():
   py_version = project.get("current")
 
   # set the JS version
-  js_version = py_version.replace("a", "-alpha").replace("b", "-beta").replace("rc", "-rc").replace(".dev", "dev")
+  js_version = py_version.replace("a", "-alpha").replace("b", "-beta").replace("rc", "-rc").replace(".dev", "-dev")
   package_json = json.loads(PACKAGE_JSON.read_text(**ENC))
   package_json["version"] = js_version
   PACKAGE_JSON.write_text(json.dumps(package_json, indent=2), **ENC)

--- a/tools/post-bump.py
+++ b/tools/post-bump.py
@@ -1,0 +1,27 @@
+import json
+from pathlib import Path
+
+import toml
+
+ENC = dict(encoding="utf-8")
+ROOT = Path(__file__).parent.parent
+PYPROJECT = ROOT / "pyproject.toml"
+PACKAGE_JSON = ROOT / "package.json"
+
+
+def main():
+  # read the Python version
+  pyproject = PYPROJECT.read_text(**ENC)
+  data = toml.loads(pyproject)
+  project = data.get("tool", {}).get("tbump", {}).get("version", {})
+  py_version = project.get("current")
+
+  # set the JS version
+  js_version = py_version.replace("a", "-alpha").replace("b", "-beta").replace("rc", "-rc").replace(".dev", "dev")
+  package_json = json.loads(PACKAGE_JSON.read_text(**ENC))
+  package_json["version"] = js_version
+  PACKAGE_JSON.write_text(json.dumps(package_json, indent=2), **ENC)
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
Running the Draft Changelog on the `main` branch failed with the following error:

```
Error: Could not parse 0.8.0a0 as a valid version string
```

https://github.com/jtpio/jupyter_releaser/runs/7023597896?check_suite_focus=true

This looks related to bumping the version for pre-releases.

This change should fix it.