### PR TITLE
Remove a remaining dependency to notebook

### DIFF
--- a/nbgrader/server_extensions/assignment_list/handlers.py
+++ b/nbgrader/server_extensions/assignment_list/handlers.py
@@ -8,7 +8,7 @@ import traceback
 from tornado import web
 from textwrap import dedent
 
-from notebook.utils import url_path_join as ujoin
+from jupyter_server.utils import url_path_join as ujoin
 from jupyter_server.base.handlers import JupyterHandler
 from traitlets import Unicode, default
 from traitlets.config import LoggingConfigurable, Config


### PR DESCRIPTION
This PR remove a dependency to `notebook.utils` available in `jupyter_server`.