### PR TITLE
Open formgrader with a local configuration file

### DIFF
--- a/nbgrader/apps/baseapp.py
+++ b/nbgrader/apps/baseapp.py
@@ -316,7 +316,10 @@ class NbGrader(JupyterApp):
     def initialize(self, argv: TypingList[str] = None, root: str = '') -> None:
         self.update_config(self.build_extra_config())
         self.init_syspath()
-        self.coursedir = CourseDirectory(parent=self, root=root)
+        if root:
+            self.coursedir = CourseDirectory(parent=self, root=root)
+        else:
+            self.coursedir = CourseDirectory(parent=self)
         super(NbGrader, self).initialize(argv)
 
         # load config that is in the coursedir directory

--- a/nbgrader/apps/baseapp.py
+++ b/nbgrader/apps/baseapp.py
@@ -64,6 +64,8 @@ class NbGrader(JupyterApp):
     aliases = nbgrader_aliases
     flags = nbgrader_flags
 
+    load_cwd_config = True
+
     _log_formatter_cls = LogFormatter
 
     @default("log_level")
@@ -358,7 +360,8 @@ class NbGrader(JupyterApp):
             paths = [os.path.abspath("{}.py".format(self.config_file))]
         else:
             config_dir = self.config_file_paths.copy()
-            config_dir.insert(0, os.getcwd())
+            if self.load_cwd_config:
+                config_dir.insert(0, os.getcwd())
             paths = [os.path.join(x, "{}.py".format(self.config_file_name)) for x in config_dir]
 
         if not any(os.path.exists(x) for x in paths):
@@ -366,8 +369,9 @@ class NbGrader(JupyterApp):
 
         super(NbGrader, self).load_config_file(**kwargs)
 
-        # Load also config from current working directory
-        super(JupyterApp, self).load_config_file(self.config_file_name, os.getcwd())
+        if (self.load_cwd_config):
+            # Load also config from current working directory
+            super(JupyterApp, self).load_config_file(self.config_file_name, os.getcwd())
 
     def start(self) -> None:
         super(NbGrader, self).start()

--- a/nbgrader/apps/baseapp.py
+++ b/nbgrader/apps/baseapp.py
@@ -313,10 +313,10 @@ class NbGrader(JupyterApp):
         format_excepthook(etype, evalue, tb)
 
     @catch_config_error
-    def initialize(self, argv: TypingList[str] = None) -> None:
+    def initialize(self, argv: TypingList[str] = None, root: str = '') -> None:
         self.update_config(self.build_extra_config())
         self.init_syspath()
-        self.coursedir = CourseDirectory(parent=self)
+        self.coursedir = CourseDirectory(parent=self, root=root)
         super(NbGrader, self).initialize(argv)
 
         # load config that is in the coursedir directory

--- a/nbgrader/docs/source/build_docs.py
+++ b/nbgrader/docs/source/build_docs.py
@@ -5,6 +5,7 @@ import re
 import shutil
 import sys
 import nbgrader.apps
+import nbgrader.server_extensions.formgrader
 
 from textwrap import dedent
 from clear_docs import run, clear_notebooks
@@ -92,6 +93,7 @@ def autogen_config(root):
 
     print('Generating example configuration file')
     config = nbgrader.apps.NbGraderApp().document_config_options()
+    config += nbgrader.server_extensions.formgrader.formgrader.FormgradeExtension().document_config_options()
     destination = os.path.join(root, 'configuration', 'config_options.rst')
     with open(destination, 'w') as f:
         f.write(header)

--- a/nbgrader/docs/source/configuration/nbgrader_config.rst
+++ b/nbgrader/docs/source/configuration/nbgrader_config.rst
@@ -70,9 +70,9 @@ Use Case 3: using config from a specific sub directory
 
 .. warning::
 
-    This option should not be used with a JupyterHub installation, as it modifies
+    This option should not be used with a multiuser Jupyterlab instance, as it modifies
     certain objects in the running instance, and can probably prevent other users
-    from using *formgrader* correctly. If you have a JupyterHub installation,
+    from using *formgrader* correctly. Also, if you have a JupyterHub installation,
     you should use the settings described in the following section.
 
 You may need to use a dedicated configuration file for each course without configuring

--- a/nbgrader/docs/source/configuration/nbgrader_config.rst
+++ b/nbgrader/docs/source/configuration/nbgrader_config.rst
@@ -65,8 +65,34 @@ For example, the ``nbgrader_config.py`` that the notebook knows about could be p
 
 Then you would additionally have a config file at ``/path/to/course/directory/nbgrader_config.py``.
 
+Use Case 3: using config from a specific sub directory
+------------------------------------------------------
 
-Use Case 3: nbgrader and JupyterHub
+.. warning::
+
+    This option should not be used with a JupyterHub installation, as it modifies
+    certain objects in the running instance, and can probably prevent other users
+    from using *formgrader* correctly. If you have a JupyterHub installation,
+    you should use the settings described in the following section.
+
+You may need to use a dedicated configuration file for each course without configuring
+JupyterHub for all courses. In this case, the config file used will be the one from the
+current directory in the filebrowser panel, instead of the one from the directory where
+the jupyter server started.
+
+This option is not enabled by default. It can be enabled by using the settings panel:
+*Nbgrader -> Formgrader* and check *Allow local nbgrader config file*.
+
+A new item is displayed in the *nbgrader* menu (or in the command palette), to open
+formgrader from the local director: *Formgrader (local)*.
+
+.. warning::
+
+    If paths are used in the configuration file, note that the root of the relative
+    paths will always be the directory where the jupyter server was started, and not
+    the directory containing the ``nbgrader_config.py`` file.
+
+Use Case 4: nbgrader and JupyterHub
 -----------------------------------
 
 .. seealso::

--- a/nbgrader/server_extensions/formgrader/base.py
+++ b/nbgrader/server_extensions/formgrader/base.py
@@ -16,7 +16,7 @@ class BaseHandler(JupyterHandler):
 
     @property
     def db_url(self):
-        return self.settings['nbgrader_coursedir'].db_url
+        return self.coursedir.db_url
 
     @property
     def url_prefix(self):
@@ -24,7 +24,7 @@ class BaseHandler(JupyterHandler):
 
     @property
     def coursedir(self):
-        return self.settings['nbgrader_coursedir']
+        return self.settings['nbgrader_formgrader'].coursedir
 
     @property
     def authenticator(self):

--- a/nbgrader/server_extensions/formgrader/formgrader.py
+++ b/nbgrader/server_extensions/formgrader/formgrader.py
@@ -1,13 +1,13 @@
 # coding: utf-8
 
 import os
+from textwrap import dedent
 
 from nbconvert.exporters import HTMLExporter
-from traitlets import default
+from traitlets import Bool, default
 from tornado import web
 from jinja2 import Environment, FileSystemLoader
 from jupyter_server.utils import url_path_join as ujoin
-from jupyter_core.paths import jupyter_config_path
 
 from . import handlers, apihandlers
 from ...apps.baseapp import NbGrader
@@ -17,6 +17,17 @@ class FormgradeExtension(NbGrader):
 
     name = u'formgrade'
     description = u'Grade a notebook using an HTML form'
+
+    debug = Bool(
+        False,
+        help=dedent(
+            """
+            Whether to display the loaded configuration in the 'Formgrader ->
+            Manage Assignments' panel. This can help debugging some misconfiguration
+            when using several files.
+            """
+        )
+    ).tag(config=True)
 
     @property
     def root_dir(self):

--- a/nbgrader/server_extensions/formgrader/formgrader.py
+++ b/nbgrader/server_extensions/formgrader/formgrader.py
@@ -19,7 +19,7 @@ class FormgradeExtension(NbGrader):
     description = u'Grade a notebook using an HTML form'
 
     debug = Bool(
-        False,
+        True,
         help=dedent(
             """
             Whether to display the loaded configuration in the 'Formgrader ->

--- a/nbgrader/server_extensions/formgrader/formgrader.py
+++ b/nbgrader/server_extensions/formgrader/formgrader.py
@@ -45,6 +45,7 @@ class FormgradeExtension(NbGrader):
 
     def load_config(self):
         app = NbGrader()
+        app.load_cwd_config = self.load_cwd_config
         app.config_dir = self.config_dir
         app.load_config_file()
 

--- a/nbgrader/server_extensions/formgrader/formgrader.py
+++ b/nbgrader/server_extensions/formgrader/formgrader.py
@@ -33,10 +33,8 @@ class FormgradeExtension(NbGrader):
         return relpath
 
     def load_config(self):
-        paths = jupyter_config_path()
-        paths.insert(0, os.getcwd())
         app = NbGrader()
-        app.config_file_paths.append(paths)
+        app.config_dir = self.config_dir
         app.load_config_file()
 
         return app.config
@@ -72,7 +70,6 @@ class FormgradeExtension(NbGrader):
         # Configure the formgrader settings
         tornado_settings = dict(
             nbgrader_formgrader=self,
-            nbgrader_coursedir=self.coursedir,
             nbgrader_authenticator=self.authenticator,
             nbgrader_exporter=HTMLExporter(config=self.config),
             nbgrader_gradebook=None,

--- a/nbgrader/server_extensions/formgrader/formgrader.py
+++ b/nbgrader/server_extensions/formgrader/formgrader.py
@@ -75,7 +75,8 @@ class FormgradeExtension(NbGrader):
             nbgrader_gradebook=None,
             nbgrader_db_url=self.coursedir.db_url,
             nbgrader_jinja2_env=jinja_env,
-            nbgrader_bad_setup=nbgrader_bad_setup
+            nbgrader_bad_setup=nbgrader_bad_setup,
+            initial_config=self.config
         )
 
         webapp.settings.update(tornado_settings)

--- a/nbgrader/server_extensions/formgrader/handlers.py
+++ b/nbgrader/server_extensions/formgrader/handlers.py
@@ -1,6 +1,7 @@
 import os
 import re
 import sys
+import json
 
 from tornado import web
 from jupyter_core.paths import jupyter_config_dir
@@ -35,6 +36,15 @@ class ManageAssignmentsHandler(BaseHandler):
     @check_xsrf
     @check_notebook_dir
     def get(self):
+        formgrader = self.settings['nbgrader_formgrader']
+        current_config = {}
+        if formgrader.debug:
+            try:
+                current_config = json.dumps(formgrader.config, indent=2)
+            except TypeError:
+                current_config = formgrader.config
+                self.log.warn("Formgrader config is not serializable")
+
         api = self.api
         html = self.render(
             "manage_assignments.tpl",
@@ -43,7 +53,8 @@ class ManageAssignmentsHandler(BaseHandler):
             windows=(sys.prefix == 'win32'),
             course_id=api.course_id,
             exchange=api.exchange_root,
-            exchange_missing=api.exchange_missing)
+            exchange_missing=api.exchange_missing,
+            current_config= current_config)
         self.write(html)
 
 

--- a/nbgrader/server_extensions/formgrader/handlers.py
+++ b/nbgrader/server_extensions/formgrader/handlers.py
@@ -20,6 +20,7 @@ class FormgraderHandler(BaseHandler):
         path = self.get_argument('path', '')
         if path:
             path = os.path.abspath(path)
+            formgrader.load_cwd_config = False
             formgrader.config = Config()
             formgrader.config_dir = path
             formgrader.initialize([], root=path)
@@ -28,6 +29,7 @@ class FormgraderHandler(BaseHandler):
                 formgrader.config = self.settings['initial_config']
                 formgrader.config_dir = jupyter_config_dir()
                 formgrader.initialize([])
+            formgrader.load_cwd_config = True
         self.redirect(f"{self.base_url}/formgrader/manage_assignments/")
 
 

--- a/nbgrader/server_extensions/formgrader/handlers.py
+++ b/nbgrader/server_extensions/formgrader/handlers.py
@@ -8,19 +8,34 @@ from .base import BaseHandler, check_xsrf, check_notebook_dir
 from ...api import MissingEntry
 
 
+class FormgraderHandler(BaseHandler):
+    @web.authenticated
+    @check_xsrf
+    @check_notebook_dir
+    def get(self):
+        formgrader = self.settings['nbgrader_formgrader']
+        path = self.get_argument('path', os.getcwd())
+        path = os.path.abspath(path)
+        formgrader.config_dir = path
+        formgrader.load_config_file()
+        formgrader.initialize([], root=path)
+        self.redirect('/formgrader/manage_assignments/')
+
+
 class ManageAssignmentsHandler(BaseHandler):
     @web.authenticated
     @check_xsrf
     @check_notebook_dir
     def get(self):
+        api = self.api
         html = self.render(
             "manage_assignments.tpl",
             url_prefix=self.url_prefix,
             base_url=self.base_url,
             windows=(sys.prefix == 'win32'),
-            course_id=self.api.course_id,
-            exchange=self.api.exchange_root,
-            exchange_missing=self.api.exchange_missing)
+            course_id=api.course_id,
+            exchange=api.exchange_root,
+            exchange_missing=api.exchange_missing)
         self.write(html)
 
 
@@ -282,7 +297,7 @@ fonts_path = os.path.join(components_path, 'bootstrap', 'fonts')
 _navigation_regex = r"(?P<action>next_incorrect|prev_incorrect|next|prev)"
 
 default_handlers = [
-    (r"/formgrader/?", ManageAssignmentsHandler),
+    (r"/formgrader/?", FormgraderHandler),
     (r"/formgrader/manage_assignments/?", ManageAssignmentsHandler),
     (r"/formgrader/manage_submissions/([^/]+)/?", ManageSubmissionsHandler),
 

--- a/nbgrader/server_extensions/formgrader/handlers.py
+++ b/nbgrader/server_extensions/formgrader/handlers.py
@@ -3,6 +3,7 @@ import re
 import sys
 
 from tornado import web
+from traitlets.config.loader import Config
 
 from .base import BaseHandler, check_xsrf, check_notebook_dir
 from ...api import MissingEntry
@@ -16,8 +17,8 @@ class FormgraderHandler(BaseHandler):
         formgrader = self.settings['nbgrader_formgrader']
         path = self.get_argument('path', os.getcwd())
         path = os.path.abspath(path)
+        formgrader.config = Config()
         formgrader.config_dir = path
-        formgrader.load_config_file()
         formgrader.initialize([], root=path)
         self.redirect('/formgrader/manage_assignments/')
 

--- a/nbgrader/server_extensions/formgrader/handlers.py
+++ b/nbgrader/server_extensions/formgrader/handlers.py
@@ -30,7 +30,7 @@ class FormgraderHandler(BaseHandler):
                 formgrader.config_dir = jupyter_config_dir()
                 formgrader.initialize([])
             formgrader.load_cwd_config = True
-        self.redirect(f"{self.base_url}/formgrader/manage_assignments/")
+        self.redirect(f"{self.base_url}/formgrader/manage_assignments")
 
 
 class ManageAssignmentsHandler(BaseHandler):

--- a/nbgrader/server_extensions/formgrader/handlers.py
+++ b/nbgrader/server_extensions/formgrader/handlers.py
@@ -3,6 +3,7 @@ import re
 import sys
 
 from tornado import web
+from jupyter_core.paths import jupyter_config_dir
 from traitlets.config.loader import Config
 
 from .base import BaseHandler, check_xsrf, check_notebook_dir
@@ -15,12 +16,18 @@ class FormgraderHandler(BaseHandler):
     @check_notebook_dir
     def get(self):
         formgrader = self.settings['nbgrader_formgrader']
-        path = self.get_argument('path', os.getcwd())
-        path = os.path.abspath(path)
-        formgrader.config = Config()
-        formgrader.config_dir = path
-        formgrader.initialize([], root=path)
-        self.redirect('/formgrader/manage_assignments/')
+        path = self.get_argument('path', '')
+        if path:
+            path = os.path.abspath(path)
+            formgrader.config = Config()
+            formgrader.config_dir = path
+            formgrader.initialize([], root=path)
+        else:
+            if formgrader.config != self.settings['initial_config']:
+                formgrader.config = self.settings['initial_config']
+                formgrader.config_dir = jupyter_config_dir()
+                formgrader.initialize([])
+        self.redirect(f"{self.base_url}/formgrader/manage_assignments/")
 
 
 class ManageAssignmentsHandler(BaseHandler):

--- a/nbgrader/server_extensions/formgrader/templates/manage_assignments.tpl
+++ b/nbgrader/server_extensions/formgrader/templates/manage_assignments.tpl
@@ -55,6 +55,22 @@ Manage Assignments
     </div>
   </div>
 </div>
+{% if current_config %}
+<div class="panel-group" id="config" role="tablist" aria-multiselectable="true">
+  <div class="panel panel-default">
+    <div class="panel-heading" role="tab" id="headingConfig">
+      <h4 class="panel-title">
+        <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseConfig" aria-expanded="false" aria-controls="collapseConfig">
+          Current configuration (click to expand)
+        </a>
+      </h4>
+    </div>
+    <div id="collapseConfig" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingConfig">
+      <pre class="panel-body">{{ current_config }}</pre>
+    </div>
+  </div>
+</div>
+{% endif %}
 {% if windows %}
 <div class="alert alert-warning" id="warning-windows">
 Windows operating system detected. Please note that the "release" and "collect"

--- a/nbgrader/tests/ui-tests/formgrader.spec.ts
+++ b/nbgrader/tests/ui-tests/formgrader.spec.ts
@@ -888,7 +888,6 @@ test("Switch views", async ({ page, baseURL, request, tmpPath }) => {
  */
 test.describe('#localFormgrader', () => {
   test("Should have formgrader settings", async ({ page, tmpPath }) => {
-    test.skip(isWindows, "This test does not work on Windows");
 
     if (isNotebook) await page.goto(`tree/${tmpPath}`);
 
@@ -944,6 +943,7 @@ test.describe('#localFormgrader', () => {
   });
 
   test('should open formgrader locally', async ({ page, tmpPath }) => {
+    test.skip(isWindows, "This test does not work on Windows");
     if (isNotebook) await page.goto(`tree/${tmpPath}`);
 
     const nbgraderMenu = page.locator(

--- a/nbgrader/tests/ui-tests/formgrader.spec.ts
+++ b/nbgrader/tests/ui-tests/formgrader.spec.ts
@@ -353,7 +353,7 @@ test("Load manage assignments", async ({ page, baseURL, request, tmpPath }) => {
   const iframe = page.mainFrame().childFrames()[0];
 
   await checkFormgraderBreadcrumbs(iframe, ["Assignments"]);
-  expect(iframe.url()).toBe(encodeURI(`${baseURL}/formgrader`));
+  expect(iframe.url()).toBe(encodeURI(`${baseURL}/formgrader/manage_assignments`));
 
   // expect the current path in tree tab to be the tmpPath.
   await switchTab(page, 'Files');

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@jupyterlab/cells": "^4.2.0",
     "@jupyterlab/coreutils": "^6.2.0",
     "@jupyterlab/docregistry": "^4.2.0",
+    "@jupyterlab/filebrowser": "^4.2.0",
     "@jupyterlab/mainmenu": "^4.2.0",
     "@jupyterlab/nbformat": "^4.2.0",
     "@jupyterlab/notebook": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
       }
     },
     "extension": true,
-    "outputDir": "nbgrader/labextension"
+    "outputDir": "nbgrader/labextension",
+    "schemaDir": "schema"
   }
 }

--- a/schema/formgrader.json
+++ b/schema/formgrader.json
@@ -1,0 +1,14 @@
+{
+  "title": "Nbgrader -> Formgrader",
+  "description": "Option of the formgrader extension.",
+  "properties": {
+    "local_config": {
+      "type": "boolean",
+      "title": "Allow local nbgrader config file",
+      "description": "This setting allow the use of a local config file for formgrader.",
+      "default": false
+    }
+  },
+  "additionalProperties": false,
+  "type": "object"
+}

--- a/schema/formgrader.json
+++ b/schema/formgrader.json
@@ -5,7 +5,7 @@
     "local_config": {
       "type": "boolean",
       "title": "Allow local nbgrader config file",
-      "description": "This setting allow the use of a local config file for formgrader.",
+      "description": "This setting allows the use of a local config file for formgrader.\nWARNING: using the local configuration file has consequences for the server, it should not be used if several users are using the same instance of Jupyterlab.",
       "default": false
     }
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -504,6 +504,7 @@ __metadata:
     "@jupyterlab/cells": ^4.2.0
     "@jupyterlab/coreutils": ^6.2.0
     "@jupyterlab/docregistry": ^4.2.0
+    "@jupyterlab/filebrowser": ^4.2.0
     "@jupyterlab/galata": ^5.2.0
     "@jupyterlab/mainmenu": ^4.2.0
     "@jupyterlab/nbformat": ^4.2.0
@@ -936,7 +937,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/filebrowser@npm:^4.2.2, @jupyterlab/filebrowser@npm:~4.2.0":
+"@jupyterlab/filebrowser@npm:^4.2.0, @jupyterlab/filebrowser@npm:^4.2.2, @jupyterlab/filebrowser@npm:~4.2.0":
   version: 4.2.2
   resolution: "@jupyterlab/filebrowser@npm:4.2.2"
   dependencies:


### PR DESCRIPTION
This PR aims to open formgrader with a configuration file (*nbgrader_config.py*) from the local directory.

Currently, the formgrader loads the *nbgrader_config.py* files from:
- the directories in `jupyter_config_path`
- the directory where Jupyter lab started: `os.cwd()`
- the directory `CourseDirectory.root` (which can be configured by one of the previous files)

With this PR, it will be possible to start the Formgrader with a config file in the curent directory in lab filebrowser, by using the new menu entry *Formgrader (local)*.
It will reinitialize the `FormgradeExtension` object with the additional configuration of the current directory.
In this case, the configuration file existing in the root directory of Jupyter lab app will not been loaded.

Using the classic menu entry `Formgrader` will restore the `FormgradeExtension` object with the initial configuration.

This feature is not enabled by default, and must be set by user in settings panel (or user settings file):

![Peek 2024-01-26 11-38](https://github.com/jupyter/nbgrader/assets/32258950/a598b9d1-6d65-4727-b6d0-55c7b1abbe7d)

This PR also adds a command line configuration to display the current config in the formgrader UI: `--FormgradeExtension.debug=true`.
This can be helpful to test this PR (at least).

<img src=https://github.com/jupyter/nbgrader/assets/32258950/2a3fb640-c2f9-4f56-bdba-fef57362182e width=500px>

I tested it on a local jupyterlab server and using jupyterhub in docker (demo multiple classes), but I think **it must be tested in some real environments** to ensure it does not break any existing behavior.

** CAUTION ** 
- it is probably not usable if several users access the same jupyterlab server, as it modifies the `FormgradeExtension` object on the server.
- if one of the config file provides a `CourseDirectory.root` configuration (which is the case on jupyterhub AFAIK), this parameter must be overwritten in the local config file. This is intentional, we don't silently remove certain parameters from the loaded files, we just change the files that are loaded.

cc. @nthiery 