### PR TITLE
Add required github-token in workflow

### DIFF
--- a/.github/workflows/binder.yaml
+++ b/.github/workflows/binder.yaml
@@ -10,3 +10,5 @@ jobs:
       pull-requests: write
     steps:
       - uses: jupyterlab/maintainer-tools/.github/actions/binder-link@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/binder.yaml
+++ b/.github/workflows/binder.yaml
@@ -11,4 +11,4 @@ jobs:
     steps:
       - uses: jupyterlab/maintainer-tools/.github/actions/binder-link@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.github_token }}

--- a/.github/workflows/binder.yaml
+++ b/.github/workflows/binder.yaml
@@ -11,4 +11,4 @@ jobs:
     steps:
       - uses: jupyterlab/maintainer-tools/.github/actions/binder-link@v1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a GITHUB-TOKEN to binder workflow, as required