### PR TITLE
Adapts timeout in tests to avoid cancelled nbextension tests

### DIFF
--- a/.github/workflows/test-docs-python-nbextensions.yml
+++ b/.github/workflows/test-docs-python-nbextensions.yml
@@ -17,7 +17,7 @@ defaults:
 jobs:
   test_nbgrader:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 25
+    timeout-minutes: 45
 
     env:
       # NOTE: UTF-8 content may be interpreted as ascii and causes errors
@@ -50,12 +50,15 @@ jobs:
         run: |
           if [ "${{ matrix.group }}" == "docs" ]; then
               echo "GROUP=docs" >> $GITHUB_ENV
+              echo "TIMEOUT_MINUTES=15" >> $GITHUB_ENV
           fi
           if [ "${{ matrix.group }}" == "nbextensions" ]; then
               echo "GROUP=nbextensions" >> $GITHUB_ENV
+              echo "TIMEOUT_MINUTES=25" >> $GITHUB_ENV
           fi
           if [ "${{ matrix.group }}" == "python" ]; then
               echo "GROUP=python" >> $GITHUB_ENV
+              echo "TIMEOUT_MINUTES=20" >> $GITHUB_ENV
           fi
       - uses: actions/checkout@v2
       - name: Install node
@@ -86,6 +89,7 @@ jobs:
         run: |
           npx playwright install
       - name: Run pytest
+        timeout-minutes: ${{ fromJSON(env.TIMEOUT_MINUTES) }}
         run: |
           python tasks.py tests --group="$GROUP"
       # - name: Submit codecov report


### PR DESCRIPTION
This PR adapts the timeout of the tests for `python-nbextensions-docs` test.
The `nbextension` takes often more than 25 minutes to run because of some delay in the installation of python dependencies in Windows.

This PR allows 45 minutes for the full test workflow, but only 25 for the nbextension test itself (15 for the docs and 20 for the python).