### PR TITLE
Fix validation for failed cells with zero points

### DIFF
--- a/nbgrader/tests/apps/files/validation-zero-points.ipynb
+++ b/nbgrader/tests/apps/files/validation-zero-points.ipynb
@@ -1,0 +1,75 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Validating this file should fail even though the assignment has 0 points."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "deletable": false,
+    "nbgrader": {
+     "checksum": "8f1eab8d02a9520920aa06f8a86a2492",
+     "grade": false,
+     "grade_id": "squares",
+     "locked": false,
+     "schema_version": 3,
+     "solution": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def squares(n):\n",
+    "   # YOUR CODE HERE\n",
+    "    return [0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "deletable": false,
+    "editable": false,
+    "nbgrader": {
+     "grade": true,
+     "grade_id": "correct_squares",
+     "locked": true,
+     "points": 0,
+     "schema_version": 3,
+     "solution": false,
+     "task": false
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "assert squares(1) == [1]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/nbgrader/tests/apps/test_nbgrader_validate.py
+++ b/nbgrader/tests/apps/test_nbgrader_validate.py
@@ -29,6 +29,12 @@ class TestNbGraderValidate(BaseTestApp):
         output = run_nbgrader(["validate", "my_subdir/open_relative_file.ipynb"], stdout=True)
         assert output.strip() == "Success! Your notebook passes all the tests."
 
+    def test_validate_zero_points(self):
+      """Does validation correctly fail when cell has zero points?"""
+      self._copy_file(join("files", "validation-zero-points.ipynb"), "validation-zero-points.ipynb")
+      output = run_nbgrader(["validate", "validation-zero-points.ipynb"], stdout=True)
+      assert output.splitlines()[0] == "VALIDATION FAILED ON 1 CELL(S)! If you submit your assignment as it is, you WILL NOT"
+
     def test_invert_validate_unchanged(self):
         """Does the inverted validation pass on an unchanged notebook?"""
         self._copy_file(join("files", "submitted-unchanged.ipynb"), "submitted-unchanged.ipynb")

--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -61,6 +61,18 @@ def is_locked(cell: NotebookNode) -> bool:
     else:
         return cell.metadata['nbgrader'].get('locked', False)
 
+
+def has_failed(cell: NotebookNode) -> bool:
+    """Returns True if the cell contains an output indicative of an error"""
+    if not cell.cell_type == 'code':
+        return False
+    for output in cell.outputs:
+        if output.output_type == 'error' or output.output_type == "stream" and output.name == "stderr":
+            return True
+    # Otherwise assume all is fine
+    return False
+
+
 def get_partial_grade(output, max_points, log=None):
     """
     Calculates partial grade for a cell, based on contents of

--- a/nbgrader/validator.py
+++ b/nbgrader/validator.py
@@ -254,7 +254,7 @@ class Validator(LoggingConfigurable):
                 # it's a markdown cell, so we can't do anything
                 if score is None:
                     pass
-                elif score < max_score:
+                elif score < max_score or (max_score == 0 and utils.has_failed(cell)):
                     failed.append(cell)
             elif self.validate_all and cell.cell_type == 'code':
                 for output in cell.outputs:


### PR DESCRIPTION
If a cell gets full points during validation, check if max_points is 0 and the cell actually failed. Fixes (part of) #1418.

If this looks good, I can also add some related tests.