### PR TITLE
Updates yarn network timeout

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+network-timeout 300000


### PR DESCRIPTION
The windows tests on labextensions often fails because of timeout fetching packages from yarnregistry.

This PR should fix it by increasing the default timeout.
Reference https://github.com/yarnpkg/yarn/issues/4890#issuecomment-364554421