### PR TITLE
Fix view feedback link when root_dir is set

### DIFF
--- a/nbgrader/exchange/default/list.py
+++ b/nbgrader/exchange/default/list.py
@@ -172,8 +172,13 @@ class ExchangeList(ABCExchangeList, Exchange):
                 info['has_exchange_feedback'] = has_exchange_feedback
                 info['feedback_updated'] = feedback_updated
                 if has_local_feedback:
-                    info['local_feedback_path'] = os.path.join(
-                        assignment_dir, 'feedback', info['timestamp'])
+                    full_path_assignment_dir = os.path.abspath(assignment_dir)
+                    if os.path.exists(full_path_assignment_dir):
+                        info['local_feedback_path'] = os.path.join(
+                            full_path_assignment_dir, 'feedback', info['timestamp'])
+                    else:
+                        info['local_feedback_path'] = os.path.join(
+                            assignment_dir, 'feedback', info['timestamp'])
                 else:
                     info['local_feedback_path'] = None
 

--- a/nbgrader/server_extensions/assignment_list/handlers.py
+++ b/nbgrader/server_extensions/assignment_list/handlers.py
@@ -149,8 +149,8 @@ class AssignmentList(LoggingConfigurable):
             else:
                 for assignment in assignments:
                     for submission in assignment["submissions"]:
-                        if 'local_feedback_path' in submission.keys() and \
-                            os.path.exists(submission['local_feedback_path']):
+                        if submission['local_feedback_path'] \
+                            and os.path.exists(submission['local_feedback_path']):
                                 submission['local_feedback_path'] = \
                                     os.path.relpath(submission['local_feedback_path'],
                                     self._root_dir)

--- a/nbgrader/server_extensions/assignment_list/handlers.py
+++ b/nbgrader/server_extensions/assignment_list/handlers.py
@@ -148,6 +148,12 @@ class AssignmentList(LoggingConfigurable):
                     }
             else:
                 for assignment in assignments:
+                    for submission in assignment["submissions"]:
+                        if 'local_feedback_path' in submission.keys() and \
+                            os.path.exists(submission['local_feedback_path']):
+                                submission['local_feedback_path'] = \
+                                    os.path.relpath(submission['local_feedback_path'],
+                                    self._root_dir)
                     assignment["submissions"] = sorted(
                         assignment["submissions"],
                         key=lambda x: x["timestamp"])


### PR DESCRIPTION
The `view feedback` link does not work when the `root_dir` of JupyterLab is different from './'.
The reason is that the feedback path is not relative to the `root_dir` but to the directory where nbgrader started.

This PR solves the problem by changing the feedback path to a relative path from `root_dir`.

I observed the same issue with classic notebook (in version `0.7.x`) if the `notebook_path` is different from './'.
This PR should probably be back ported to `0.7.x` branch.

Close https://github.com/jupyter/nbgrader/issues/1664