### PR TITLE
Fix Docker image for demo

### DIFF
--- a/demos/Dockerfile
+++ b/demos/Dockerfile
@@ -6,12 +6,24 @@
 
 FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
+ENV NODE_VERSION=16.17.1
+
 RUN apt-get update \
  && apt-get -y dist-upgrade \
- && apt-get -y install git sudo
+ && apt-get -y install git sudo curl
+
 # cache some of the bigger installs
-RUN apt-get -y install python3-pip nodejs npm
-RUN python3 -m pip install --upgrade jupyterhub notebook nbclassic
+RUN apt-get -y install python3-pip npm
+RUN python3 -m pip install --upgrade jupyterhub
+
+# Install nodejs v16 (not available yet on apt).
+ENV NVM_DIR=/root/.nvm
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
+RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
+RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
+RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
+ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
+
 RUN git clone https://github.com/jupyter/nbgrader /srv/nbgrader/nbgrader
 # COPY is like deploy_demos.sh
 COPY ./ /root/

--- a/demos/restart_demo.sh
+++ b/demos/restart_demo.sh
@@ -26,6 +26,7 @@ install_dependencies () {
     apt install -y npm
     npm install -g configurable-http-proxy
     apt install -y python3-pip
+    pip3 install -U nbclassic==0.3.7
     pip3 install -U jupyterlab
     pip3 install -U jupyterhub
 }

--- a/demos/restart_demo.sh
+++ b/demos/restart_demo.sh
@@ -2,6 +2,23 @@
 
 set -ex
 
+
+NODE_MAJOR_VERSION=`node --version | cut -d'.' -f 1 | cut -d'v' -f 2`
+
+test_node_version () {
+    MAJOR_VERSION_RE='^[0-9]+$'
+    # checks if a version exists
+    if ! [[ $1 =~ $MAJOR_VERSION_RE ]] ; then
+        echo "Nodejs seems not installed. This requires nodejs>=14 to continue" >&2; exit 1
+    fi
+    # checks if the version is 14 or more
+    if [ $1 -lt 14 ]; then
+        echo "Nodejs version must be 14 or more, current is $1">&2; exit 1
+    fi
+}
+
+test_node_version ${NODE_MAJOR_VERSION}
+
 # Configuration variables.
 root="$(realpath `dirname $0`)"
 srv_root="/srv/nbgrader"


### PR DESCRIPTION
This PR fix #1668.
- It installs `nodejs=16` (not available on apt) in docker image
- it pins `nbclassic<0.4.0` as currently expected by nbgrader. 

If nbclassic is not pinned, the v0.4.0 is first installed with jupyterlab. When installing nbgrader, the `v0.4.0` is uninstall in favor of `v0.3.7`. It seems that it breaks `jupyter-nbextension`...