### PR TITLE
Install the labextension in the correct directory 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,10 +110,7 @@ exclude = [
 
 [tool.hatch.build.targets.wheel.shared-data]
 "etc/jupyter/jupyter_server_config.d" = "etc/jupyter/jupyter_server_config.d"
-"nbgrader/labextension/static" = "share/jupyter/labextensions/nbgrader/static"
-"install.json" = "share/jupyter/labextensions/nbgrader/install.json"
-"nbgrader/labextension/package.json" = "share/jupyter/labextensions/nbgrader/package.json"
-"nbgrader/labextension/schemas/nbgrader" = "share/jupyter/labextensions/nbgrader/schemas/nbgrader"
+"nbgrader/labextension" = "share/jupyter/labextensions/@jupyter/nbgrader"
 
 [tool.hatch.build.hooks.jupyter-builder]
 dependencies = [

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,12 +18,12 @@ import { ButtonExtension } from "./validate_assignment/index";
  * The plugin IDs
  */
 const pluginIDs = {
-  menus: 'nbgrader:menu',
-  assignmentsList: 'nbgrader:assignment-list',
-  coursesList: 'nbgrader:course-list',
-  formgrader: 'nbgrader:formgrader',
-  createAssignment: 'nbgrader:create-assignment',
-  validateAssignment: 'nbgrader:validate-assignment'
+  menus: '@jupyter/nbgrader:menu',
+  assignmentsList: '@jupyter/nbgrader:assignment-list',
+  coursesList: '@jupyter/nbgrader:course-list',
+  formgrader: '@jupyter/nbgrader:formgrader',
+  createAssignment: '@jupyter/nbgrader:create-assignment',
+  validateAssignment: '@jupyter/nbgrader:validate-assignment'
 }
 
 /**


### PR DESCRIPTION
Follow up https://github.com/jupyter/nbgrader/pull/1875 to change the plugin IDs and to install the labextension in the correct directory (`'@jupyter/nbgrader`).
This change is required to use the schema files (settings), i.e. https://github.com/jupyter/nbgrader/pull/1859