### PR TITLE
groupshared feedback re-release fix

### DIFF
--- a/nbgrader/exchange/default/release_feedback.py
+++ b/nbgrader/exchange/default/release_feedback.py
@@ -67,9 +67,12 @@ class ExchangeReleaseFeedback(Exchange, ABCExchangeReleaseFeedback):
                 submission_secret = fh.read()
 
             checksum = notebook_hash(secret=submission_secret, notebook_id=notebook_id)
-            dest = os.path.join(self.dest_path, "{}.html".format(checksum))
+            dest = os.path.join(self.dest_path, "{}-tmp.html".format(checksum))
 
             self.log.info("Releasing feedback for student '{}' on assignment '{}/{}/{}' ({})".format(
                 student_id, self.coursedir.course_id, self.coursedir.assignment_id, notebook_id, timestamp))
             shutil.copy(html_file, dest)
+            # Copy to temporary location and mv to update atomically.
+            updated_feedback = os.path.join(self.dest_path, "{}.html". format(checksum))
+            shutil.move(dest, updated_feedback)
             self.log.info("Feedback released to: {}".format(dest))


### PR DESCRIPTION
Groupshared users could not re-release student feedback due to shutil.copy functionality used by release_feedback. Shutil.copy tries to chmod the destination file which does not work in groupshared scenarios where files have different owners but same groups. Therefore groupshared users cannot copy a new generated feedback with the same name over the old one owned by another user. In the fix the file gets copied in a temporary location and is moved over the old file. 

Tests were not implemented as I believe it is not possible to test interactions requiring multiple users automatically. To replicate the issue, you need two users with groupshared enabled that release feedback for the same student's assignment. 