### PR TITLE
Move the jupyter_releaser hooks from package.json to pyproject.toml

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,16 +94,5 @@
     "extension": true,
     "outputDir": "nbgrader/labextension",
     "schemaDir": "schema"
-  },
-  "jupyter-releaser": {
-    "hooks": {
-      "before-build-npm": [
-        "python -m pip install jupyterlab~=3.1",
-        "jlpm"
-      ],
-      "before-build-python": [
-        "jlpm clean:all"
-      ]
-    }
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ ignore = ["nbgrader/labextension/**", "yarn.lock"]
 
 [tool.jupyter-releaser.hooks]
 after-bump-version = ["python tools/post-bump.py"]
-before-build-npm = ["jlpm"]
+before-build-npm = ["python -m pip install 'jupyterlab<4'", "jlpm"]
 before-build-python = ["jlpm clean:all"]
 
 [tool.tbump.version]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ ignore = ["nbgrader/labextension/**", "yarn.lock"]
 
 [tool.jupyter-releaser.hooks]
 after-bump-version = ["python tools/post-bump.py"]
+before-build-npm = ["jlpm"]
+before-build-python = ["jlpm clean:all"]
 
 [tool.tbump.version]
 current = "0.8.0a0"


### PR DESCRIPTION
Brings together all `jupyter_releaser` hooks  in `pyproject.toml` file,  it seems that the jupyter_releaser do not run the hooks from 2 sources.

cc @jtpio for review