### PR TITLE
Fixed LaTeX rendering in some demo notebooks

### DIFF
--- a/nbgrader/docs/source/user_guide/autograded/bitdiddle/ps1/problem1.ipynb
+++ b/nbgrader/docs/source/user_guide/autograded/bitdiddle/ps1/problem1.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Before you turn this problem in, make sure everything runs as expected. First, **restart the kernel** (in the menubar, select Kernel$\\rightarrow$Restart) and then **run all cells** (in the menubar, select Cell$\\rightarrow$Run All).\n",
+    "Before you turn this problem in, make sure everything runs as expected. First, **restart the kernel** (in the menubar, select Kernel$\\rightarrow$Restart) and then **run all cells** (in the menubar, select Cell $\\rightarrow$ Run All).\n",
     "\n",
     "Make sure you fill in any place that says `YOUR CODE HERE` or \"YOUR ANSWER HERE\", as well as your name and collaborators below:"
    ]

--- a/nbgrader/docs/source/user_guide/autograded/bitdiddle/ps1/problem1.ipynb
+++ b/nbgrader/docs/source/user_guide/autograded/bitdiddle/ps1/problem1.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Before you turn this problem in, make sure everything runs as expected. First, **restart the kernel** (in the menubar, select Kernel$\\rightarrow$Restart) and then **run all cells** (in the menubar, select Cell $\\rightarrow$ Run All).\n",
+    "Before you turn this problem in, make sure everything runs as expected. First, **restart the kernel** (in the menubar, select Kernel $\\rightarrow$ Restart) and then **run all cells** (in the menubar, select Cell $\\rightarrow$ Run All).\n",
     "\n",
     "Make sure you fill in any place that says `YOUR CODE HERE` or \"YOUR ANSWER HERE\", as well as your name and collaborators below:"
    ]

--- a/nbgrader/docs/source/user_guide/autograded/bitdiddle/ps1/problem2.ipynb
+++ b/nbgrader/docs/source/user_guide/autograded/bitdiddle/ps1/problem2.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Before you turn this problem in, make sure everything runs as expected. First, **restart the kernel** (in the menubar, select Kernel$\\rightarrow$Restart) and then **run all cells** (in the menubar, select Cell$\\rightarrow$Run All).\n",
+    "Before you turn this problem in, make sure everything runs as expected. First, **restart the kernel** (in the menubar, select Kernel $\\rightarrow$ Restart) and then **run all cells** (in the menubar, select Cell $\\rightarrow$ Run All).\n",
     "\n",
     "Make sure you fill in any place that says `YOUR CODE HERE` or \"YOUR ANSWER HERE\", as well as your name and collaborators below:"
    ]

--- a/nbgrader/docs/source/user_guide/autograded/hacker/ps1/problem1.ipynb
+++ b/nbgrader/docs/source/user_guide/autograded/hacker/ps1/problem1.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Before you turn this problem in, make sure everything runs as expected. First, **restart the kernel** (in the menubar, select Kernel$\\rightarrow$Restart) and then **run all cells** (in the menubar, select Cell$\\rightarrow$Run All).\n",
+    "Before you turn this problem in, make sure everything runs as expected. First, **restart the kernel** (in the menubar, select Kernel $\\rightarrow$ Restart) and then **run all cells** (in the menubar, select Cell $\\rightarrow$ Run All).\n",
     "\n",
     "Make sure you fill in any place that says `YOUR CODE HERE` or \"YOUR ANSWER HERE\", as well as your name and collaborators below:"
    ]

--- a/nbgrader/docs/source/user_guide/autograded/hacker/ps1/problem2.ipynb
+++ b/nbgrader/docs/source/user_guide/autograded/hacker/ps1/problem2.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Before you turn this problem in, make sure everything runs as expected. First, **restart the kernel** (in the menubar, select Kernel$\\rightarrow$Restart) and then **run all cells** (in the menubar, select Cell$\\rightarrow$Run All).\n",
+    "Before you turn this problem in, make sure everything runs as expected. First, **restart the kernel** (in the menubar, select Kernel $\\rightarrow$ Restart) and then **run all cells** (in the menubar, select Cell $\\rightarrow$ Run All).\n",
     "\n",
     "Make sure you fill in any place that says `YOUR CODE HERE` or \"YOUR ANSWER HERE\", as well as your name and collaborators below:"
    ]

--- a/nbgrader/docs/source/user_guide/downloaded/ps1/archive/ps1_hacker_attempt_2016-01-30-20-30-10_problem1.ipynb
+++ b/nbgrader/docs/source/user_guide/downloaded/ps1/archive/ps1_hacker_attempt_2016-01-30-20-30-10_problem1.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Before you turn this problem in, make sure everything runs as expected. First, **restart the kernel** (in the menubar, select Kernel$\\rightarrow$Restart) and then **run all cells** (in the menubar, select Cell$\\rightarrow$Run All).\n",
+    "Before you turn this problem in, make sure everything runs as expected. First, **restart the kernel** (in the menubar, select Kernel $\\rightarrow$ Restart) and then **run all cells** (in the menubar, select Cell $\\rightarrow$ Run All).\n",
     "\n",
     "Make sure you fill in any place that says `YOUR CODE HERE` or \"YOUR ANSWER HERE\", as well as your name and collaborators below:"
    ]

--- a/nbgrader/docs/source/user_guide/feedback/bitdiddle/ps1/problem1.html
+++ b/nbgrader/docs/source/user_guide/feedback/bitdiddle/ps1/problem1.html
@@ -240,7 +240,7 @@ span.nbgrader-label {
 <div class="prompt input_prompt">
 </div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<p>Before you turn this problem in, make sure everything runs as expected. First, <strong>restart the kernel</strong> (in the menubar, select Kernel$\rightarrow$Restart) and then <strong>run all cells</strong> (in the menubar, select Cell$\rightarrow$Run All).</p>
+<p>Before you turn this problem in, make sure everything runs as expected. First, <strong>restart the kernel</strong> (in the menubar, select Kernel $\rightarrow$ Restart) and then <strong>run all cells</strong> (in the menubar, select Cell $\rightarrow$ Run All).</p>
 <p>Make sure you fill in any place that says <code>YOUR CODE HERE</code> or "YOUR ANSWER HERE", as well as your name and collaborators below:</p>
 </div>
 </div></div>

--- a/nbgrader/docs/source/user_guide/feedback/bitdiddle/ps1/problem2.html
+++ b/nbgrader/docs/source/user_guide/feedback/bitdiddle/ps1/problem2.html
@@ -234,7 +234,7 @@ span.nbgrader-label {
 <div class="prompt input_prompt">
 </div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<p>Before you turn this problem in, make sure everything runs as expected. First, <strong>restart the kernel</strong> (in the menubar, select Kernel$\rightarrow$Restart) and then <strong>run all cells</strong> (in the menubar, select Cell$\rightarrow$Run All).</p>
+<p>Before you turn this problem in, make sure everything runs as expected. First, <strong>restart the kernel</strong> (in the menubar, select Kernel $\rightarrow$ Restart) and then <strong>run all cells</strong> (in the menubar, select Cell $\rightarrow$ Run All).</p>
 <p>Make sure you fill in any place that says <code>YOUR CODE HERE</code> or "YOUR ANSWER HERE", as well as your name and collaborators below:</p>
 </div>
 </div></div>

--- a/nbgrader/docs/source/user_guide/feedback/hacker/ps1/problem1.html
+++ b/nbgrader/docs/source/user_guide/feedback/hacker/ps1/problem1.html
@@ -239,7 +239,7 @@ span.nbgrader-label {
 <div class="prompt input_prompt">
 </div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<p>Before you turn this problem in, make sure everything runs as expected. First, <strong>restart the kernel</strong> (in the menubar, select Kernel$\rightarrow$Restart) and then <strong>run all cells</strong> (in the menubar, select Cell$\rightarrow$Run All).</p>
+<p>Before you turn this problem in, make sure everything runs as expected. First, <strong>restart the kernel</strong> (in the menubar, select Kernel $\rightarrow$ Restart) and then <strong>run all cells</strong> (in the menubar, select Cell $\rightarrow$ Run All).</p>
 <p>Make sure you fill in any place that says <code>YOUR CODE HERE</code> or "YOUR ANSWER HERE", as well as your name and collaborators below:</p>
 </div>
 </div></div>

--- a/nbgrader/docs/source/user_guide/feedback/hacker/ps1/problem2.html
+++ b/nbgrader/docs/source/user_guide/feedback/hacker/ps1/problem2.html
@@ -234,7 +234,7 @@ span.nbgrader-label {
 <div class="prompt input_prompt">
 </div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<p>Before you turn this problem in, make sure everything runs as expected. First, <strong>restart the kernel</strong> (in the menubar, select Kernel$\rightarrow$Restart) and then <strong>run all cells</strong> (in the menubar, select Cell$\rightarrow$Run All).</p>
+<p>Before you turn this problem in, make sure everything runs as expected. First, <strong>restart the kernel</strong> (in the menubar, select Kernel $\rightarrow$ Restart) and then <strong>run all cells</strong> (in the menubar, select Cell $\rightarrow$ Run All).</p>
 <p>Make sure you fill in any place that says <code>YOUR CODE HERE</code> or "YOUR ANSWER HERE", as well as your name and collaborators below:</p>
 </div>
 </div></div>

--- a/nbgrader/docs/source/user_guide/release/ps1/problem1.ipynb
+++ b/nbgrader/docs/source/user_guide/release/ps1/problem1.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Before you turn this problem in, make sure everything runs as expected. First, **restart the kernel** (in the menubar, select Kernel$\\rightarrow$Restart) and then **run all cells** (in the menubar, select Cell$\\rightarrow$Run All).\n",
+    "Before you turn this problem in, make sure everything runs as expected. First, **restart the kernel** (in the menubar, select Kernel $\\rightarrow$ Restart) and then **run all cells** (in the menubar, select Cell $\\rightarrow$ Run All).\n",
     "\n",
     "Make sure you fill in any place that says `YOUR CODE HERE` or \"YOUR ANSWER HERE\", as well as your name and collaborators below:"
    ]

--- a/nbgrader/docs/source/user_guide/release/ps1/problem2.ipynb
+++ b/nbgrader/docs/source/user_guide/release/ps1/problem2.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Before you turn this problem in, make sure everything runs as expected. First, **restart the kernel** (in the menubar, select Kernel$\\rightarrow$Restart) and then **run all cells** (in the menubar, select Cell$\\rightarrow$Run All).\n",
+    "Before you turn this problem in, make sure everything runs as expected. First, **restart the kernel** (in the menubar, select Kernel $\\rightarrow$ Restart) and then **run all cells** (in the menubar, select Cell $\\rightarrow$ Run All).\n",
     "\n",
     "Make sure you fill in any place that says `YOUR CODE HERE` or \"YOUR ANSWER HERE\", as well as your name and collaborators below:"
    ]

--- a/nbgrader/docs/source/user_guide/source/header.ipynb
+++ b/nbgrader/docs/source/user_guide/source/header.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Before you turn this problem in, make sure everything runs as expected. First, **restart the kernel** (in the menubar, select Kernel$\\rightarrow$Restart) and then **run all cells** (in the menubar, select Cell$\\rightarrow$Run All).\n",
+    "Before you turn this problem in, make sure everything runs as expected. First, **restart the kernel** (in the menubar, select Kernel $\\rightarrow$ Restart) and then **run all cells** (in the menubar, select Cell $\\rightarrow$ Run All).\n",
     "\n",
     "Make sure you fill in any place that says `YOUR CODE HERE` or \"YOUR ANSWER HERE\", as well as your name and collaborators below:"
    ]


### PR DESCRIPTION
The current notebooks are incorrectly rendered because the dollar sign should not be perceded by a space to be rendered correctly in Visual Studio Code cells, adding a space around them fixes the problem, however it does render correctly on GitHub.

The part in red is the default format, the part in green is the fixed format.
<img width="1294" alt="Screenshot 2024-06-14 at 5 54 17 PM" src="https://github.com/jupyter/nbgrader/assets/70425741/5b5220f8-2ca4-430e-b50e-265594c04517">
