### PR TITLE
Add maximum size for entire directory as submission option

### DIFF
--- a/nbgrader/coursedir.py
+++ b/nbgrader/coursedir.py
@@ -279,6 +279,17 @@ class CourseDirectory(LoggingConfigurable):
         )
     ).tag(config=True)
 
+    max_dir_size = Integer(
+        100000,
+        help=dedent(
+            """
+            Maximum size of directories (in kilobytes; default: 100Mb).
+            Upon copying directories recursively, larger files will be
+            ignored with a warning.
+            """
+        )
+    ).tag(config=True)
+
     def format_path(self, nbgrader_step: str, student_id: str, assignment_id: str, escape: bool = False) -> str:
         kwargs = dict(
             nbgrader_step=nbgrader_step,

--- a/nbgrader/tests/apps/test_nbgrader_submit.py
+++ b/nbgrader/tests/apps/test_nbgrader_submit.py
@@ -2,6 +2,7 @@ import os
 import datetime
 import time
 import stat
+import pytest
 
 from os.path import join, isfile, exists
 
@@ -231,7 +232,7 @@ class TestNbGraderSubmit(BaseTestApp):
         filename, = os.listdir(join(exchange, "abc101", "inbound"))
         assert not exists(join(exchange, "abc101", "inbound", filename, "foo.txt"))
 
-    def test_submit_include(self, exchange, cache, course_dir):
+    def test_submit_max_file_size(self, exchange, cache, course_dir):
         self._release_and_fetch("ps1", exchange, cache, course_dir)
         self._make_file(join("ps1", "small_file"), contents="x" * 2000)
         self._make_file(join("ps1", "large_file"), contents="x" * 2001)
@@ -240,3 +241,11 @@ class TestNbGraderSubmit(BaseTestApp):
         filename, = os.listdir(join(exchange, "abc101", "inbound"))
         assert exists(join(exchange, "abc101", "inbound", filename, "small_file"))
         assert not exists(join(exchange, "abc101", "inbound", filename, "large_file"))
+
+    def test_submit_max_dir_size(self, exchange, cache, course_dir):
+        self._release_and_fetch("ps1", exchange, cache, course_dir)
+        self._make_file(join("ps1", "small_file"), contents="x" * 2000)
+        self._make_file(join("ps1", "large_file"), contents="x" * 2001)
+        with pytest.raises(RuntimeError):
+            self._submit("ps1", exchange, cache,
+                        flags=['--CourseDirectory.max_dir_size=3'])


### PR DESCRIPTION
The previous maximum size option was applied to individual files only. This adds a separate option to limit the maximum size of the entire directory. The option is called max_dir_size and is implemented similarly to max_file_size. The default is same as the max file size.