### PR TITLE
Pin sphinx<7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ dev = [
 ]
 docs = [
     "myst-parser",
-    "sphinx",
+    "sphinx<7",
     "sphinx-autodoc-typehints",
     "sphinx_rtd_theme",
 ]


### PR DESCRIPTION
Pins `sphinx<7` in *docs* dependencies, `sphinx-rtd-theme` is not compatible with it yet:
https://github.com/readthedocs/readthedocs.org/issues/10279