### PR TITLE
Assignment names breaking regex

### DIFF
--- a/.github/workflows/test-docs-python-nbextensions.yml
+++ b/.github/workflows/test-docs-python-nbextensions.yml
@@ -17,7 +17,7 @@ defaults:
 jobs:
   test_nbgrader:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 25
+    timeout-minutes: 45
 
     env:
       # NOTE: UTF-8 content may be interpreted as ascii and causes errors
@@ -28,19 +28,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-20.04]
+        os: [windows-latest, ubuntu-22.04]
         group: ["docs", "nbextensions", "python"]
-        python: ["3.7", "3.8", "3.9", "3.10"]
+        python: ["3.8", "3.9", "3.10", "3.11"]
         exclude:
           - os: windows-latest
-            group: docs
-          - python: "3.7"
             group: docs
           - python: "3.8"
             group: docs
           - python: "3.9"
             group: docs
-          - python: "3.7"
+          - python: "3.10"
+            group: docs
+          - python: "3.8"
             group: nbextensions
     steps:
       # This is how you set an environment variable in a GitHub workflow that
@@ -50,12 +50,15 @@ jobs:
         run: |
           if [ "${{ matrix.group }}" == "docs" ]; then
               echo "GROUP=docs" >> $GITHUB_ENV
+              echo "TIMEOUT_MINUTES=15" >> $GITHUB_ENV
           fi
           if [ "${{ matrix.group }}" == "nbextensions" ]; then
               echo "GROUP=nbextensions" >> $GITHUB_ENV
+              echo "TIMEOUT_MINUTES=25" >> $GITHUB_ENV
           fi
           if [ "${{ matrix.group }}" == "python" ]; then
               echo "GROUP=python" >> $GITHUB_ENV
+              echo "TIMEOUT_MINUTES=20" >> $GITHUB_ENV
           fi
       - uses: actions/checkout@v2
       - name: Install node
@@ -86,6 +89,7 @@ jobs:
         run: |
           npx playwright install
       - name: Run pytest
+        timeout-minutes: ${{ fromJSON(env.TIMEOUT_MINUTES) }}
         run: |
           python tasks.py tests --group="$GROUP"
       # - name: Submit codecov report

--- a/.github/workflows/test-labextensions.yml
+++ b/.github/workflows/test-labextensions.yml
@@ -28,8 +28,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-20.04]
-        python: ["3.9", "3.10"]
+        os: [windows-latest, ubuntu-22.04]
+        python: ["3.10", "3.11"]
     steps:
       # This is how you set an environment variable in a GitHub workflow that
       # will be available in following steps as if you would used `export

--- a/.gitignore
+++ b/.gitignore
@@ -124,7 +124,9 @@ package-lock.json
 .goutputstream*
 .idea
 .mypy_cache
-
+.envrc
+.node-version
+.direnv/
 
 # playwright output tests directory
 playwright-tests/

--- a/nbgrader/coursedir.py
+++ b/nbgrader/coursedir.py
@@ -78,14 +78,17 @@ class CourseDirectory(LoggingConfigurable):
             The assignment name. This MUST be specified, either by setting the
             config option, passing an argument on the command line, or using the
             --assignment option on the command line.
+
+            The assignment name cannot include any of the characters +()/\\[]\{\}$^
             """
         )
     ).tag(config=True)
 
     @validate('assignment_id')
     def _validate_assignment_id(self, proposal: Bunch) -> str:
-        if '+' in proposal['value']:
-            raise TraitError('Assignment names should not contain the following characters: +')
+        bad_characters = r'+()/\\[]{}$^'
+        if set(proposal['value']) & set(bad_characters):
+            raise TraitError(f'Assignment names may not contain the following characters: {bad_characters}')
         if proposal['value'].strip() != proposal['value']:
             self.log.warning("assignment_id '%s' has trailing whitespace, stripping it away", proposal['value'])
         return proposal['value'].strip()

--- a/nbgrader/coursedir.py
+++ b/nbgrader/coursedir.py
@@ -6,7 +6,7 @@ from textwrap import dedent
 from traitlets.config import LoggingConfigurable
 from traitlets import Integer, Bool, Unicode, List, default, validate, TraitError
 
-from .utils import full_split, parse_utc
+from .utils import full_split, parse_utc, sanitise_givencode
 from traitlets.utils.bunch import Bunch
 import datetime
 from typing import Optional
@@ -21,12 +21,20 @@ class CourseDirectory(LoggingConfigurable):
             A key that is unique per instructor and course. This can be
             specified, either by setting the config option, or using the
             --course option on the command line.
+
+            Certain characters (braces, slashes, and some punctuation)
+            _may_ cause issues, so are substituted for high-end unicode
+            look-alikes.
             """
         )
     ).tag(config=True)
 
     @validate('course_id')
-    def _validate_course_id(self, proposal):
+    def _validate_course_id(self, proposal: list) -> str:
+        value = proposal['value']
+        proposal['value'] = sanitise_givencode(value)
+        if proposal['value'] != value:
+            self.log.warning("course_id '%s' had unacceptable charcaters, and transformed to '%s'", value, proposal['value'])
         if proposal['value'].strip() != proposal['value']:
             self.log.warning("course_id '%s' has trailing whitespace, stripping it away", proposal['value'])
         return proposal['value'].strip()
@@ -79,16 +87,19 @@ class CourseDirectory(LoggingConfigurable):
             config option, passing an argument on the command line, or using the
             --assignment option on the command line.
 
-            The assignment name cannot include any of the characters +()/\\[]\{\}$^
+            Certain characters (braces, slashes, and some punctuation)
+            _will_ cause issues, so are substituted for high-end unicode
+            look-alikes.
             """
         )
     ).tag(config=True)
 
     @validate('assignment_id')
     def _validate_assignment_id(self, proposal: Bunch) -> str:
-        bad_characters = r'+()/\\[]{}$^'
-        if set(proposal['value']) & set(bad_characters):
-            raise TraitError(f'Assignment names may not contain the following characters: {bad_characters}')
+        value = proposal['value']
+        proposal['value'] = sanitise_givencode(value)
+        if proposal['value'] != value:
+            self.log.warning("assignment_id '%s' had unacceptable charcaters, and transformed to '%s'", value, proposal['value'])
         if proposal['value'].strip() != proposal['value']:
             self.log.warning("assignment_id '%s' has trailing whitespace, stripping it away", proposal['value'])
         return proposal['value'].strip()

--- a/nbgrader/docs/source/user_guide/creating_and_grading_assignments.ipynb
+++ b/nbgrader/docs/source/user_guide/creating_and_grading_assignments.ipynb
@@ -129,13 +129,16 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "**Note**: As you are developing your assignments, you should save them\n",
     "into the `source/{assignment_id}/` folder of the nbgrader hierarchy,\n",
     "where `assignment_id` is the name of the assignment you are creating\n",
-    "(e.g. \"ps1\")."
+    "(e.g. \"ps1\").\n",
+    "\n",
+    "Due to the way nbgrader parses the directory structure, we need to exclude some characters from `assignment_id` . Currently the list of _bad characters_ is `+()/\\[]{}$^`"
    ]
   },
   {
@@ -522,11 +525,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
@@ -645,11 +644,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
@@ -708,11 +703,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
@@ -905,11 +896,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
@@ -1131,11 +1118,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
@@ -1216,11 +1199,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
@@ -1248,11 +1227,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1280,9 +1255,18 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python",
+   "display_name": "python-3.10.2",
    "language": "python",
-   "name": "python"
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.2"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "07a112c504f75e58a549d79f3ba1986944262a831603568f54b3b9d6743c8933"
+   }
   }
  },
  "nbformat": 4,

--- a/nbgrader/docs/source/user_guide/creating_and_grading_assignments.ipynb
+++ b/nbgrader/docs/source/user_guide/creating_and_grading_assignments.ipynb
@@ -138,9 +138,7 @@
     "where `assignment_id` is the name of the assignment you are creating\n",
     "(e.g. \"ps1\").\n",
     "\n",
-    "Due to the way nbgrader parses the directory structure, certain characters (braces, slashes, and some punctuation) _will_ cause issues, so are substituted for high-end unicode look-alikes.\n",
-    "\n",
-    "Currently the list of _bad characters_ is `+()/\\[]{}$^`"
+    "Due to the way nbgrader parses the directory structure, we need to exclude some characters from `assignment_id` . Currently the list of _bad characters_ is `+()/\\[]{}$^`"
    ]
   },
   {

--- a/nbgrader/docs/source/user_guide/creating_and_grading_assignments.ipynb
+++ b/nbgrader/docs/source/user_guide/creating_and_grading_assignments.ipynb
@@ -138,7 +138,9 @@
     "where `assignment_id` is the name of the assignment you are creating\n",
     "(e.g. \"ps1\").\n",
     "\n",
-    "Due to the way nbgrader parses the directory structure, we need to exclude some characters from `assignment_id` . Currently the list of _bad characters_ is `+()/\\[]{}$^`"
+    "Due to the way nbgrader parses the directory structure, certain characters (braces, slashes, and some punctuation) _will_ cause issues, so are substituted for high-end unicode look-alikes.\n",
+    "\n",
+    "Currently the list of _bad characters_ is `+()/\\[]{}$^`"
    ]
   },
   {

--- a/nbgrader/server_extensions/formgrader/static/js/manage_assignments.js
+++ b/nbgrader/server_extensions/formgrader/static/js/manage_assignments.js
@@ -499,6 +499,7 @@ var insertRow = function (table) {
 var createAssignmentModal = function () {
     var modal;
     var createAssignment = function () {
+        var bad_character_regex = /[+\(\)\/\\\[\]\{\}\$\^]/;
         var name = modal.find(".name").val();
         var duedate = modal.find(".duedate").val();
         var timezone = modal.find(".timezone").val();
@@ -513,9 +514,9 @@ var createAssignmentModal = function () {
             modal.modal('hide');
             return;
         }
-        if (name.indexOf("+") != -1) {
+        if (bad_character_regex.test(name)) {
             var err = $("#create-error");
-            err.text("Assignment names may not include the '+' character.");
+            err.text("Assignment names may not include any of the characters +\(\)[]{}/\\$^");
             err.show();
             return;
         } else {

--- a/nbgrader/server_extensions/formgrader/static/js/manage_assignments.js
+++ b/nbgrader/server_extensions/formgrader/static/js/manage_assignments.js
@@ -498,27 +498,8 @@ var insertRow = function (table) {
 
 var createAssignmentModal = function () {
     var modal;
-    var _sanitise_givencode = function (value) {
-        if (value) {
-            value = value.replaceAll(/\\/g, "∖");  // set miuhs U+2216
-            value = value.replaceAll(/{/g, "｛");  // full width left curly U+FF5B
-            value = value.replaceAll(/}/g, "｝");  /// full width right curly U+FF5D
-            value = value.replaceAll(/\(/g, "（");  // full width left brace U+FF08
-            value = value.replaceAll(/\)/g, "）");  // full width right brace U+FF09
-            value = value.replaceAll(/\[/g, "［");  // full width square U+FF3B
-            value = value.replaceAll(/\]/g, "］");  // full width square U+FF3D
-            value = value.replaceAll(/\//g, "∕");  // divisional slash U+2215
-            value = value.replaceAll(/\$/g, "＄");  // Fullwidth Dollar Sign U+FF04
-            value = value.replaceAll(/\^/g, "＾");  // Fullwidth Circumflex Accent U+FF3E
-            value = value.replaceAll(/\+/g, "➕");  // Heavy Plus Sign U+2795
-            value = value.replaceAll(/\?/g, "❔");  // White Question Mark Ornament U+2754 (❓=U+2753)
-            value = value.replaceAll(/\*/g, "★");  // Black Star U+2605
-            value = value.replaceAll(/\|/g, "❘");  // Light Vertical Bar U+2758
-            value = value.replaceAll(/[\n\r\t\f]/g, "");  // removed carriage movements
-        }
-        return value
-    }
     var createAssignment = function () {
+        var bad_character_regex = /[+\(\)\/\\\[\]\{\}\$\^]/;
         var name = modal.find(".name").val();
         var duedate = modal.find(".duedate").val();
         var timezone = modal.find(".timezone").val();
@@ -533,7 +514,15 @@ var createAssignmentModal = function () {
             modal.modal('hide');
             return;
         }
-        name = _sanitise_givencode(name);
+        if (bad_character_regex.test(name)) {
+            var err = $("#create-error");
+            err.text("Assignment names may not include any of the characters +\(\)[]{}/\\$^");
+            err.show();
+            return;
+        } else {
+            var err = $("#create-error");
+            err.hide();
+        }
 
         var model = new Assignment({
             "name": name,

--- a/nbgrader/server_extensions/formgrader/static/js/manage_assignments.js
+++ b/nbgrader/server_extensions/formgrader/static/js/manage_assignments.js
@@ -498,8 +498,27 @@ var insertRow = function (table) {
 
 var createAssignmentModal = function () {
     var modal;
+    var _sanitise_givencode = function (value) {
+        if (value) {
+            value = value.replaceAll(/\\/g, "∖");  // set miuhs U+2216
+            value = value.replaceAll(/{/g, "｛");  // full width left curly U+FF5B
+            value = value.replaceAll(/}/g, "｝");  /// full width right curly U+FF5D
+            value = value.replaceAll(/\(/g, "（");  // full width left brace U+FF08
+            value = value.replaceAll(/\)/g, "）");  // full width right brace U+FF09
+            value = value.replaceAll(/\[/g, "［");  // full width square U+FF3B
+            value = value.replaceAll(/\]/g, "］");  // full width square U+FF3D
+            value = value.replaceAll(/\//g, "∕");  // divisional slash U+2215
+            value = value.replaceAll(/\$/g, "＄");  // Fullwidth Dollar Sign U+FF04
+            value = value.replaceAll(/\^/g, "＾");  // Fullwidth Circumflex Accent U+FF3E
+            value = value.replaceAll(/\+/g, "➕");  // Heavy Plus Sign U+2795
+            value = value.replaceAll(/\?/g, "❔");  // White Question Mark Ornament U+2754 (❓=U+2753)
+            value = value.replaceAll(/\*/g, "★");  // Black Star U+2605
+            value = value.replaceAll(/\|/g, "❘");  // Light Vertical Bar U+2758
+            value = value.replaceAll(/[\n\r\t\f]/g, "");  // removed carriage movements
+        }
+        return value
+    }
     var createAssignment = function () {
-        var bad_character_regex = /[+\(\)\/\\\[\]\{\}\$\^]/;
         var name = modal.find(".name").val();
         var duedate = modal.find(".duedate").val();
         var timezone = modal.find(".timezone").val();
@@ -514,15 +533,7 @@ var createAssignmentModal = function () {
             modal.modal('hide');
             return;
         }
-        if (bad_character_regex.test(name)) {
-            var err = $("#create-error");
-            err.text("Assignment names may not include any of the characters +\(\)[]{}/\\$^");
-            err.show();
-            return;
-        } else {
-            var err = $("#create-error");
-            err.hide();
-        }
+        name = _sanitise_givencode(name);
 
         var model = new Assignment({
             "name": name,

--- a/nbgrader/tests/apps/files/validation-zero-points.ipynb
+++ b/nbgrader/tests/apps/files/validation-zero-points.ipynb
@@ -1,0 +1,75 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Validating this file should fail even though the assignment has 0 points."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "deletable": false,
+    "nbgrader": {
+     "checksum": "8f1eab8d02a9520920aa06f8a86a2492",
+     "grade": false,
+     "grade_id": "squares",
+     "locked": false,
+     "schema_version": 3,
+     "solution": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def squares(n):\n",
+    "   # YOUR CODE HERE\n",
+    "    return [0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "deletable": false,
+    "editable": false,
+    "nbgrader": {
+     "grade": true,
+     "grade_id": "correct_squares",
+     "locked": true,
+     "points": 0,
+     "schema_version": 3,
+     "solution": false,
+     "task": false
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "assert squares(1) == [1]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/nbgrader/tests/apps/test_nbgrader_autograde.py
+++ b/nbgrader/tests/apps/test_nbgrader_autograde.py
@@ -990,6 +990,7 @@ class TestNbGraderAutograde(BaseTestApp):
         run_nbgrader(["autograde", "ps1", "--db", db])
 
     def test_infinite_loop(self, db, course_dir):
+        # pytest.skip("this test has been hanging for over 90 minutes!")
         run_nbgrader(["db", "assignment", "add", "ps1", "--db", db, "--duedate",
                       "2015-02-02 14:58:23.948203 America/Los_Angeles"])
         run_nbgrader(["db", "student", "add", "foo", "--db", db])

--- a/nbgrader/tests/apps/test_nbgrader_autograde.py
+++ b/nbgrader/tests/apps/test_nbgrader_autograde.py
@@ -990,7 +990,6 @@ class TestNbGraderAutograde(BaseTestApp):
         run_nbgrader(["autograde", "ps1", "--db", db])
 
     def test_infinite_loop(self, db, course_dir):
-        # pytest.skip("this test has been hanging for over 90 minutes!")
         run_nbgrader(["db", "assignment", "add", "ps1", "--db", db, "--duedate",
                       "2015-02-02 14:58:23.948203 America/Los_Angeles"])
         run_nbgrader(["db", "student", "add", "foo", "--db", db])

--- a/nbgrader/tests/apps/test_nbgrader_generate_assignment.py
+++ b/nbgrader/tests/apps/test_nbgrader_generate_assignment.py
@@ -60,6 +60,12 @@ class TestNbGraderGenerateAssignment(BaseTestApp):
         with pytest.raises(traitlets.TraitError):
             run_nbgrader(["generate_assignment", "foo+bar"])
         assert not os.path.isfile(join(course_dir, "release", "foo+bar", "foo.ipynb"))
+        with pytest.raises(traitlets.TraitError):
+            run_nbgrader(["generate_assignment", "123 (abc)"], retcode=1)
+        assert not os.path.isfile(join(course_dir, "release", "123 (abc)", "foo.ipynb"))
+        with pytest.raises(traitlets.TraitError):
+            run_nbgrader(["generate_assignment", "123/abc"], retcode=1)
+        assert not os.path.isfile(join(course_dir, "release", "123/abc", "foo.ipynb"))
 
     def test_multiple_files(self, course_dir):
         """Can multiple files be assigned?"""

--- a/nbgrader/tests/apps/test_nbgrader_generate_assignment.py
+++ b/nbgrader/tests/apps/test_nbgrader_generate_assignment.py
@@ -10,6 +10,7 @@ from textwrap import dedent
 from ...api import Gradebook
 from .. import run_nbgrader
 from .base import BaseTestApp
+from ...utils import sanitise_givencode
 
 
 class TestNbGraderGenerateAssignment(BaseTestApp):
@@ -55,17 +56,13 @@ class TestNbGraderGenerateAssignment(BaseTestApp):
         assert os.path.isfile(join(course_dir, "release", "ps1", "foo.ipynb"))
 
     def test_single_file_bad_assignment_name(self, course_dir, temp_cwd):
-        """Test that an error is thrown when the assignment name is invalid."""
-        self._empty_notebook(join(course_dir, 'source', 'foo+bar', 'foo.ipynb'))
-        with pytest.raises(traitlets.TraitError):
-            run_nbgrader(["generate_assignment", "foo+bar"])
-        assert not os.path.isfile(join(course_dir, "release", "foo+bar", "foo.ipynb"))
-        with pytest.raises(traitlets.TraitError):
-            run_nbgrader(["generate_assignment", "123 (abc)"], retcode=1)
-        assert not os.path.isfile(join(course_dir, "release", "123 (abc)", "foo.ipynb"))
-        with pytest.raises(traitlets.TraitError):
-            run_nbgrader(["generate_assignment", "123/abc"], retcode=1)
-        assert not os.path.isfile(join(course_dir, "release", "123/abc", "foo.ipynb"))
+        """Test that an assignment name with bad characters is renamed."""
+        badName = 'abc (12/34) {not|really?}[^e$]'
+        transformedName = sanitise_givencode(badName)
+        self._empty_notebook(join(course_dir, 'source', transformedName, 'foo.ipynb'))
+
+        run_nbgrader(["generate_assignment", badName])
+        assert os.path.isfile(join(course_dir, "release", transformedName, "foo.ipynb"))
 
     def test_multiple_files(self, course_dir):
         """Can multiple files be assigned?"""

--- a/nbgrader/tests/apps/test_nbgrader_generate_solution.py
+++ b/nbgrader/tests/apps/test_nbgrader_generate_solution.py
@@ -44,7 +44,9 @@ class TestNbGraderGenerateSolution(BaseTestApp):
     def test_single_file_bad_assignment_name(self, course_dir, temp_cwd):
         """Test that an error is thrown when the assignment name is invalid."""
         self._empty_notebook(join(course_dir, 'source', 'foo+bar', 'foo.ipynb'))
-        assert not os.path.isfile(join(course_dir, "solution", "foo➕bar", "foo.ipynb"))
+        with pytest.raises(traitlets.TraitError):
+            run_nbgrader(["generate_solution", "foo+bar"])
+        assert not os.path.isfile(join(course_dir, "solution", "foo+bar", "foo.ipynb"))
 
     def test_multiple_files(self, course_dir):
         """Can multiple files be assigned?"""

--- a/nbgrader/tests/apps/test_nbgrader_generate_solution.py
+++ b/nbgrader/tests/apps/test_nbgrader_generate_solution.py
@@ -44,9 +44,7 @@ class TestNbGraderGenerateSolution(BaseTestApp):
     def test_single_file_bad_assignment_name(self, course_dir, temp_cwd):
         """Test that an error is thrown when the assignment name is invalid."""
         self._empty_notebook(join(course_dir, 'source', 'foo+bar', 'foo.ipynb'))
-        with pytest.raises(traitlets.TraitError):
-            run_nbgrader(["generate_solution", "foo+bar"])
-        assert not os.path.isfile(join(course_dir, "solution", "foo+bar", "foo.ipynb"))
+        assert not os.path.isfile(join(course_dir, "solution", "foo➕bar", "foo.ipynb"))
 
     def test_multiple_files(self, course_dir):
         """Can multiple files be assigned?"""

--- a/nbgrader/tests/apps/test_nbgrader_validate.py
+++ b/nbgrader/tests/apps/test_nbgrader_validate.py
@@ -29,6 +29,12 @@ class TestNbGraderValidate(BaseTestApp):
         output = run_nbgrader(["validate", "my_subdir/open_relative_file.ipynb"], stdout=True)
         assert output.strip() == "Success! Your notebook passes all the tests."
 
+    def test_validate_zero_points(self):
+      """Does validation correctly fail when cell has zero points?"""
+      self._copy_file(join("files", "validation-zero-points.ipynb"), "validation-zero-points.ipynb")
+      output = run_nbgrader(["validate", "validation-zero-points.ipynb"], stdout=True)
+      assert output.splitlines()[0] == "VALIDATION FAILED ON 1 CELL(S)! If you submit your assignment as it is, you WILL NOT"
+
     def test_invert_validate_unchanged(self):
         """Does the inverted validation pass on an unchanged notebook?"""
         self._copy_file(join("files", "submitted-unchanged.ipynb"), "submitted-unchanged.ipynb")

--- a/nbgrader/tests/nbextensions/test_formgrader.py
+++ b/nbgrader/tests/nbextensions/test_formgrader.py
@@ -970,6 +970,45 @@ def test_add_new_assignment(browser, port, gradebook):
 
 
 @pytest.mark.nbextensions
+def test_new_assignment_excludes_bad_characters(browser, port, gradebook):
+    utils._load_gradebook_page(browser, port, "")
+    n = len(browser.find_elements(By.CSS_SELECTOR, "tbody tr"))
+
+    # click the "add new assignment" button
+    utils._click_link(browser, "Add new assignment...")
+    utils._wait_for_element(browser, "add-assignment-modal")
+    WebDriverWait(browser, 10).until(EC.visibility_of_element_located((By.CSS_SELECTOR, "#add-assignment-modal .save")))
+
+    # repeat the '+' from above
+    elem = browser.find_element(By.CSS_SELECTOR, "#add-assignment-modal .name")
+    elem.click()
+    elem.send_keys("ps2+a")
+
+    # click save and wait for the error message to appear
+    utils._click_element(browser, "#add-assignment-modal .save")
+    WebDriverWait(browser, 10).until(EC.visibility_of_element_located((By.CSS_SELECTOR, "#create-error")))
+
+    # Try round brackets
+    elem = browser.find_element(By.CSS_SELECTOR, "#add-assignment-modal .name")
+    elem.clear()
+    elem.click()
+    elem.send_keys("ps2 (123)")
+
+    # click save and wait for the error message to appear
+    utils._click_element(browser, "#add-assignment-modal .save")
+    WebDriverWait(browser, 10).until(EC.visibility_of_element_located((By.CSS_SELECTOR, "#create-error")))
+
+    # Try forward slash
+    elem = browser.find_element(By.CSS_SELECTOR, "#add-assignment-modal .name")
+    elem.clear()
+    elem.click()
+    elem.send_keys("ps2/123")
+
+    # click save and wait for the error message to appear
+    utils._click_element(browser, "#add-assignment-modal .save")
+    WebDriverWait(browser, 10).until(EC.visibility_of_element_located((By.CSS_SELECTOR, "#create-error")))
+
+@pytest.mark.nbextensions
 def test_edit_assignment(browser, port, gradebook):
     utils._load_gradebook_page(browser, port, "")
 

--- a/nbgrader/tests/nbextensions/test_formgrader.py
+++ b/nbgrader/tests/nbextensions/test_formgrader.py
@@ -20,7 +20,7 @@ from .. import run_nbgrader
 from ...api import Gradebook, MissingEntry
 from . import formgrade_utils as utils
 from .conftest import notwindows, _make_nbserver, _make_browser, _close_nbserver, _close_browser
-from ...utils import rmtree, sanitise_givencode
+from ...utils import rmtree
 
 
 if sys.platform == 'win32':
@@ -913,7 +913,7 @@ def test_add_new_assignment(browser, port, gradebook):
     # set the name and dudedate
     elem = browser.find_element(By.CSS_SELECTOR, "#add-assignment-modal .name")
     elem.click()
-    elem.send_keys("ps2 ")
+    elem.send_keys("ps2+a")
     elem = browser.find_element(By.CSS_SELECTOR, "#add-assignment-modal .duedate")
     elem.click()
     browser.execute_script("arguments[0].value = '2017-07-05T17:00';", elem)
@@ -924,7 +924,18 @@ def test_add_new_assignment(browser, port, gradebook):
 
     # click save and wait for the error message to appear
     utils._click_element(browser, "#add-assignment-modal .save")
+    WebDriverWait(browser, 10).until(EC.visibility_of_element_located((By.CSS_SELECTOR, "#create-error")))
 
+    # set a valid name
+    elem = browser.find_element(By.CSS_SELECTOR, "#add-assignment-modal .name")
+    elem.clear()
+    elem.click()
+    # check with a name containing whitespace, as this should be stripped
+    # away and handled by the interface
+    elem.send_keys("ps2 ")
+
+    # click save and wait for the modal to close
+    utils._click_element(browser, "#add-assignment-modal .save")
     modal_not_present = lambda browser: browser.execute_script("""return $("#add-assignment-modal").length === 0;""")
     WebDriverWait(browser, 10).until(modal_not_present)
 
@@ -959,9 +970,7 @@ def test_add_new_assignment(browser, port, gradebook):
 
 
 @pytest.mark.nbextensions
-def test_new_assignment_corrects_bad_characters(browser, port, gradebook):
-    badName = 'xyz (12/34*) + {not|really?}[^e$]'
-    goodName = sanitise_givencode(badName)
+def test_new_assignment_excludes_bad_characters(browser, port, gradebook):
     utils._load_gradebook_page(browser, port, "")
     n = len(browser.find_elements(By.CSS_SELECTOR, "tbody tr"))
 
@@ -970,27 +979,34 @@ def test_new_assignment_corrects_bad_characters(browser, port, gradebook):
     utils._wait_for_element(browser, "add-assignment-modal")
     WebDriverWait(browser, 10).until(EC.visibility_of_element_located((By.CSS_SELECTOR, "#add-assignment-modal .save")))
 
-    # set the name and dudedate
+    # repeat the '+' from above
     elem = browser.find_element(By.CSS_SELECTOR, "#add-assignment-modal .name")
     elem.click()
+    elem.send_keys("ps2+a")
 
-    # check with a name containing whitespace, as this should be stripped
-    # away and handled by the interface
-    elem.send_keys(badName)
-
-    # click save and wait for the modal to close
+    # click save and wait for the error message to appear
     utils._click_element(browser, "#add-assignment-modal .save")
-    modal_not_present = lambda browser: browser.execute_script("""return $("#add-assignment-modal").length === 0;""")
-    WebDriverWait(browser, 10).until(modal_not_present)
+    WebDriverWait(browser, 10).until(EC.visibility_of_element_located((By.CSS_SELECTOR, "#create-error")))
 
-    # wait until both rows are present
-    rows_present = lambda browser: len(browser.find_elements(By.CSS_SELECTOR, "tbody tr")) == (n + 1)
-    WebDriverWait(browser, 10).until(rows_present)
+    # Try round brackets
+    elem = browser.find_element(By.CSS_SELECTOR, "#add-assignment-modal .name")
+    elem.clear()
+    elem.click()
+    elem.send_keys("ps2 (123)")
 
-    # check that the new row is correct - index is from 0, length from 1.
-    #  'n' will be the last entry
-    row = browser.find_elements(By.CSS_SELECTOR, "tbody tr")[n]
-    assert row.find_element(By.CSS_SELECTOR, ".name").text == goodName
+    # click save and wait for the error message to appear
+    utils._click_element(browser, "#add-assignment-modal .save")
+    WebDriverWait(browser, 10).until(EC.visibility_of_element_located((By.CSS_SELECTOR, "#create-error")))
+
+    # Try forward slash
+    elem = browser.find_element(By.CSS_SELECTOR, "#add-assignment-modal .name")
+    elem.clear()
+    elem.click()
+    elem.send_keys("ps2/123")
+
+    # click save and wait for the error message to appear
+    utils._click_element(browser, "#add-assignment-modal .save")
+    WebDriverWait(browser, 10).until(EC.visibility_of_element_located((By.CSS_SELECTOR, "#create-error")))
 
 @pytest.mark.nbextensions
 def test_edit_assignment(browser, port, gradebook):

--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -10,6 +10,7 @@ import logging
 import traceback
 import contextlib
 import fnmatch
+import re
 
 from setuptools.archive_util import unpack_archive
 from setuptools.archive_util import unpack_tarfile
@@ -562,3 +563,24 @@ def notebook_hash(path, unique_key=None):
 def make_unique_key(course_id, assignment_id, notebook_id, student_id, timestamp):
     return "+".join([
         course_id, assignment_id, notebook_id, student_id, timestamp])
+
+# Swap all low-order characters that have meaning in regexp for similar high-order
+# unicode equivelants.
+def sanitise_givencode(value: str=None) -> str:
+    if value:
+        value = re.sub(r"\\", "∖", value)  # set minus U+2216
+        value = re.sub(r"{", "｛", value)  # full width left curly U+FF5B
+        value = re.sub(r"}", "｝", value)  # full width right curly U+FF5D
+        value = re.sub(r"\(", "（", value)  # full width left brace U+FF08
+        value = re.sub(r"\)", "）", value)  # full width right brace U+FF09
+        value = re.sub(r"\[", "［", value)  # full width square U+FF3B
+        value = re.sub(r"\]", "］", value)  # full width square U+FF3D
+        value = re.sub(r"/", "∕", value)  # divisional slash U+2215
+        value = re.sub(r"\$", "＄", value)  # Fullwidth Dollar Sign U+FF04
+        value = re.sub(r"\^", "＾", value)  # Fullwidth Circumflex Accent U+FF3E
+        value = re.sub(r"\+", "➕", value)  # Heavy Plus Sign U+2795
+        value = re.sub(r"\?", "❔", value)  # White Question Mark Ornament U+2754 (❓=U+2753)
+        value = re.sub(r"\*", "★", value)  # Black Star U+2605
+        value = re.sub(r"\|", "❘", value)  # Light Vertical Bar U+2758
+        value = re.sub(r"[\n\r\t\f]", "", value)  # removed carriage movements
+    return value

--- a/nbgrader/validator.py
+++ b/nbgrader/validator.py
@@ -254,7 +254,7 @@ class Validator(LoggingConfigurable):
                 # it's a markdown cell, so we can't do anything
                 if score is None:
                     pass
-                elif score < max_score:
+                elif score < max_score or (max_score == 0 and utils.has_failed(cell)):
                     failed.append(cell)
             elif self.validate_all and cell.cell_type == 'code':
                 for output in cell.outputs:


### PR DESCRIPTION
This extends the list of banned assignment-name characters beyond `+` to include a bunch that break the path regex code.

closes #1738 