### PR TITLE
Add a dependency to setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "python-dateutil>=2.8",
     "rapidfuzz>=1.8",
     "requests>=2.26",
+    "setuptools",
     "sqlalchemy>=1.4,<3",
     "PyYAML>=6.0",
 ]


### PR DESCRIPTION
Fix https://github.com/jupyter/nbgrader/issues/1838

This PR adds a dependency to *setuptools*.

*setuptools* should normally be installed as a dependency of *babel*, itself a dependency of *jupyterlab_server*.

Nevertheless, it seems that some version of babel do not have this explicit dependency (e.g. `babel==2.10`), which can lead to instable installation of *nbgrader*.
