### PR TITLE
Add missing grade_cells before autograding

### DIFF
--- a/nbgrader/preprocessors/overwritecells.py
+++ b/nbgrader/preprocessors/overwritecells.py
@@ -3,13 +3,83 @@ from nbformat.v4.nbbase import validate
 from .. import utils
 from ..api import Gradebook, MissingEntry
 from . import NbGraderPreprocessor
+from ..nbgraderformat import MetadataValidator
 from nbconvert.exporters.exporter import ResourcesDict
 from nbformat.notebooknode import NotebookNode
+from traitlets import Bool, Unicode
 from typing import Tuple, Any
+from textwrap import dedent
 
 
 class OverwriteCells(NbGraderPreprocessor):
     """A preprocessor to overwrite information about grade and solution cells."""
+
+    add_missing_cells = Bool(
+        False,
+        help=dedent(
+            """
+            Whether or not missing grade_cells should be added back
+            to the notebooks being graded.
+            """
+        ),
+    ).tag(config=True)
+
+    missing_cell_notification = Unicode(
+        "This cell (id:{cell_id}) was missing from the submission. " +
+        "It was added back by nbgrader.\n\n",  # Markdown requires two newlines
+        help=dedent(
+            """
+            A text to add at the beginning of every missing cell re-added to the notebook during autograding.
+            """
+        )
+    ).tag(config=True)
+
+    def missing_cell_transform(self, source_cell, max_score, is_solution=False, is_task=False):
+        """
+        Converts source_cell obtained from Gradebook into a cell that can be added to the notebook.
+        It is assumed that the cell is a grade_cell (unless is_task=True)
+        """
+
+        missing_cell_notification = self.missing_cell_notification.format(cell_id=source_cell.name)
+
+        cell = {
+            "cell_type": source_cell.cell_type,
+            "metadata": {
+                "deletable": False,
+                "editable": False,
+                "nbgrader": {
+                    "grade": True,
+                    "grade_id": source_cell.name,
+                    "locked": source_cell.locked,
+                    "checksum": source_cell.checksum,
+                    "cell_type": source_cell.cell_type,
+                    "points": max_score,
+                    "solution": False
+                }
+            },
+            "source": missing_cell_notification + source_cell.source
+        }
+
+        # Code cell format is slightly different
+        if cell["cell_type"] == "code":
+            cell["execution_count"] = None
+            cell["outputs"] = []
+            cell["source"] = "# " + cell["source"]  # make the notification we add a comment
+
+        # some grade cells are editable (manually graded answers)
+        if is_solution:
+            del cell["metadata"]["editable"]
+            cell["metadata"]["nbgrader"]["solution"] = True
+        # task cells are also a bit different
+        elif is_task:
+            cell["metadata"]["nbgrader"]["grade"] = False
+            cell["metadata"]["nbgrader"]["task"] = True
+            # this is when task cells were added so metadata validation should start from here
+            cell["metadata"]["nbgrader"]["schema_version"] = 3
+
+        cell = NotebookNode(cell)
+        cell = MetadataValidator().upgrade_cell_metadata(cell)
+        return cell
 
     def preprocess(self, nb: NotebookNode, resources: ResourcesDict) -> Tuple[NotebookNode, ResourcesDict]:
         # pull information from the resources
@@ -22,6 +92,77 @@ class OverwriteCells(NbGraderPreprocessor):
 
         with self.gradebook:
             nb, resources = super(OverwriteCells, self).preprocess(nb, resources)
+            if self.add_missing_cells:
+                nb, resources = self.add_missing_grade_cells(nb, resources)
+                nb, resources = self.add_missing_task_cells(nb, resources)
+
+        return nb, resources
+
+    def add_missing_grade_cells(self, nb: NotebookNode, resources: ResourcesDict) -> Tuple[NotebookNode, ResourcesDict]:
+        """
+        Add missing grade cells back to the notebook.
+        If missing, find the previous solution/grade cell, and add the current cell after it.
+        It is assumed such a cell exists because
+        presumably the grade_cell exists to grade some work in the solution cell.
+        """
+        source_nb = self.gradebook.find_notebook(self.notebook_id, self.assignment_id)
+        source_cells = source_nb.source_cells
+        source_cell_ids = [cell.name for cell in source_cells]
+        grade_cells = {cell.name: cell for cell in source_nb.grade_cells}
+        solution_cell_ids = [cell.name for cell in source_nb.solution_cells]
+
+        # track indices of solution and grade cells in the submitted notebook
+        submitted_cell_idxs = dict()
+        for idx, cell in enumerate(nb.cells):
+            if utils.is_grade(cell) or utils.is_solution(cell):
+                submitted_cell_idxs[cell.metadata.nbgrader["grade_id"]] = idx
+
+        # Every time we add a cell, the idxs above get shifted
+        # We could process the notebook backwards, but that makes adding the cells in the right place more difficult
+        # So we keep track of how many we have added so far
+        added_count = 0
+
+        for grade_cell_id, grade_cell in grade_cells.items():
+            # If missing, find the previous solution/grade cell, and add the current cell after it.
+            if grade_cell_id not in submitted_cell_idxs:
+                self.log.warning(f"Missing grade cell {grade_cell_id} encountered, adding to notebook")
+                source_cell_idx = source_cell_ids.index(grade_cell_id)
+                cell_to_add = source_cells[source_cell_idx]
+                cell_to_add = self.missing_cell_transform(cell_to_add, grade_cell.max_score,
+                                                          is_solution=grade_cell_id in solution_cell_ids)
+                # First cell was deleted, add it to start
+                if source_cell_idx == 0:
+                    nb.cells.insert(0, cell_to_add)
+                    submitted_cell_idxs[grade_cell_id] = 0
+                # Deleted cell is not the first, add it after the previous solution/grade cell
+                else:
+                    prev_cell_id = source_cell_ids[source_cell_idx - 1]
+                    prev_cell_idx = submitted_cell_idxs[prev_cell_id] + added_count
+                    nb.cells.insert(prev_cell_idx + 1, cell_to_add)  # +1 to add it after
+                    submitted_cell_idxs[grade_cell_id] = submitted_cell_idxs[prev_cell_id]
+
+                # If the cell we just added is followed by other missing cells, we need to know its index in the nb
+                # However, no need to add `added_count` to avoid double-counting
+
+                added_count += 1  # shift idxs
+
+        return nb, resources
+
+    def add_missing_task_cells(self, nb: NotebookNode, resources: ResourcesDict) -> Tuple[NotebookNode, ResourcesDict]:
+        """
+        Add missing task cells back to the notebook.
+        We can't figure out their original location, so they are added at the end, in their original order.
+        """
+        source_nb = self.gradebook.find_notebook(self.notebook_id, self.assignment_id)
+        source_cells = source_nb.source_cells
+        source_cell_ids = [cell.name for cell in source_cells]
+        submitted_ids = [cell["metadata"]["nbgrader"]["grade_id"] for cell in nb.cells if
+                         "nbgrader" in cell["metadata"]]
+        for task_cell in source_nb.task_cells:
+            if task_cell.name not in submitted_ids:
+                cell_to_add = source_cells[source_cell_ids.index(task_cell.name)]
+                cell_to_add = self.missing_cell_transform(cell_to_add, task_cell.max_score, is_task=True)
+                nb.cells.append(cell_to_add)
 
         return nb, resources
 


### PR DESCRIPTION
Add a new flag `OverwriteCells.add_missing_cells`, that, when set to `True`, compares the submitted notebook to the database before autograding and adds missing grade cells to (approximately) correct locations.

Fixes https://github.com/jupyter/nbgrader/issues/1682 (with the provided flag).

## Notes
- Missing grade cells are added immediately after the previous grade/solution cell, because presumably the notebook structure is repeated blocks of
```
question students should answer (solution cell)
test for the above (grade cell)
test for the above (grade cell)
...
```
- The above doesn't apply to manually graded answers, and currently I can't think of a good way to find their correct location based on the database
- Missing cells could be added based on the notebook in the `released/` directory, but there is no guarantee they are the same. Instructors can overwrite it, in which case the original notebook might not be recoverable. I am not sure if the database is completely safe, but it should be safer.

## To-dos
If this looks good, I will also
- [x] add tests
- [x] extend to restoring task cells as well ("Needs Manual Grade" behaves the same as [#1682](https://github.com/jupyter/nbgrader/issues/1682) if task cells are missing). 
- [x] Make the notification configurable?