### PR TITLE
Removes dependency to MarkupSafe<2.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
     "jupyter_server>=1.12,<2",
     "jupyterlab<4",
     "jupyterlab_server",
-    "MarkupSafe<2.2.0",
     "nbclassic<0.5.0",
     "nbclient>=0.6.1",
     "nbconvert>=6",


### PR DESCRIPTION
`MarkupSafe` has been primarily added when jinja2 has been pinned to version `<3` (https://github.com/jupyter/nbgrader/pull/1559).
Currently it is `jinja2>=3`, the dependency on MarkupSafe can probably be removed.