### PR TITLE
Pins selenium version to 4.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ tests =
     pytest-tornasync
     jupyter_packaging
     coverage
-    selenium>2.4
+    selenium>2.4,<4.3
     codecov
     nbval
     requests-mock


### PR DESCRIPTION
Pins selenium version to `4.2` as the latest `4.3.0` breaks tests.