### PR TITLE
Upgrade upload-artifact action

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -26,7 +26,7 @@ jobs:
         if: ${{ matrix.group == 'link_check' }}
         uses: jupyter-server/jupyter_releaser/.github/actions/check-links@v1
       - name: Upload Distributions
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: nbgrader-jupyter-releaser-dist-${{ github.run_number }}
           path: .jupyter_releaser_checkout/dist

--- a/.github/workflows/test-extensions.yml
+++ b/.github/workflows/test-extensions.yml
@@ -91,7 +91,7 @@ jobs:
           python tasks.py tests --group=${{ matrix.group }}
       - name: Upload Playwright Test report
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: nbgrader-uitests-${{ matrix.group }}-${{ matrix.os }}-python${{ matrix.python }}
           path: |


### PR DESCRIPTION
The v2 of upload artifact action is now deprecated and must be upgraded.
https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/