### PR TITLE
Timeout configuration in validation and error message

### DIFF
--- a/nbgrader/tests/apps/files/timeout.ipynb
+++ b/nbgrader/tests/apps/files/timeout.ipynb
@@ -1,0 +1,70 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "deletable": false,
+    "nbgrader": {
+     "cell_type": "code",
+     "checksum": "cc6463a7b1770423bdf8bc8b01bee931",
+     "grade": false,
+     "grade_id": "squares",
+     "locked": false,
+     "schema_version": 3,
+     "solution": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "def foo():\n",
+    "    time.sleep(5)\n",
+    "    return True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "deletable": false,
+    "editable": false,
+    "nbgrader": {
+     "cell_type": "code",
+     "checksum": "a6a51275965b572fa21c2f06be0fccff",
+     "grade": true,
+     "grade_id": "correct_squares",
+     "locked": false,
+     "points": 1,
+     "schema_version": 3,
+     "solution": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "assert foo()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/nbgrader/tests/apps/test_nbgrader_validate.py
+++ b/nbgrader/tests/apps/test_nbgrader_validate.py
@@ -1,4 +1,5 @@
 from os.path import join
+from textwrap import dedent
 
 from .. import run_nbgrader
 from .base import BaseTestApp
@@ -14,7 +15,10 @@ class TestNbGraderValidate(BaseTestApp):
         """Does the validation fail on an unchanged notebook?"""
         self._copy_file(join("files", "submitted-unchanged.ipynb"), "submitted-unchanged.ipynb")
         output = run_nbgrader(["validate", "submitted-unchanged.ipynb"], stdout=True)
-        assert output.splitlines()[0] == "VALIDATION FAILED ON 3 CELL(S)! If you submit your assignment as it is, you WILL NOT"
+        assert (
+            output.splitlines()[0]
+            == "VALIDATION FAILED ON 3 CELL(S)! If you submit your assignment as it is, you WILL NOT"
+        )
 
     def test_validate_changed(self):
         """Does the validation pass on an changed notebook?"""
@@ -33,7 +37,10 @@ class TestNbGraderValidate(BaseTestApp):
       """Does validation correctly fail when cell has zero points?"""
       self._copy_file(join("files", "validation-zero-points.ipynb"), "validation-zero-points.ipynb")
       output = run_nbgrader(["validate", "validation-zero-points.ipynb"], stdout=True)
-      assert output.splitlines()[0] == "VALIDATION FAILED ON 1 CELL(S)! If you submit your assignment as it is, you WILL NOT"
+      assert (
+            output.splitlines()[0]
+            == "VALIDATION FAILED ON 1 CELL(S)! If you submit your assignment as it is, you WILL NOT"
+      )
 
     def test_invert_validate_unchanged(self):
         """Does the inverted validation pass on an unchanged notebook?"""
@@ -51,7 +58,10 @@ class TestNbGraderValidate(BaseTestApp):
         """Does the validate fail if a grade cell has changed?"""
         self._copy_file(join("files", "submitted-grade-cell-changed.ipynb"), "submitted-grade-cell-changed.ipynb")
         output = run_nbgrader(["validate", "submitted-grade-cell-changed.ipynb"], stdout=True)
-        assert output.splitlines()[0] == "THE CONTENTS OF 1 TEST CELL(S) HAVE CHANGED! This might mean that even though the tests"
+        assert (
+            output.splitlines()[0]
+            == "THE CONTENTS OF 1 TEST CELL(S) HAVE CHANGED! This might mean that even though the tests"
+        )
 
     def test_grade_cell_changed_ignore_checksums(self):
         """Does the validate pass if a grade cell has changed but we're ignoring checksums?"""
@@ -66,7 +76,10 @@ class TestNbGraderValidate(BaseTestApp):
         """Does the validate fail if a grade cell has changed, even with --invert?"""
         self._copy_file(join("files", "submitted-grade-cell-changed.ipynb"), "submitted-grade-cell-changed.ipynb")
         output = run_nbgrader(["validate", "submitted-grade-cell-changed.ipynb", "--invert"], stdout=True)
-        assert output.splitlines()[0] == "THE CONTENTS OF 1 TEST CELL(S) HAVE CHANGED! This might mean that even though the tests"
+        assert (
+            output.splitlines()[0]
+            == "THE CONTENTS OF 1 TEST CELL(S) HAVE CHANGED! This might mean that even though the tests"
+        )
 
     def test_invert_grade_cell_changed_ignore_checksums(self):
         """Does the validate fail if a grade cell has changed with --invert and ignoring checksums?"""
@@ -85,13 +98,19 @@ class TestNbGraderValidate(BaseTestApp):
             "validate", "submitted-unchanged.ipynb",
             "--Validator.ignore_checksums=True"
         ], stdout=True)
-        assert output.splitlines()[0] == "VALIDATION FAILED ON 1 CELL(S)! If you submit your assignment as it is, you WILL NOT"
+        assert (
+            output.splitlines()[0]
+            == "VALIDATION FAILED ON 1 CELL(S)! If you submit your assignment as it is, you WILL NOT"
+        )
 
     def test_locked_cell_changed(self):
         """Does the validate fail if a locked cell has changed?"""
         self._copy_file(join("files", "submitted-locked-cell-changed.ipynb"), "submitted-locked-cell-changed.ipynb")
         output = run_nbgrader(["validate", "submitted-locked-cell-changed.ipynb"], stdout=True)
-        assert output.splitlines()[0] == "THE CONTENTS OF 2 TEST CELL(S) HAVE CHANGED! This might mean that even though the tests"
+        assert (
+            output.splitlines()[0]
+            == "THE CONTENTS OF 2 TEST CELL(S) HAVE CHANGED! This might mean that even though the tests"
+        )
 
     def test_locked_cell_changed_ignore_checksums(self):
         """Does the validate pass if a locked cell has changed but we're ignoring checksums?"""
@@ -100,13 +119,19 @@ class TestNbGraderValidate(BaseTestApp):
             "validate", "submitted-locked-cell-changed.ipynb",
             "--Validator.ignore_checksums=True"
         ], stdout=True)
-        assert output.splitlines()[0] == "VALIDATION FAILED ON 1 CELL(S)! If you submit your assignment as it is, you WILL NOT"
+        assert (
+                output.splitlines()[0]
+                == "VALIDATION FAILED ON 1 CELL(S)! If you submit your assignment as it is, you WILL NOT"
+        )
 
     def test_invert_locked_cell_changed(self):
         """Does the validate fail if a locked cell has changed, even with --invert?"""
         self._copy_file(join("files", "submitted-locked-cell-changed.ipynb"), "submitted-locked-cell-changed.ipynb")
         output = run_nbgrader(["validate", "submitted-locked-cell-changed.ipynb", "--invert"], stdout=True)
-        assert output.splitlines()[0] == "THE CONTENTS OF 2 TEST CELL(S) HAVE CHANGED! This might mean that even though the tests"
+        assert (
+                output.splitlines()[0]
+                == "THE CONTENTS OF 2 TEST CELL(S) HAVE CHANGED! This might mean that even though the tests"
+        )
 
     def test_invert_locked_cell_changed_ignore_checksums(self):
         """Does the validate fail if a locked cell has changed with --invert and ignoring checksums?"""
@@ -131,5 +156,34 @@ class TestNbGraderValidate(BaseTestApp):
     def test_validate_with_validating_envvar(self, db, course_dir):
         self._copy_file(join("files", "validating-environment-variable.ipynb"), "nb1.ipynb")
         output = run_nbgrader(["validate", "nb1.ipynb"], stdout=True)
-        assert output.splitlines()[0] == "VALIDATION FAILED ON 1 CELL(S)! If you submit your assignment as it is, you WILL NOT"
+        assert (
+                output.splitlines()[0]
+                == "VALIDATION FAILED ON 1 CELL(S)! If you submit your assignment as it is, you WILL NOT"
+        )
 
+    def test_validate_timeout(self, db, course_dir):
+        """Does validate accept timeout configuration correctly?"""
+        self._copy_file(join("files", "timeout.ipynb"), "nb1.ipynb")
+        output = run_nbgrader(["validate", "nb1.ipynb"], stdout=True)
+        assert output.strip() == "Success! Your notebook passes all the tests."
+
+        # timeout=1 leads to an asyncio error on Windows
+        output = run_nbgrader(["validate", "--Execute.timeout=2", "nb1.ipynb"], stdout=True)
+        assert output.splitlines()[-2].strip() == "CellTimeoutError: No reply from kernel before timeout"
+
+    def test_validate_timeout_config(self, db, course_dir):
+        """Is the timeout error message configurable"""
+        self._copy_file(join("files", "timeout.ipynb"), "nb1.ipynb")
+        # supplying a list as dict value (for traceback) on cli was annoying
+        # writing this into a config file is easier
+        self._make_file("nbgrader_config.py",
+                        dedent("""
+                        c = get_config()
+                        c.Execute.error_on_timeout = {
+                            "ename": "CustomError",
+                            "evalue": "",
+                            "traceback": ["Custom"],
+                        }
+                        """))
+        output = run_nbgrader(["validate", "--Execute.timeout=2", "nb1.ipynb"], stdout=True)
+        assert output.splitlines()[-2].strip() == "Custom"

--- a/nbgrader/validator.py
+++ b/nbgrader/validator.py
@@ -286,11 +286,8 @@ class Validator(LoggingConfigurable):
         resources = {}
         with utils.setenv(NBGRADER_VALIDATING='1', NBGRADER_EXECUTION='validate'):
             for preprocessor in self.preprocessors:
-                # https://github.com/jupyter/nbgrader/pull/1075
-                # It seemes that without the self.config passed below,
-                # --ExecutePreprocessor.timeout doesn't work.  Better solution
-                # requested, unknown why this is needed.
-                pp = preprocessor(**self.config[preprocessor.__name__])
+                # Let configuration be handled by traitlets
+                pp = preprocessor(parent=self)
                 nb, resources = pp.preprocess(nb, resources)
         return nb
 


### PR DESCRIPTION
<s>Make timeout configuration work via:
- either `c.Execute.timeout` or `c.ExecutePreprocessor.timeout` in `nbgrader_config.py` or,
- `--Execute.timeout` or `--ExecutePreprocessor.timeout` in the command-line.</s>
- 
Since  #1690 is now merged, this pr also makes `error_on_timeout` configurable and makes it actually printed on command line or included in Notebook/Lab response messages.

In the case of validating, the current implementation does not use configuration in the way `traitlets` expects, in that it just calls `preprocessor({"timeout": x})`, which is caught by `ExecutePreprocessor` (this may work, but only by accident). By giving the argument `parent=self`, the configuration is deferred to the initialization of `Configurable`, which knows how to do it properly.