### PR TITLE
Loosen the traitlets version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "rapidfuzz>=1.8",
     "requests>=2.26",
     "sqlalchemy>=1.4,<2",
-    "traitlets<5.7.0",
+    "traitlets>5.0,<6",
 ]
 version = "0.8.1"
 


### PR DESCRIPTION
The requirement of a specific traitlets version was first set in commit 35ed7aae9a72a4a7f2e4d9117eb8f0ae6bac6411 to be <5.2 because apparently 5.2 broke tests.

The last time this line was updated was in #1704, where it was bumped up to allow the latest version at the time, 5.6, by setting the value to <5.7. There was an additional change in #1704 which sets a log level, but this seems to be backwards compatible.

These changes seem to no longer be relevant as the test suite now passes with traitlets versions 5.2, 5.7, as well as many others >5. The only version I found to fail was 5.0.0.

This commit loosens the version requirement to allow these other versions of the traitlets package which don't cause known conflicts, as well as allow future minor, but not major version bumps.