### PR TITLE
Upgrade python requirement

### DIFF
--- a/.github/workflows/test-docs-python-nbextensions.yml
+++ b/.github/workflows/test-docs-python-nbextensions.yml
@@ -28,19 +28,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-20.04]
+        os: [windows-latest, ubuntu-22.04]
         group: ["docs", "nbextensions", "python"]
-        python: ["3.7", "3.8", "3.9", "3.10"]
+        python: ["3.8", "3.9", "3.10", "3.11"]
         exclude:
           - os: windows-latest
-            group: docs
-          - python: "3.7"
             group: docs
           - python: "3.8"
             group: docs
           - python: "3.9"
             group: docs
-          - python: "3.7"
+          - python: "3.10"
+            group: docs
+          - python: "3.8"
             group: nbextensions
     steps:
       # This is how you set an environment variable in a GitHub workflow that

--- a/.github/workflows/test-labextensions.yml
+++ b/.github/workflows/test-labextensions.yml
@@ -28,8 +28,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-20.04]
-        python: ["3.9", "3.10"]
+        os: [windows-latest, ubuntu-22.04]
+        python: ["3.10", "3.11"]
     steps:
       # This is how you set an environment variable in a GitHub workflow that
       # will be available in following steps as if you would used `export


### PR DESCRIPTION
Python 3.7 is not supported anymore by `ipython`, which breaks the dependencies installation for tests.
This issue occurs when upgrading `ipython`, see https://github.com/jupyter/nbgrader/pull/1690#issuecomment-1462592055

This PR drops Python 3.7 in tests, and includes Python 3.11.
It also upgrades the Linux distribution used in tests, from Ubuntu 20.04 to Ubuntu 22.04.

