### PR TITLE
Fix version error message

### DIFF
--- a/nbgrader/server_extensions/assignment_list/handlers.py
+++ b/nbgrader/server_extensions/assignment_list/handlers.py
@@ -339,13 +339,13 @@ class NbGraderVersionHandler(BaseAssignmentHandler):
         if ui_version != nbgrader_version:
             msg = dedent(
                 """
-                The version of the Assignment List nbextension does not match
-                the server extension; the nbextension version is {} while the
+                The version of the Assignment List labextension does not match
+                the server extension; the labextension version is {} while the
                 server version is {}. This can happen if you have recently
                 upgraded nbgrader, and may cause this extension to not work
                 correctly. To fix the problem, please see the nbgrader
                 installation instructions:
-                http://nbgrader.readthedocs.io/en/stable/user_guide/installation.html
+                http://nbgrader.readthedocs.io/en/main/user_guide/installation.html
                 """.format(ui_version, nbgrader_version)
             ).strip().replace("\n", " ")
             self.log.error(msg)

--- a/nbgrader/server_extensions/course_list/handlers.py
+++ b/nbgrader/server_extensions/course_list/handlers.py
@@ -199,13 +199,13 @@ class NbGraderVersionHandler(JupyterHandler):
         if ui_version != nbgrader_version:
             msg = dedent(
                 """
-                The version of the Course List nbextension does not match
-                the server extension; the nbextension version is {} while the
+                The version of the Course List labextension does not match
+                the server extension; the labextension version is {} while the
                 server version is {}. This can happen if you have recently
                 upgraded nbgrader, and may cause this extension to not work
                 correctly. To fix the problem, please see the nbgrader
                 installation instructions:
-                http://nbgrader.readthedocs.io/en/stable/user_guide/installation.html
+                http://nbgrader.readthedocs.io/en/main/user_guide/installation.html
                 """.format(ui_version, nbgrader_version)
             ).strip().replace("\n", " ")
             self.log.error(msg)

--- a/nbgrader/server_extensions/validate_assignment/handlers.py
+++ b/nbgrader/server_extensions/validate_assignment/handlers.py
@@ -106,13 +106,13 @@ class NbGraderVersionHandler(JupyterHandler):
         if ui_version != nbgrader_version:
             msg = dedent(
                 """
-                The version of the Validate nbextension does not match
-                the server extension; the nbextension version is {} while the
+                The version of the Validate labextension does not match
+                the server extension; the labextension version is {} while the
                 server version is {}. This can happen if you have recently
                 upgraded nbgrader, and may cause this extension to not work
                 correctly. To fix the problem, please see the nbgrader
                 installation instructions:
-                http://nbgrader.readthedocs.io/en/stable/user_guide/installation.html
+                http://nbgrader.readthedocs.io/en/main/user_guide/installation.html
                 """.format(ui_version, nbgrader_version)
             ).strip().replace("\n", " ")
             self.log.error(msg)


### PR DESCRIPTION
Replace `nbextension` by `labextension` in the error message when the versions between the server and the extension mismatch.