### PR TITLE
Allow current working directory for nbgrader config file only

### DIFF
--- a/nbgrader/apps/baseapp.py
+++ b/nbgrader/apps/baseapp.py
@@ -351,12 +351,17 @@ class NbGrader(JupyterApp):
         if self.config_file:
             paths = [os.path.abspath("{}.py".format(self.config_file))]
         else:
-            paths = [os.path.join(x, "{}.py".format(self.config_file_name)) for x in self.config_file_paths]
+            config_dir = self.config_file_paths.copy()
+            config_dir.insert(0, os.getcwd())
+            paths = [os.path.join(x, "{}.py".format(self.config_file_name)) for x in config_dir]
 
         if not any(os.path.exists(x) for x in paths):
             self.log.warning("No nbgrader_config.py file found (rerun with --debug to see where nbgrader is looking)")
 
         super(NbGrader, self).load_config_file(**kwargs)
+
+        # Load also config from current working directory
+        super(JupyterApp, self).load_config_file(self.config_file_name, os.getcwd())
 
     def start(self) -> None:
         super(NbGrader, self).start()


### PR DESCRIPTION
This PR is to (re)allow loading configuration file from current working directory.
This feature has been removed from [jupyter_core](https://github.com/jupyter/jupyter_core/commit/1fd79f9c192d4c56235ec1847f18d3b079b722b9) for security reasons (https://github.com/advisories/GHSA-pq7m-3gw7-gq5x).

This will fix the tests on extensions which are broken since the last release of jupyter_core.

For what I understand it should only load configuration file for nbgrader, it should not reintroduce the security error.