### PR TITLE
Revert change breaking sqlalchemy 1.4.x

### DIFF
--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -9,7 +9,7 @@ from sqlalchemy import (create_engine, ForeignKey, Column, String, Text,
                         DateTime, Interval, Float, Enum, UniqueConstraint,
                         Boolean, inspect, text)
 from sqlalchemy.orm import (sessionmaker, scoped_session, relationship,
-                            column_property, DeclarativeBase)
+                            column_property, declarative_base)
 from sqlalchemy.orm.exc import NoResultFound, FlushError
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.exc import IntegrityError, StatementError
@@ -25,8 +25,7 @@ from typing import List, Any, Optional, Union
 from .auth import Authenticator
 
 
-class Base(DeclarativeBase):
-    pass
+Base = declarative_base()
 
 
 def new_uuid() -> str:


### PR DESCRIPTION
#1788 had a change that broke compatibility with `sqlalchemy==1.4.x`, noticed in #1796. This pr reverts that change.

All nbgrader python tests pass in both `1.4.x` and `2`.