### PR TITLE
Fix missing `.` in the JS version

### DIFF
--- a/tools/post-bump.py
+++ b/tools/post-bump.py
@@ -17,7 +17,7 @@ def main():
   py_version = project.get("current")
 
   # set the JS version
-  js_version = py_version.replace("a", "-alpha").replace("b", "-beta").replace("rc", "-rc").replace(".dev", "-dev")
+  js_version = py_version.replace("a", "-alpha.").replace("b", "-beta.").replace("rc", "-rc.").replace(".dev", "-dev.")
   package_json = json.loads(PACKAGE_JSON.read_text(**ENC))
   package_json["version"] = js_version
   PACKAGE_JSON.write_text(json.dumps(package_json, indent=2), **ENC)


### PR DESCRIPTION
Follow-up to https://github.com/jupyter/nbgrader/pull/1610

As noticed in https://github.com/jupyter/nbgrader/pull/1613 the JS version is missing a `.`.