### PR TITLE
Fix autograde for students with backslash in their ID

### DIFF
--- a/nbgrader/server_extensions/formgrader/static/js/manage_submissions.js
+++ b/nbgrader/server_extensions/formgrader/static/js/manage_submissions.js
@@ -135,7 +135,8 @@ var SubmissionUI = Backbone.View.extend({
         this.$student_name.text("Please wait...");
         var student = this.model.get("student");
         var assignment = this.model.get("name");
-        $.post(base_url + "/formgrader/api/submission/" + assignment + "/" + student + "/autograde")
+        var encodedURI = encodeURI(base_url + "/formgrader/api/submission/" + assignment + "/" + student + "/autograde")
+        $.post(encodedURI)
             .done(_.bind(this.autograde_success, this))
             .fail(_.bind(this.autograde_failure, this));
     },

--- a/nbgrader/tests/apps/test_nbgrader_autograde.py
+++ b/nbgrader/tests/apps/test_nbgrader_autograde.py
@@ -57,18 +57,22 @@ class TestNbGraderAutograde(BaseTestApp):
         run_nbgrader(["db", "assignment", "add", "ps1", "--db", db, "--duedate", "2015-02-02 14:58:23.948203 America/Los_Angeles"])
         run_nbgrader(["db", "student", "add", "foo", "--db", db])
         run_nbgrader(["db", "student", "add", "bar", "--db", db])
+        run_nbgrader(["db", "student", "add", "\student", "--db", db])
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
         run_nbgrader(["generate_assignment", "ps1", "--db", db])
 
         self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
         self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "bar", "ps1", "p1.ipynb"))
+        self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "\student", "ps1", "p1.ipynb"))
         run_nbgrader(["autograde", "ps1", "--db", db])
 
         assert os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "p1.ipynb"))
         assert not os.path.isfile(join(course_dir, "autograded", "foo", "ps1", "timestamp.txt"))
         assert os.path.isfile(join(course_dir, "autograded", "bar", "ps1", "p1.ipynb"))
         assert not os.path.isfile(join(course_dir, "autograded", "bar", "ps1", "timestamp.txt"))
+        assert os.path.isfile(join(course_dir, "autograded", "\student", "ps1", "p1.ipynb"))
+        assert not os.path.isfile(join(course_dir, "autograded", "\student", "ps1", "timestamp.txt"))
 
         with Gradebook(db) as gb:
             notebook = gb.find_submission_notebook("p1", "ps1", "foo")


### PR DESCRIPTION
Currently, using autograde on a student with a backslash in their student id raises an error. Backslashes were not encoded properly and appeared as forward slashes in the post request.

This pr aims to fix #912 by encoding the full api call.