### PR TITLE
Unpin nbclassic

### DIFF
--- a/demos/restart_demo.sh
+++ b/demos/restart_demo.sh
@@ -43,7 +43,6 @@ install_dependencies () {
     apt install -y npm
     npm install -g configurable-http-proxy
     apt install -y python3-pip
-    pip3 install -U nbclassic==0.3.7
     pip3 install -U jupyterlab
     pip3 install -U jupyterhub
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
     "jupyter_server>=1.12,<2",
     "jupyterlab<4",
     "jupyterlab_server",
-    "nbclassic<0.5.0",
     "nbclient>=0.6.1",
     "nbconvert>=6",
     "notebook>=6.4,<7",


### PR DESCRIPTION
`nbclassic` has been pinned to version `<0.4.0` because of *Mathjax* issue (https://github.com/jupyter/nbgrader/issues/1622).
The current version is `<0.5.0` and it seems there is no *Mathjax* issue anymore.
There is no need to pin it anymore.
