### PR TITLE
Fix formgrader link from course_list

### DIFF
--- a/nbgrader/server_extensions/course_list/handlers.py
+++ b/nbgrader/server_extensions/course_list/handlers.py
@@ -79,7 +79,7 @@ class CourseListHandler(JupyterHandler):
         if status:
             raise gen.Return([{
                 'course_id': coursedir.course_id,
-                'url': base_url + '/lab',
+                'url': base_url + '/formgrader',
                 'kind': 'local'
             }])
 

--- a/nbgrader/server_extensions/course_list/handlers.py
+++ b/nbgrader/server_extensions/course_list/handlers.py
@@ -113,7 +113,7 @@ class CourseListHandler(JupyterHandler):
 
         courses = [{
             'course_id': coursedir.course_id,
-            'url': url + "/lab",
+            'url': url + "/lab?formgrader=true",
             'kind': 'jupyterhub'
         }]
         raise gen.Return(courses)
@@ -156,7 +156,7 @@ class CourseListHandler(JupyterHandler):
             service = services[course]
             courses.append({
                 'course_id': course,
-                'url': self.get_base_url() + service['prefix'].rstrip('/') + "/lab",
+                'url': self.get_base_url() + service['prefix'].rstrip('/') + "/lab?formgrader=true",
                 'kind': 'jupyterhub'
             })
 

--- a/src/course_list/courselist.ts
+++ b/src/course_list/courselist.ts
@@ -62,7 +62,7 @@ function createElementFromCourse(data: any, app: JupyterFrontEnd, isNotebook:boo
     } else {
       const url = data['url'] as string;
       if (isNotebook) {
-        anchor.href = URLExt.join(url.replace(/lab\/?$/, 'tree'));
+        anchor.href = url.replace(/\/lab(\/|\?)?/, '/tree$1');
       } else {
         anchor.href = url
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { ILabShell, ILayoutRestorer, JupyterFrontEnd, JupyterFrontEndPlugin } from "@jupyterlab/application";
+import { ILabShell, ILayoutRestorer, IRouter, JupyterFrontEnd, JupyterFrontEndPlugin } from "@jupyterlab/application";
 import { ICommandPalette, MainAreaWidget, WidgetTracker } from "@jupyterlab/apputils";
 import { PageConfig, URLExt } from "@jupyterlab/coreutils";
 import { IMainMenu } from '@jupyterlab/mainmenu';
@@ -239,11 +239,12 @@ const courseListExtension: JupyterFrontEndPlugin<void> = {
 const formgraderExtension: JupyterFrontEndPlugin<void> = {
   id: pluginIDs.formgrader,
   autoStart: true,
-  optional: [ILayoutRestorer, INotebookTree],
+  optional: [ILayoutRestorer, INotebookTree, IRouter],
   activate: (
     app: JupyterFrontEnd,
     restorer: ILayoutRestorer | null,
-    notebookTree: INotebookTree | null
+    notebookTree: INotebookTree | null,
+    router: IRouter | null
   ) => {
     // Declare a widget variable
     let widget: MainAreaWidget<FormgraderWidget>;
@@ -288,6 +289,15 @@ const formgraderExtension: JupyterFrontEndPlugin<void> = {
         app.shell.activateById(widget.id);
       }
     });
+
+    // Open formgrader from URL.
+    if (router) {
+      const formgraderPattern = /(\?|&)formgrader=true/;
+      router.register({
+        command: commandIDs.openFormgrader,
+        pattern: formgraderPattern
+      });
+    }
 
     // Restore the widget state
     if (restorer != null){

--- a/src/index.ts
+++ b/src/index.ts
@@ -178,7 +178,6 @@ const courseListExtension: JupyterFrontEndPlugin<void> = {
   id: pluginIDs.coursesList,
   autoStart: true,
   optional: [ILayoutRestorer, INotebookTree],
-
   activate: (
     app: JupyterFrontEnd,
     restorer: ILayoutRestorer | null,


### PR DESCRIPTION
This PR fixes https://github.com/jupyter/nbgrader/issues/1829

It also adds a new option to open the *formgrader* panel from the URL search param (`formgrader=true`).
Which is useful when opening a new nbgrader service with jupyterhub, to redirect automatically to the formgrader panel