### PR TITLE
Upgrade to sqlalchemy>=2

### DIFF
--- a/nbgrader/alembic/versions/167914646830_added_task_cells.py
+++ b/nbgrader/alembic/versions/167914646830_added_task_cells.py
@@ -79,13 +79,13 @@ def upgrade():
     )
 
     connection = op.get_bind()
-    results = connection.execute(sa.select([
+    results = connection.execute(sa.select(
         old_grade_table.c.name,
         old_grade_table.c.id,
         old_grade_table.c.cell_type,
         old_grade_table.c.notebook_id,
         old_grade_table.c.max_score
-        ])).fetchall()
+        )).fetchall()
 
     # copy info to the base_cell table
     base_grade_cells = [
@@ -109,11 +109,11 @@ def upgrade():
     op.bulk_insert(new_grade_table, grade_cells)
 
     # now transfer the solution cells...
-    results = connection.execute(sa.select([
+    results = connection.execute(sa.select(
         old_solution_table.c.name,
         old_solution_table.c.id,
         old_solution_table.c.notebook_id,
-        ])).fetchall()
+        )).fetchall()
 
     # copy info to the base_cell table
     base_solution_cells = [

--- a/nbgrader/alembic/versions/e43177bfe90b_added_course_table_and_relationships.py
+++ b/nbgrader/alembic/versions/e43177bfe90b_added_course_table_and_relationships.py
@@ -42,13 +42,14 @@ def upgrade():
 
     # If the course table is empty, create a default course
     connection = op.get_bind()
-    res = connection.execute("select id from course")
+    res = connection.execute(sa.text("select id from course"))
     results = res.fetchall()
     default_course = "default_course"
 
     if len(results) == 0:
         connection.execute(
-            "INSERT INTO course (id) VALUES ('{}')".format(default_course))
+            sa.text("INSERT INTO course (id) VALUES ('{}')".format(default_course))
+        )
 
     with op.batch_alter_table("assignment") as batch_op:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "python-dateutil>=2.8",
     "rapidfuzz>=1.8",
     "requests>=2.26",
-    "sqlalchemy>=1.4,<2",
+    "sqlalchemy>=1.4,<3",
     "traitlets>5.0,<6",
 ]
 version = "0.8.3"


### PR DESCRIPTION
Most of the required changes so far were fairly innocent.

One of the warnings when running on `sqlalchemy<2` was [this one](https://docs.sqlalchemy.org/en/14/changelog/migration_14.html#change-5150) about changing cascade_backref behavior. It is still a bit unclear to me what consequences this change might have, but tests were passing on `sqlalchemy<2` with using `future=True` in `Session` and `Engine`, and they are passing now. 