### PR TITLE
Show Deadlines in Assignment List

### DIFF
--- a/nbgrader/coursedir.py
+++ b/nbgrader/coursedir.py
@@ -225,6 +225,11 @@ class CourseDirectory(LoggingConfigurable):
         )
     ).tag(config=True)
 
+    deadline_file = Unicode(
+        "deadlines.json",
+        help="File for storing deadlines"
+    ).tag(config=True)
+
     groupshared = Bool(
         False,
         help=dedent(

--- a/nbgrader/exchange/abc/exchange.py
+++ b/nbgrader/exchange/abc/exchange.py
@@ -36,11 +36,6 @@ class Exchange(LoggingConfigurable):
         help="Format string for timestamps"
     ).tag(config=True)
 
-    deadline_file = Unicode(
-        "deadlines.txt",
-        help="File for storing deadlines"
-    ).tag(config=True)
-
     @validate('timestamp_format')
     def _valid_timestamp_format(self, proposal):
         try:

--- a/nbgrader/exchange/abc/exchange.py
+++ b/nbgrader/exchange/abc/exchange.py
@@ -36,6 +36,11 @@ class Exchange(LoggingConfigurable):
         help="Format string for timestamps"
     ).tag(config=True)
 
+    deadline_file = Unicode(
+        "deadlines.txt",
+        help="File for storing deadlines"
+    ).tag(config=True)
+
     @validate('timestamp_format')
     def _valid_timestamp_format(self, proposal):
         try:

--- a/nbgrader/server_extensions/assignment_list/handlers.py
+++ b/nbgrader/server_extensions/assignment_list/handlers.py
@@ -84,7 +84,7 @@ class AssignmentList(LoggingConfigurable):
                     authenticator=authenticator,
                     config=config)
                 assignments = lister.start()
-                assignments = DeadlineManager(config, self.log) \
+                assignments = DeadlineManager(config.Exchange.root, coursedir, self.log) \
                     .fetch_deadlines(assignments)
 
             except Exception as e:

--- a/nbgrader/server_extensions/assignment_list/handlers.py
+++ b/nbgrader/server_extensions/assignment_list/handlers.py
@@ -19,6 +19,7 @@ from ...apps import NbGrader
 from ...coursedir import CourseDirectory
 from ...auth import Authenticator
 from ... import __version__ as nbgrader_version
+from ..helpers.deadline import DeadlineManager
 
 
 static = os.path.join(os.path.dirname(__file__), 'static')
@@ -83,6 +84,8 @@ class AssignmentList(LoggingConfigurable):
                     authenticator=authenticator,
                     config=config)
                 assignments = lister.start()
+                assignments = DeadlineManager(config, self.log) \
+                    .fetch_deadlines(assignments)
 
             except Exception as e:
                 self.log.error(traceback.format_exc())

--- a/nbgrader/server_extensions/formgrader/apihandlers.py
+++ b/nbgrader/server_extensions/formgrader/apihandlers.py
@@ -144,7 +144,7 @@ class AssignmentHandler(BaseApiHandler):
         assignment = {"duedate": duedate}
         assignment_id = assignment_id.strip()
         self.gradebook.update_or_create_assignment(assignment_id, **assignment)
-        DeadlineManager(self.api._trait_values["config"], self.log) \
+        DeadlineManager(self.api.exchange_root, self.coursedir, self.log) \
             .update_or_add_deadline(assignment_id, duedate)
         sourcedir = os.path.abspath(self.coursedir.format_path(self.coursedir.source_directory, '.', assignment_id))
         if not os.path.isdir(sourcedir):

--- a/nbgrader/server_extensions/formgrader/apihandlers.py
+++ b/nbgrader/server_extensions/formgrader/apihandlers.py
@@ -3,6 +3,7 @@ import os
 
 from tornado import web
 
+from ...server_extensions.helpers.deadline import DeadlineManager
 from .base import BaseApiHandler, check_xsrf, check_notebook_dir
 from ...api import MissingEntry
 
@@ -143,6 +144,8 @@ class AssignmentHandler(BaseApiHandler):
         assignment = {"duedate": duedate}
         assignment_id = assignment_id.strip()
         self.gradebook.update_or_create_assignment(assignment_id, **assignment)
+        DeadlineManager(self.api._trait_values["config"], self.log) \
+            .update_or_add_deadline(assignment_id, duedate)
         sourcedir = os.path.abspath(self.coursedir.format_path(self.coursedir.source_directory, '.', assignment_id))
         if not os.path.isdir(sourcedir):
             os.makedirs(sourcedir)

--- a/nbgrader/server_extensions/helpers/deadline.py
+++ b/nbgrader/server_extensions/helpers/deadline.py
@@ -41,14 +41,13 @@ class DeadlineManager:
             for assignment, deadline in deadlines.items():
                 fh.write(f"{assignment}/{deadline}\n")
         
-        if self.config.CourseDirectory.groupshared:
-            st_mode = os.stat(file_path).st_mode
-            if st_mode & 0o664 != 0o664:
-                try:
-                    os.chmod(file_path, (st_mode | 0o664) & 0o777)
-                except PermissionError:
-                    self.log.warning("Could not update permissions of %s to make it groupshared", file_path)
-                
+        access_mode = 0o664 if self.config.CourseDirectory.groupshared else 0o644
+        st_mode = os.stat(file_path).st_mode
+        if st_mode & access_mode != access_mode:
+            try:
+                os.chmod(file_path, (st_mode | access_mode) & 0o777)
+            except PermissionError:
+                self.log.warning("Could not update permissions of %s", file_path)
     
     def _format_deadline(self, deadline):
         """Format the deadline."""

--- a/nbgrader/server_extensions/helpers/deadline.py
+++ b/nbgrader/server_extensions/helpers/deadline.py
@@ -52,8 +52,8 @@ class DeadlineManager:
         except IsADirectoryError:
             self.log.error("The path to file is a directory: %s", file_path)
             return
-        except TypeError:
-            self.log.error("Invalid data type to write in file: %s", deadlines)
+        except:
+            self.log.error("An unexpected error occurred while writing deadlines")
             return
         
         access_mode = 0o664 if self.coursedir.groupshared else 0o644
@@ -63,6 +63,8 @@ class DeadlineManager:
                 os.chmod(file_path, (st_mode | access_mode) & 0o777)
             except PermissionError:
                 self.log.warning("Could not update permissions of %s", file_path)
+            except:
+                self.log.error("An unexpected error occurred while updating permissions of %s", file_path)
     
     def _format_deadline(self, deadline):
         """Format the deadline."""
@@ -76,10 +78,13 @@ class DeadlineManager:
 
         try:
             entries = json.load(open(file_path, "r"))
-        except FileNotFoundError:
-            self.log.warning("No deadlines file found at {}".format(file_path))
+        except (FileNotFoundError, PermissionError):
+            self.log.warning("No deadlines file found or accessible at {}".format(file_path))
             return {}
         except json.JSONDecodeError:
             self.log.warning("Invalid JSON in deadlines file at {}".format(file_path))
+            return {}
+        except:
+            self.log.error("An unexpected error occurred while loading deadlines")
             return {}
         return entries

--- a/nbgrader/server_extensions/helpers/deadline.py
+++ b/nbgrader/server_extensions/helpers/deadline.py
@@ -1,0 +1,85 @@
+import os
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from ... import utils
+
+
+class DeadlineManager:
+    def __init__(self, config, logger):
+        self.config = config
+        self.log = logger
+    
+    def fetch_deadlines(self, assignments):
+        """Fetch the deadline for the given course id and assignments."""
+
+        dir_name = os.path.join(self.config.Exchange.root, self.config.CourseDirectory.course_id)
+        file_path = os.path.join(dir_name, self.config.Exchange.deadline_file)
+        deadlines = self._read_deadlines(file_path)
+        for assignment in assignments:
+            if assignment["assignment_id"] in deadlines:
+                assignment["due_date"] = deadlines[assignment["assignment_id"]]
+        return assignments
+   
+    def update_or_add_deadline(self, assignment_id, deadline):
+        """Add a deadline in the deadlines file or update it if it exists."""
+        deadline = self._format_deadline(deadline)
+        
+        dir_name = os.path.join(self.config.Exchange.root, self.config.CourseDirectory.course_id)
+        file_path = os.path.join(dir_name, self.config.Exchange.deadline_file)
+        deadlines = self._read_deadlines(file_path)
+        deadlines[assignment_id] = deadline
+        
+        self._write_deadlines(file_path, deadlines)
+    
+    def _write_deadlines(self, file_path, deadlines):
+        """Write the deadlines to the deadlines file and sets access permissions."""
+        with open(file_path, "w") as fh:
+            for assignment, deadline in deadlines.items():
+                fh.write(f"{assignment}/{deadline}\n")
+        
+        if self.config.CourseDirectory.groupshared:
+            st_mode = os.stat(file_path).st_mode
+            if st_mode & 0o660 != 0o660:
+                try:
+                    os.chmod(file_path, (st_mode | 0o660) & 0o777)
+                except PermissionError:
+                    self.log.warning("Could not update permissions of %s to make it groupshared", file_path)
+                
+    
+    def _format_deadline(self, deadline):
+        """Format the deadline."""
+        tz = "UTC"  # Default timezone
+        if self.config.Exchange.timezone:
+            tz = self.config.Exchange.timezone
+        try:
+             tzinfo = ZoneInfo(tz)
+        except ZoneInfoNotFoundError:
+            self.log.error("Invalid deadline format: {}".format(deadline))
+            tzinfo = ZoneInfo("UTC")
+            
+        return utils.parse_utc(deadline) \
+            .replace(tzinfo=ZoneInfo("UTC")) \
+            .astimezone(tzinfo) \
+            .strftime("%Y-%m-%d %H:%M:%S %Z")
+
+    def _read_deadlines(self, file_path):
+        """Read the deadlines from the deadlines file."""
+
+        try:
+            with open(file_path, "r") as fh:
+                lines = fh.readlines()       
+        except FileNotFoundError:
+            self.log.warning("No deadlines file found at {}".format(file_path))
+            return {}
+        return self._parse_deadlines(lines)
+        
+    def _parse_deadlines(self, lines):
+        """Parse the deadlines from the lines."""
+        deadlines = {}
+        for line in lines:
+            parts = line.split("/")
+            if len(parts) != 2:
+                self.log.warning("Invalid deadline line: {}".format(line))
+            assignment, deadline = parts
+            deadlines[assignment.strip()] = deadline.strip()
+        return deadlines

--- a/nbgrader/server_extensions/helpers/deadline.py
+++ b/nbgrader/server_extensions/helpers/deadline.py
@@ -1,6 +1,6 @@
 import json
 import os
-from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+from zoneinfo import ZoneInfo
 
 from ... import utils
 
@@ -60,20 +60,10 @@ class DeadlineManager:
     
     def _format_deadline(self, deadline):
         """Format the deadline."""
-        tz = "UTC"  # Default timezone
-        if self.config.Exchange.timezone:
-            tz = self.config.Exchange.timezone
-        # try:
-        #      tzinfo = ZoneInfo(tz)
-        # except ZoneInfoNotFoundError:
-        #     self.log.error("Invalid deadline format: {}".format(deadline))
-        #     tzinfo = ZoneInfo("UTC")
-            
+        
         return utils.parse_utc(deadline) \
             .replace(tzinfo=ZoneInfo("UTC")) \
-            .isoformat()  # ?
-            # .strftime("%Y-%m-%d %H:%M:%S %Z")
-            # .astimezone(tzinfo) \
+            .isoformat()
 
     def _read_deadlines(self, file_path):
         """Read the deadlines from the deadlines file."""

--- a/nbgrader/server_extensions/helpers/deadline.py
+++ b/nbgrader/server_extensions/helpers/deadline.py
@@ -14,7 +14,7 @@ class DeadlineManager:
 
         dir_name = os.path.join(self.config.Exchange.root, self.config.CourseDirectory.course_id)
         file_path = os.path.join(dir_name, self.config.Exchange.deadline_file)
-        if not os.path.exists(file_path):
+        if not os.path.exists(file_path) or not os.path.isfile(file_path):
             self.log.warning("No deadlines file found at {}".format(file_path))
             return assignments
 

--- a/nbgrader/server_extensions/helpers/deadline.py
+++ b/nbgrader/server_extensions/helpers/deadline.py
@@ -14,6 +14,10 @@ class DeadlineManager:
 
         dir_name = os.path.join(self.config.Exchange.root, self.config.CourseDirectory.course_id)
         file_path = os.path.join(dir_name, self.config.Exchange.deadline_file)
+        if not os.path.exists(file_path):
+            self.log.warning("No deadlines file found at {}".format(file_path))
+            return assignments
+
         deadlines = self._read_deadlines(file_path)
         for assignment in assignments:
             if assignment["assignment_id"] in deadlines:
@@ -39,9 +43,9 @@ class DeadlineManager:
         
         if self.config.CourseDirectory.groupshared:
             st_mode = os.stat(file_path).st_mode
-            if st_mode & 0o660 != 0o660:
+            if st_mode & 0o664 != 0o664:
                 try:
-                    os.chmod(file_path, (st_mode | 0o660) & 0o777)
+                    os.chmod(file_path, (st_mode | 0o664) & 0o777)
                 except PermissionError:
                     self.log.warning("Could not update permissions of %s to make it groupshared", file_path)
                 

--- a/src/assignment_list/assignmentlist.ts
+++ b/src/assignment_list/assignmentlist.ts
@@ -260,51 +260,42 @@ class Assignment {
       buttons: [Dialog.okButton()]
     }, true);
 
-
   };
 
   private static async proceedLateSubmissionWarning(): Promise<any> {
 
-    // const body_title = React.createElement('p', null, "You're submitting after the deadline. Your submission might not be graded.");
-    // const body = React.createElement("div", {'id': 'late-submission-message'}, [body_title]);
-    // showNbGraderDialog({
-    //   title: "Late Submission",
-    //   body: body,
-    //   buttons: [Dialog.okButton()]
-    // }, true);
-
     return showDialog({
-      title: 'Late Submission', // Can be text or a react element
-      body: 'The assignment is past due date. Would you like to proceed?', // Can be text, a widget or a react element
-      host: document.body, // Parent element for rendering the dialog
-      buttons: [ // List of buttons
+      title: 'Late Submission',
+      body: 'The assignment is past due date. Would you like to proceed?',
+      host: document.body,
+      buttons: [
         {
-          label: 'cancel', // Button label
-          caption: 'cancel submission', // Button title
-          className: '', // Additional button CSS class
-          accept: false, // Whether this button will discard or accept the dialog
-          displayType: 'default', // applies 'default' or 'warn' styles
+          label: 'cancel',
+          caption: 'cancel submission',
+          className: '',
+          accept: false,
+          displayType: 'default',
           ariaLabel: '',
           iconClass: 'closeIcon',
           iconLabel: 'Cancel',
           actions: []
         },
         {
-          label: 'submit', // Button label
-          caption: 'proceed', // Button title
-          className: '', // Additional button CSS class
-          accept: true, // Whether this button will discard or accept the dialog
-          displayType: 'default', // applies 'default' or 'warn' styles
+          label: 'submit',
+          caption: 'proceed',
+          className: '',
+          accept: true,
+          displayType: 'default',
           ariaLabel: '',
           iconClass: 'checkIcon',
           iconLabel: 'Submit',
           actions: []
         },
       ],
-      defaultButton: 0, // Index of the default button
-      focusNodeSelector: '.my-input', // Selector for focussing an input element when dialog opens
-      hasClose: false, // Whether to display a close button or not
-      renderer: undefined // To define customized dialog structure
+      defaultButton: 0,
+      focusNodeSelector: '.my-input',
+      hasClose: false,
+      renderer: undefined
     }).then((result => {
       return result.button.accept;
     }));
@@ -421,7 +412,9 @@ class Assignment {
     row.append(link);
     var dl = document.createElement('span');
     dl.classList.add('item_deadline', 'col-sm-4')
-    dl.innerText = new Date(this.data['due_date']).toLocaleString().replace(',', '') || '';
+    dl.innerText = !!this.data['due_date']
+      ? new Date(this.data['due_date']).toLocaleString().replace(',', '')
+      : '';
     row.append(dl)
     var s = document.createElement('span');
     s.classList.add('item_course', 'col-sm-2')
@@ -477,7 +470,7 @@ const remove_children = function (element: HTMLElement) {
   element.innerHTML = '';
 }
 
-class Submission{
+class Submission {
 
   element: any;
   data: any;

--- a/src/assignment_list/assignmentlist.ts
+++ b/src/assignment_list/assignmentlist.ts
@@ -345,13 +345,13 @@ class Assignment {
         let pastDueDate = false;
         if (!!this.data['due_date']) {
           // Extract date from string
-          var due_date = new Date(this.data['due_date'].substring(0, this.data['due_date'].lastIndexOf(" ")));
-          var now = new Date();
+          var due_date = new Date(this.data['due_date'].substring(0, this.data['due_date'].lastIndexOf(" ")))
+              .getTime();
+          var now = new Date().getTime();
           pastDueDate = (due_date < now)
         }
         if (pastDueDate) {
           button.innerText = 'Late Submit';
-          // button.style.opacity = '0.65';
         }
         button.onclick = async function(){
           if (pastDueDate) {

--- a/src/assignment_list/assignmentlist.ts
+++ b/src/assignment_list/assignmentlist.ts
@@ -226,7 +226,7 @@ class Assignment {
 
   private make_link(): HTMLSpanElement {
     var container = document.createElement('span');;
-    container.classList.add('item_name', 'col-sm-6');
+    container.classList.add('item_name', 'col-sm-4');
 
     var link;
     if (this.data['status'] === 'fetched') {
@@ -264,7 +264,7 @@ class Assignment {
 
   private make_button(): HTMLSpanElement{
     var container = document.createElement('span');
-    container.classList.add('item_status', 'col-sm-4')
+    container.classList.add('item_status', 'col-sm-2')
     var button = document.createElement('button');
     button.classList.add('btn', 'btn-primary', 'btn-xs')
     container.append(button);
@@ -353,9 +353,13 @@ class Assignment {
 
   private make_row(): void {
     var row = document.createElement('div');
-    row.classList.add('col-md-12');
+    row.classList.add('col-md-14');
     var link = this.make_link();
     row.append(link);
+    var dl = document.createElement('span');
+    dl.classList.add('item_deadline', 'col-sm-4')
+    dl.innerText = this.data['due_date'] || '';
+    row.append(dl)
     var s = document.createElement('span');
     s.classList.add('item_course', 'col-sm-2')
     s.innerText = this.data['course_id']
@@ -498,7 +502,7 @@ class Notebook{
   private make_button(): HTMLSpanElement {
     var that = this;
     var container = document.createElement('span');
-    container.classList.add('item_status', 'col-sm-4');
+    container.classList.add('item_status', 'col-sm-2');
     var button = document.createElement('button')
     button.classList.add('btn', 'btn-default', 'btn-xs')
 

--- a/src/assignment_list/assignmentlist.ts
+++ b/src/assignment_list/assignmentlist.ts
@@ -344,16 +344,14 @@ class Assignment {
         button.innerText = "Submit";
         let pastDueDate = false;
         if (!!this.data['due_date']) {
-          // Extract date from string
-          var due_date = new Date(this.data['due_date'].substring(0, this.data['due_date'].lastIndexOf(" ")))
-              .getTime();
+          var due_date = new Date(this.data['due_date']).getTime();
           var now = new Date().getTime();
           pastDueDate = (due_date < now)
         }
         if (pastDueDate) {
           button.innerText = 'Late Submit';
         }
-        button.onclick = async function(){
+        button.onclick = async function() {
           if (pastDueDate) {
             const proceed = await Assignment.proceedLateSubmissionWarning();
             if (!proceed) {
@@ -371,11 +369,11 @@ class Assignment {
               method: 'POST'
             });
 
-            if(!reply.success){
+            if (!reply.success) {
               that.submit_error(reply);
               button.innerText = 'Submit'
               button.removeAttribute('disabled')
-            }else{
+            } else {
               that.on_refresh(reply);
             }
 
@@ -386,9 +384,7 @@ class Assignment {
               `Error on POST /assignment_list/assignments/submit ${dataToSend}.\n${reason}`
             );
           }
-
         }
-
 
     } else if (this.data.status == 'submitted') {
       button.innerText = "Fetch Feedback";
@@ -425,7 +421,7 @@ class Assignment {
     row.append(link);
     var dl = document.createElement('span');
     dl.classList.add('item_deadline', 'col-sm-4')
-    dl.innerText = this.data['due_date'] || '';
+    dl.innerText = new Date(this.data['due_date']).toLocaleString().replace(',', '') || '';
     row.append(dl)
     var s = document.createElement('span');
     s.classList.add('item_course', 'col-sm-2')

--- a/style/course_list.css
+++ b/style/course_list.css
@@ -66,7 +66,7 @@
     padding-right: 0;
 }
 
-#courses .list_item .item_name, #courses .list_item .item_course{
+#courses .list_item .item_name, #courses .list_item .item_course .item_deadline{
     display: inline-block;
     width: 16.66666667%;
 }


### PR DESCRIPTION
In this PR, we introduce a workaround for storing and displaying deadlines to students, which fixes #943.

Currently, the due date is stored in the Gradebook and inaccessible in the student's view. To tackle this issue, we store the deadlines in a file in the *exchange* (fs-based) at a configured path as well. This allows us to display the deadlines in a new column within the AssignmentList. The solution respects the existing configurations for time zones and group sharing.

![new-assignment-list-look](https://github.com/user-attachments/assets/9158923e-f9e2-4575-bd7b-b409bdfc7650)

Moreover, the Submit button now triggers a dialog that asks for confirmation in the case of a late submission.

<img width="450" alt="late-submission-warning-dialog" src="https://github.com/user-attachments/assets/b7fb9618-5542-4655-8f63-9804744a7a1b">

**Note** that the deadline file manipulation is attached to API so it will only be set for assignments created/editted after the upgrade. Assignments released before the update won't have deadline files made, and won't be shown to the users (which is fixed by simply pressing the edit button with no changes for each).

According to the feedback received from instructors who use nbgrader, this will enhance the assignment submission and collection processes, and reduce the need for manual intervention.