### PR TITLE
Remove use of deprecated typing.io

### DIFF
--- a/nbgrader/nbgraderformat/v1.py
+++ b/nbgrader/nbgraderformat/v1.py
@@ -116,13 +116,13 @@ class MetadataValidatorV1(BaseMetadataValidator):
             ids.add(grade_id)
 
 
-def read_v1(source: typing.io.TextIO, as_version: int, **kwargs: typing.Any) -> NotebookNode:
+def read_v1(source: typing.TextIO, as_version: int, **kwargs: typing.Any) -> NotebookNode:
     nb = _read(source, as_version, **kwargs)
     MetadataValidatorV1().validate_nb(nb)
     return nb
 
 
-def write_v1(nb: NotebookNode, fp: typing.io.TextIO, **kwargs: typing.Any) -> None:
+def write_v1(nb: NotebookNode, fp: typing.TextIO, **kwargs: typing.Any) -> None:
     MetadataValidatorV1().validate_nb(nb)
     _write(nb, fp, **kwargs)
 

--- a/nbgrader/nbgraderformat/v2.py
+++ b/nbgrader/nbgraderformat/v2.py
@@ -105,13 +105,13 @@ class MetadataValidatorV2(BaseMetadataValidator):
             ids.add(grade_id)
 
 
-def read_v2(source: typing.io.TextIO, as_version: int, **kwargs: typing.Any) -> NotebookNode:
+def read_v2(source: typing.TextIO, as_version: int, **kwargs: typing.Any) -> NotebookNode:
     nb = _read(source, as_version, **kwargs)
     MetadataValidatorV2().validate_nb(nb)
     return nb
 
 
-def write_v2(nb: NotebookNode, fp: typing.io.TextIO, **kwargs: typing.Any) -> None:
+def write_v2(nb: NotebookNode, fp: typing.TextIO, **kwargs: typing.Any) -> None:
     MetadataValidatorV2().validate_nb(nb)
     _write(nb, fp, **kwargs)
 

--- a/nbgrader/nbgraderformat/v3.py
+++ b/nbgrader/nbgraderformat/v3.py
@@ -111,13 +111,13 @@ class MetadataValidatorV3(BaseMetadataValidator):
             ids.add(grade_id)
 
 
-def read_v3(source: typing.io.TextIO, as_version: int, **kwargs: typing.Any) -> NotebookNode:
+def read_v3(source: typing.TextIO, as_version: int, **kwargs: typing.Any) -> NotebookNode:
     nb = _read(source, as_version, **kwargs)
     MetadataValidatorV3().validate_nb(nb)
     return nb
 
 
-def write_v3(nb: NotebookNode, fp: typing.io.TextIO, **kwargs: typing.Any) -> None:
+def write_v3(nb: NotebookNode, fp: typing.TextIO, **kwargs: typing.Any) -> None:
     MetadataValidatorV3().validate_nb(nb)
     _write(nb, fp, **kwargs)
 


### PR DESCRIPTION
The typing.io namespace was deprecated in python 3.8, which is the lowest version currently supported by nbgrader.

https://docs.python.org/3/library/typing.html#aliases-to-other-concrete-types