### PR TITLE
Remove codecov test dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ docs = [
     "sphinx_rtd_theme",
 ]
 tests = [
-    "codecov",
     "coverage",
     "jupyter_packaging",
     "nbval",


### PR DESCRIPTION
The [python package](https://github.com/codecov/codecov-python) seems to be deprecated. The badge was removed in https://github.com/jupyter/nbgrader/pull/1741, so I am not sure if this is useful until the badge is added back anyway.