### PR TITLE
Changed quickstart example

### DIFF
--- a/nbgrader/docs/source/configuration/nbgrader_config.rst
+++ b/nbgrader/docs/source/configuration/nbgrader_config.rst
@@ -33,7 +33,7 @@ Use Case 1: nbgrader and ``jupyter notebook`` run in the same directory
 The easiest way to use nbgrader and the formgrader extension is to run both
 from the same directory. For example::
 
-    nbgrader quickstart ./course101
+    nbgrader quickstart course101
     cd ./course101
     jupyter notebook
 


### PR DESCRIPTION
I recently ran into a problem when using `nbgrader quickstart`. In the docs currently, one example given [here](https://nbgrader.readthedocs.io/en/stable/configuration/nbgrader_config.html#use-case-1-nbgrader-and-jupyter-notebook-run-in-the-same-directory) is
```
nbgrader quickstart ./course101
```
which results in a `nbgrader_config.py` with `course_id = "./course101"`. However, in other parts of the code, the course id seems to be determined via reading directories, so is set to `"course101"`.  This then causes problems in at least in feedback related functions when `notebook_hash` is called, leading to different hashes for the same assignment.

I don't know what is the best way to fix this, maybe adding a check somewhere that limits/sanitizes course ids would work. 

This pull request changes the quickstart example in the docs to not accidentally lead people to this problem.