### PR TITLE
Set CSP frame-ancestors 'self' for nbgrader handlers

### DIFF
--- a/nbgrader/server_extensions/formgrader/base.py
+++ b/nbgrader/server_extensions/formgrader/base.py
@@ -60,6 +60,10 @@ class BaseHandler(JupyterHandler):
         api.log_level = level
         return api
 
+    def initialize(self):
+        super().initialize()
+        self.set_header("Content-Security-Policy", "frame-ancestors 'self'")
+
     def render(self, name, **ns):
         template = self.settings['nbgrader_jinja2_env'].get_template(name)
         return template.render(**ns)


### PR DESCRIPTION
This PR solves issue #1870 (formgrader does not show in JupyerLab tab due to JupyterHub >=4.1.0 security settings in HTTP headers).

Starting with JupyterHub 4.1.0 HTTP header
```
Content-Security-Policy:  frame-ancestors 'none'
```
is the default setting instead of
```
Content-Security-Policy: frame-ancestors 'self'
```
See [Mitigating same-origin deployments](https://jupyterhub.readthedocs.io/en/stable/explanation/websecurity.html#mitigating-same-origin-deployments) for some background on this decision and [CSP: frame-ancestors](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors#self) for details on the header.

The `none` header prevents loading of formgrader in a tab of JupyterLab.

The JupyterHub `none` setting overwrites the `self` setting of Jupyter Server running without JupyterHub. See
* [jupyter_server/base/handlers.py#L101](https://github.com/jupyter-server/jupyter_server/blob/74655ce66f36ed85a83591e6658e70ba91232580/jupyter_server/base/handlers.py#L101) for default setting `self` in Jupyter Server,
* [jupyterhub/singleuser/extension.py#L658](https://github.com/jupyterhub/jupyterhub/blob/99b32dd372ae41c14473e543be4c302b80f613aa/jupyterhub/singleuser/extension.py#L658) for default setting `none` in JupyterHub's Jupyter Server extension,
* [jupyterhub/singleuser/mixins.py#L688](https://github.com/jupyterhub/jupyterhub/blob/99b32dd372ae41c14473e543be4c302b80f613aa/jupyterhub/singleuser/mixins.py#L688) for default setting `none` in JupyterHub's code for classic notebook.

To allow embedding of nbgrader's formgrader (and possibly other nbgrader components) without affecting security of other JupyterHub components this PR sets `frame-ancestors` to `self` for responses of nbgrader handlers only.

The class `BaseHandler` modified by this PR is a subclass of [`tornado.web.RequestHandler`](https://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler), which provides the [`set_header`](https://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.set_header) method.