### PR TITLE
Pin version of nbclassic<0.4.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ install_requires =
     traitlets<5.2.0
     jupyterlab<4
     jupyterlab_server
+    nbclassic<0.4.0
 
 [options.extras_require]
 docs =


### PR DESCRIPTION
The latest `nbclassic` version `0.4.0` breaks nbgrader so for now it should be pinned in a previous version.
