### PR TITLE
Grant Extension interface in the ManageSubmissions section

### DIFF
--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -613,7 +613,8 @@ class SubmittedAssignment(Base):
             "max_written_score": self.max_written_score,
             "task_score": self.task_score,
             "max_task_score": self.max_task_score,
-            "needs_manual_grade": self.needs_manual_grade
+            "needs_manual_grade": self.needs_manual_grade,
+            "extension": (self.extension + datetime.datetime(1970, 1, 1)).isoformat() if self.extension is not None else None,
         }
 
     def __repr__(self) -> str:
@@ -3090,7 +3091,8 @@ class Gradebook(object):
             func.coalesce(written_scores.c.max_written_score, 0.0),
             func.coalesce(task_scores.c.task_score, 0.0),
             func.coalesce(task_scores.c.max_task_score, 0.0),
-            _manual_grade
+            _manual_grade,
+            SubmittedAssignment.extension
         ).select_from(SubmittedAssignment
         ).join(SubmittedNotebook).join(Assignment).join(Student).join(Grade)\
          .outerjoin(code_scores, SubmittedAssignment.id == code_scores.c.id)\
@@ -3119,7 +3121,7 @@ class Gradebook(object):
             "score", "max_score", "code_score", "max_code_score",
             "written_score", "max_written_score",
             "task_score", "max_task_score",
-            "needs_manual_grade"
+            "needs_manual_grade", "extension"
         ]
         return [dict(zip(keys, x)) for x in assignments]
 

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -614,7 +614,7 @@ class SubmittedAssignment(Base):
             "task_score": self.task_score,
             "max_task_score": self.max_task_score,
             "needs_manual_grade": self.needs_manual_grade,
-            "extension": (self.extension + datetime.datetime(1970, 1, 1)).isoformat() if self.extension is not None else None,
+            "extension": self.extension.total_seconds() if self.extension is not None else None,
         }
 
     def __repr__(self) -> str:
@@ -1347,7 +1347,7 @@ class Gradebook(object):
 
         """
         course = None
-        
+
         try:
             course = self.db.query(Course)\
                 .filter(Course.id==course_id)\

--- a/nbgrader/apps/api.py
+++ b/nbgrader/apps/api.py
@@ -618,7 +618,7 @@ class NbGraderAPI(LoggingConfigurable):
             submission["autograded"] = True
             submission["submitted"] = True
             if submission["extension"]:
-                submission["extension"] = (submission["extension"] + datetime.datetime(1970, 1, 1)).isoformat()
+                submission["extension"] = submission["extension"].total_seconds()
             submissions.append(submission)
 
         for student_id in ungraded:
@@ -1165,7 +1165,7 @@ class NbGraderAPI(LoggingConfigurable):
             ret_dic["value"] = sorted(assignments, key=lambda x: (x['course_id'], x['assignment_id']))
         return ret_dic
 
-    def grant_extension_to_student(self, assignment_id, student_id, minutes, hours, days):
+    def grant_extension_to_student(self, assignment_id, student_id, minutes, hours, days, weeks):
         """Grants extension for a particular assignment and student.
 
         Arguments
@@ -1180,6 +1180,8 @@ class NbGraderAPI(LoggingConfigurable):
             The number of hours to extend the assignment deadline
         days: int
             The number of days to extend the assignment deadline
+        weeks: int
+            The number of weeks to extend the assignment deadline
 
         Returns
         -------
@@ -1193,7 +1195,7 @@ class NbGraderAPI(LoggingConfigurable):
         """
         with self.gradebook as gb:
             try:
-                gb.grant_extension(assignment_id, student_id, minutes, hours, days)
+                gb.grant_extension(assignment_id, student_id, minutes, hours, days, weeks)
             except InvalidEntry as e:
                 return {"success": False, "error": str(e)}
         return {"success": True}

--- a/nbgrader/apps/api.py
+++ b/nbgrader/apps/api.py
@@ -1,3 +1,4 @@
+import datetime
 import glob
 import re
 import sys
@@ -11,7 +12,7 @@ from traitlets import Instance, Enum, Unicode, observe
 from ..coursedir import CourseDirectory
 from ..converters import GenerateAssignment, Autograde, GenerateFeedback, GenerateSolution
 from ..exchange import ExchangeFactory, ExchangeError
-from ..api import MissingEntry, Gradebook, Student, SubmittedAssignment
+from ..api import MissingEntry, InvalidEntry, Gradebook, Student, SubmittedAssignment
 from ..utils import parse_utc, temp_attrs, capture_log, as_timezone, to_numeric_tz
 from ..auth import Authenticator
 
@@ -525,6 +526,7 @@ class NbGraderAPI(LoggingConfigurable):
                 "autograded": False,
                 "submitted": True,
                 "student": student_id,
+                "extension": None,
             }
 
             if student_id not in students:
@@ -569,6 +571,7 @@ class NbGraderAPI(LoggingConfigurable):
                 "autograded": False,
                 "submitted": False,
                 "student": student_id,
+                "extension": None,
             }
 
             if student_id not in students:
@@ -614,6 +617,8 @@ class NbGraderAPI(LoggingConfigurable):
                 submission["display_timestamp"] = None
             submission["autograded"] = True
             submission["submitted"] = True
+            if submission["extension"]:
+                submission["extension"] = (submission["extension"] + datetime.datetime(1970, 1, 1)).isoformat()
             submissions.append(submission)
 
         for student_id in ungraded:
@@ -1159,3 +1164,36 @@ class NbGraderAPI(LoggingConfigurable):
             assignments = lister_rel.start()
             ret_dic["value"] = sorted(assignments, key=lambda x: (x['course_id'], x['assignment_id']))
         return ret_dic
+
+    def grant_extension_to_student(self, assignment_id, student_id, minutes, hours, days):
+        """Grants extension for a particular assignment and student.
+
+        Arguments
+        ---------
+        assignment_id: string
+            The name of the assignment
+        student_id: string
+            The unique id of the student
+        minutes: int
+            The number of minutes to extend the assignment deadline
+        hours: int
+            The number of hours to extend the assignment deadline
+        days: int
+            The number of days to extend the assignment deadline
+
+        Returns
+        -------
+        result: dict
+            A dictionary with the following keys (error and log may or may not be present):
+
+            - success (bool): whether or not the operation completed successfully
+            - error (string): formatted traceback
+            - log (string): captured log output
+
+        """
+        with self.gradebook as gb:
+            try:
+                gb.grant_extension(assignment_id, student_id, minutes, hours, days)
+            except InvalidEntry as e:
+                return {"success": False, "error": str(e)}
+        return {"success": True}

--- a/nbgrader/server_extensions/formgrader/apihandlers.py
+++ b/nbgrader/server_extensions/formgrader/apihandlers.py
@@ -289,9 +289,10 @@ class ExtensionHandler(BaseApiHandler):
             minutes = int(data.get('minutes', 0))
             hours = int(data.get('hours', 0))
             days = int(data.get('days', 0))
+            weeks = int(data.get('weeks', 0))
         except ValueError:
             raise web.HTTPError(400, "Invalid extension time")
-        self.write(json.dumps(self.api.grant_extension_to_student(assignment_id, student_id, minutes, hours, days)))
+        self.write(json.dumps(self.api.grant_extension_to_student(assignment_id, student_id, minutes, hours, days, weeks)))
 
 
 class GenerateAllFeedbackHandler(BaseApiHandler):

--- a/nbgrader/server_extensions/formgrader/apihandlers.py
+++ b/nbgrader/server_extensions/formgrader/apihandlers.py
@@ -279,6 +279,21 @@ class AutogradeHandler(BaseApiHandler):
         self.write(json.dumps(self.api.autograde(assignment_id, student_id)))
 
 
+class ExtensionHandler(BaseApiHandler):
+    @web.authenticated
+    @check_xsrf
+    @check_notebook_dir
+    def post(self, assignment_id, student_id):
+        data = self.get_json_body()
+        try:
+            minutes = int(data.get('minutes', 0))
+            hours = int(data.get('hours', 0))
+            days = int(data.get('days', 0))
+        except ValueError:
+            raise web.HTTPError(400, "Invalid extension time")
+        self.write(json.dumps(self.api.grant_extension_to_student(assignment_id, student_id, minutes, hours, days)))
+
+
 class GenerateAllFeedbackHandler(BaseApiHandler):
     @web.authenticated
     @check_xsrf
@@ -330,6 +345,7 @@ default_handlers = [
     (r"/formgrader/api/submissions/([^/]+)", SubmissionCollectionHandler),
     (r"/formgrader/api/submission/([^/]+)/([^/]+)", SubmissionHandler),
     (r"/formgrader/api/submission/([^/]+)/([^/]+)/autograde", AutogradeHandler),
+    (r"/formgrader/api/submission/extension/([^/]+)/([^/]+)", ExtensionHandler),
 
     (r"/formgrader/api/submitted_notebooks/([^/]+)/([^/]+)", SubmittedNotebookCollectionHandler),
     (r"/formgrader/api/submitted_notebook/([^/]+)/flag", FlagSubmissionHandler),

--- a/nbgrader/server_extensions/formgrader/static/js/manage_submissions.js
+++ b/nbgrader/server_extensions/formgrader/static/js/manage_submissions.js
@@ -285,6 +285,11 @@ var SubmissionUI = Backbone.View.extend({
         var tableBody = $("<tbody/>");
         body.append(tableBody);
 
+        var weeks = $("<tr/>");
+        tableBody.append(weeks);
+        weeks.append($("<td/>").addClass("align-middle").text("Weeks"));
+        weeks.append($("<td/>").append($("<input/>").addClass("modal-weeks").attr({type: "number", min: 0, step: 1, value: this.modal_extension_weeks})));
+
         var days = $("<tr/>");
         tableBody.append(days);
         days.append($("<td/>").addClass("align-middle").text("Days"));
@@ -313,11 +318,14 @@ var SubmissionUI = Backbone.View.extend({
 
         this.$modal = createModal("grant-extension-modal", "Granting Extension to " + this.model.get("student"), body, footer);
 
-        var extension = new Date(this.model.get("extension") || '1970-01-01T00:00:00Z');
-        var modal_extension_days = Math.trunc(extension.getTime() / 86400000);
-        var modal_extension_hours = extension.getHours();
-        var modal_extension_minutes = extension.getMinutes();
+        var extension = this.model.get("extension") || 0;
+        var modal_extension_days = Math.trunc(extension / 86400);
+        var modal_extension_weeks = Math.trunc(modal_extension_days / 7);
+        modal_extension_days = modal_extension_days % 7;
+        var modal_extension_hours = Math.trunc((extension % 86400) / 3600);
+        var modal_extension_minutes = Math.trunc((extension % 3600) / 60);
 
+        this.$modal.find("input.modal-weeks").val(modal_extension_weeks);
         this.$modal.find("input.modal-days").val(modal_extension_days);
         this.$modal.find("input.modal-hours").val(modal_extension_hours);
         this.$modal.find("input.modal-minutes").val(modal_extension_minutes);
@@ -327,6 +335,7 @@ var SubmissionUI = Backbone.View.extend({
     save: function () {
         this.animateSaving();
 
+        var weeks = this.$modal.find("input.modal-weeks").val() || 0;
         var days = this.$modal.find("input.modal-days").val() || 0;
         var hours = this.$modal.find("input.modal-hours").val() || 0;
         var minutes = this.$modal.find("input.modal-minutes").val() || 0;
@@ -342,7 +351,8 @@ var SubmissionUI = Backbone.View.extend({
             data: JSON.stringify({
                 minutes: minutes,
                 hours: hours,
-                days: days
+                days: days,
+                weeks: weeks,
             }),
             })
             .done(_.bind(this.grant_extension_log, this));
@@ -380,6 +390,7 @@ var SubmissionUI = Backbone.View.extend({
         if (this.$modal) {
             this.$modal.modal('hide')
             this.$modal = undefined;
+            this.modal_extension_weeks = 0;
             this.modal_extension_days = 0;
             this.modal_extension_hours = 0;
             this.modal_extension_minutes = 0;

--- a/nbgrader/server_extensions/formgrader/static/js/manage_submissions.js
+++ b/nbgrader/server_extensions/formgrader/static/js/manage_submissions.js
@@ -21,6 +21,10 @@ var SubmissionUI = Backbone.View.extend({
         this.$autograde = this.$el.find(".autograde");
         this.$generate_feedback = this.$el.find(".generate-feedback");
         this.$release_feedback = this.$el.find(".release-feedback");
+        this.$grant_extension = this.$el.find(".grant-extension");
+
+        this.$modal = undefined;
+        this.$modal_save = undefined;
 
         this.listenTo(this.model, "sync", this.render);
 
@@ -36,6 +40,7 @@ var SubmissionUI = Backbone.View.extend({
         this.$autograde.empty();
         this.$generate_feedback.empty();
         this.$release_feedback.empty();
+        this.$grant_extension.empty();
     },
 
     render: function () {
@@ -127,6 +132,14 @@ var SubmissionUI = Backbone.View.extend({
             .click(_.bind(this.release_feedback, this))
             .append($("<span/>")
                 .addClass("glyphicon glyphicon-envelope")
+                .attr("aria-hidden", "true")));
+
+        // grant extension
+        this.$grant_extension.append($("<a/>")
+            .attr("href", "#")
+            .click(_.bind(this.grant_extension, this))
+            .append($("<span/>")
+                .addClass("glyphicon glyphicon-calendar")
                 .attr("aria-hidden", "true")));
     },
 
@@ -256,6 +269,126 @@ var SubmissionUI = Backbone.View.extend({
             "There was an error releasing feedback for '" + assignment + "' for student '" + student + "'.");
     },
 
+    grant_extension: function () {
+        if (!this.model.get("autograded")) {
+            createModal(
+                "error-modal",
+                "Error",
+                "Extensions cannot be granted for ungraded submissions.");
+            return;
+        }
+        this.openModal();
+    },
+
+    openModal: function () {
+        var body = $("<table/>").addClass("table table-striped form-table");
+        var tableBody = $("<tbody/>");
+        body.append(tableBody);
+
+        var days = $("<tr/>");
+        tableBody.append(days);
+        days.append($("<td/>").addClass("align-middle").text("Days"));
+        days.append($("<td/>").append($("<input/>").addClass("modal-days").attr({type: "number", min: 0, step: 1, value: this.modal_extension_days})));
+
+        var hours = $("<tr/>");
+        tableBody.append(hours);
+        hours.append($("<td/>").addClass("align-middle").text("Hours"));
+        hours.append($("<td/>").append($("<input/>").addClass("modal-hours").attr({type: "number", min: 0, step: 1, value: this.modal_extension_hours})));
+
+        var minutes = $("<tr/>");
+        tableBody.append(minutes);
+        minutes.append($("<td/>").addClass("align-middle").text("Minutes"));
+        minutes.append($("<td/>").append($("<input/>").addClass("modal-minutes").attr({type: "number", min: 0, step: 1, value: this.modal_extension_minutes})));
+
+        var footer = $("<div/>");
+        footer.append($("<button/>")
+            .addClass("btn btn-primary save")
+            .attr("type", "button")
+            .text("Save"));
+        footer.append($("<button/>")
+            .addClass("btn btn-danger")
+            .attr("type", "button")
+            .attr("data-dismiss", "modal")
+            .text("Cancel"));
+
+        this.$modal = createModal("grant-extension-modal", "Granting Extension to " + this.model.get("student"), body, footer);
+
+        var extension = new Date(this.model.get("extension") || '1970-01-01T00:00:00Z');
+        var modal_extension_days = Math.trunc(extension.getTime() / 86400000);
+        var modal_extension_hours = extension.getHours();
+        var modal_extension_minutes = extension.getMinutes();
+
+        this.$modal.find("input.modal-days").val(modal_extension_days);
+        this.$modal.find("input.modal-hours").val(modal_extension_hours);
+        this.$modal.find("input.modal-minutes").val(modal_extension_minutes);
+        this.$modal.find("button.save").click(_.bind(this.save, this));
+    },
+
+    save: function () {
+        this.animateSaving();
+
+        var days = this.$modal.find("input.modal-days").val() || 0;
+        var hours = this.$modal.find("input.modal-hours").val() || 0;
+        var minutes = this.$modal.find("input.modal-minutes").val() || 0;
+
+        this.closeModal();
+        let student = this.model.get("student");
+        let assignment = this.model.get("name");
+
+        $.ajax({
+            url: base_url + '/formgrader/api/submission/extension/' + assignment + '/' + student,
+            type: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify({
+                minutes: minutes,
+                hours: hours,
+                days: days
+            }),
+            })
+            .done(_.bind(this.grant_extension_log, this));
+    },
+
+    grant_extension_log: function (response) {
+        this.model.fetch();
+        response = JSON.parse(response);
+        var student = this.model.get("student");
+        var assignment = this.model.get("name");
+        if (response["success"]) {
+            createLogModal(
+                "success-modal",
+                "Success",
+                "Successfully granted extension to '" + assignment + "' for student '" + student + "'.",
+                response["log"]);
+
+        } else {
+            createLogModal(
+                "error-modal",
+                "Error",
+                "There was an error granting extension to '" + assignment + "' for student '" + student + "':",
+                response["log"],
+                response["error"]);
+        }
+    },
+
+    animateSaving: function () {
+        if (this.$modal_save) {
+            this.$modal_save.text("Saving...");
+        }
+    },
+
+    closeModal: function () {
+        if (this.$modal) {
+            this.$modal.modal('hide')
+            this.$modal = undefined;
+            this.modal_extension_days = 0;
+            this.modal_extension_hours = 0;
+            this.modal_extension_minutes = 0;
+            this.$modal_save = undefined;
+        }
+
+        this.render();
+    },
+
 });
 
 var insertRow = function (table) {
@@ -268,6 +401,7 @@ var insertRow = function (table) {
     row.append($("<td/>").addClass("text-center autograde"));
     row.append($("<td/>").addClass("text-center generate-feedback"));
     row.append($("<td/>").addClass("text-center release-feedback"));
+    row.append($("<td/>").addClass("text-center grant-extension"));
     table.append(row)
     return row;
 };

--- a/nbgrader/server_extensions/formgrader/templates/manage_submissions.tpl
+++ b/nbgrader/server_extensions/formgrader/templates/manage_submissions.tpl
@@ -64,12 +64,14 @@ nbgrader autograde "{{ assignment_id }}"</pre>
   <th class="text-center no-sort">Autograde</th>
   <th class="text-center no-sort">Generate Feedback</th>
   <th class="text-center no-sort">Release Feedback</th>
+  <th class="text-center no-sort">Grant Extension</th>
 </tr>
 {%- endblock -%}
 
 {%- block table_body -%}
 <tr>
   <td>Loading, please wait...</td>
+  <td></td>
   <td></td>
   <td></td>
   <td></td>

--- a/nbgrader/tests/api/test_models.py
+++ b/nbgrader/tests/api/test_models.py
@@ -1173,7 +1173,7 @@ def test_submittedassignment_to_dict(submissions):
         'id', 'name', 'student', 'timestamp', 'score', 'max_score', 'code_score',
         'max_code_score', 'written_score', 'max_written_score',
         'task_score', 'max_task_score',
-        'needs_manual_grade', 'last_name', 'first_name'}
+        'needs_manual_grade', 'last_name', 'first_name', 'extension'}
 
     assert sad['id'] == sa.id
     assert sad['name'] == 'foo'

--- a/nbgrader/tests/apps/test_api.py
+++ b/nbgrader/tests/apps/test_api.py
@@ -6,7 +6,7 @@ import filecmp
 
 from os.path import join
 from traitlets.config import Config
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from ...apps.api import NbGraderAPI
 from ...coursedir import CourseDirectory
@@ -310,7 +310,7 @@ class TestNbGraderAPI(BaseTestApp):
             "id", "name", "student", "last_name", "first_name", "score",
             "max_score", "code_score", "max_code_score", "written_score",
             "max_written_score", "task_score", "max_task_score", "needs_manual_grade", "autograded",
-            "timestamp", "submitted", "display_timestamp"])
+            "timestamp", "submitted", "display_timestamp", "extension"])
 
         default = {
             "id": None,
@@ -330,7 +330,8 @@ class TestNbGraderAPI(BaseTestApp):
             "autograded": False,
             "timestamp": None,
             "display_timestamp": None,
-            "submitted": False
+            "submitted": False,
+            "extension": None,
         }
 
         s = api.get_submission("ps1", "foo")
@@ -364,6 +365,7 @@ class TestNbGraderAPI(BaseTestApp):
         target["written_score"] = 0
         target["max_written_score"] = 2
         target["needs_manual_grade"] = True
+        target["extension"] = None
         assert s == target
 
     def test_get_submission_no_timestamp(self, api, course_dir, db):
@@ -371,7 +373,7 @@ class TestNbGraderAPI(BaseTestApp):
             "id", "name", "student", "last_name", "first_name", "score",
             "max_score", "code_score", "max_code_score", "written_score",
             "max_written_score", "task_score", "max_task_score", "needs_manual_grade", "autograded",
-            "timestamp", "submitted", "display_timestamp"])
+            "timestamp", "submitted", "display_timestamp", "extension"])
 
         default = {
             "id": None,
@@ -391,7 +393,8 @@ class TestNbGraderAPI(BaseTestApp):
             "autograded": False,
             "timestamp": None,
             "display_timestamp": None,
-            "submitted": False
+            "submitted": False,
+            "extension": None,
         }
 
         s = api.get_submission("ps1", "foo")
@@ -420,6 +423,7 @@ class TestNbGraderAPI(BaseTestApp):
         target["written_score"] = 0
         target["max_written_score"] = 2
         target["needs_manual_grade"] = True
+        target["extension"] = None
         assert s == target
 
     def test_get_submissions(self, api, course_dir, db):
@@ -826,3 +830,15 @@ class TestNbGraderAPI(BaseTestApp):
         result = api.fetch_feedback("ps2", "foo")
         assert result["success"]
         assert os.path.exists(join("ps2", "feedback", timestamp, "p2.html"))
+
+    def test_grant_extension_to_student(self, api, course_dir):
+        self._copy_file(join("files", "submitted-unchanged.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
+        self._copy_file(join("files", "submitted-changed.ipynb"), join(course_dir, "submitted", "foo", "ps1", "p1.ipynb"))
+        api.generate_assignment("ps1")
+        api.autograde("ps1", "foo")
+
+        result = api.grant_extension_to_student("ps1", "foo", 1, 2, 3)
+        assert result["success"]
+
+        extension = api.get_submission("ps1", "foo")["extension"]
+        assert extension == datetime(1970, 1, 4, 2, 1).isoformat()

--- a/nbgrader/tests/apps/test_api.py
+++ b/nbgrader/tests/apps/test_api.py
@@ -837,8 +837,8 @@ class TestNbGraderAPI(BaseTestApp):
         api.generate_assignment("ps1")
         api.autograde("ps1", "foo")
 
-        result = api.grant_extension_to_student("ps1", "foo", 1, 2, 3)
+        result = api.grant_extension_to_student("ps1", "foo", 1, 2, 3, 4)
         assert result["success"]
 
         extension = api.get_submission("ps1", "foo")["extension"]
-        assert extension == datetime(1970, 1, 4, 2, 1).isoformat()
+        assert extension == timedelta(weeks=4, days=3, hours=2, minutes=1).total_seconds()


### PR DESCRIPTION
Long ago, the `grant_extension` method was added to the gradebook following #660—however, no API handler or user interface utilized this functionality.

In this PR, a new modal has been introduced to the “Manage Submissions” view in FormGrader, allowing viewing and granting individual extensions to auto-graded submissions.

![image](https://github.com/user-attachments/assets/d412f54e-deae-408c-891a-d3871a4e962e)

As mentioned, the modal opens only for the auto-graded submissions. This limitation is an attempt to minimize the changes to the existing API.

<img width="614" alt="image" src="https://github.com/user-attachments/assets/b2475ba2-5451-4f06-ac21-d97c178f2092">
