### PR TITLE
Submission scores in Assigment List

### DIFF
--- a/nbgrader/server_extensions/formgrader/templates/feedback/index.html.j2
+++ b/nbgrader/server_extensions/formgrader/templates/feedback/index.html.j2
@@ -6,6 +6,8 @@
 <head>
 
 <meta charset="utf-8" />
+<meta name="nbgrader-score" content="{{ resources.nbgrader.score | float | round(2) }}" />
+<meta name="nbgrader-max-score" content="{{ resources.nbgrader.max_score | float | round(2) }}" />
 <title>{{ resources.nbgrader.notebook }}</title>
 
 {{ resources.include_css('bootstrap.min.css')}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "setuptools",
     "sqlalchemy>=1.4,<3",
     "PyYAML>=6.0",
+    "lxml>=5.3.0",
 ]
 version = "0.9.3"
 

--- a/src/assignment_list/assignmentlist.ts
+++ b/src/assignment_list/assignmentlist.ts
@@ -88,6 +88,8 @@ export class AssignmentList {
   private load_list_success(data: string | any[]): void {
     this.clear_list(false);
 
+    var total_score = 0;
+    var total_max_score = 0;
     var len = data.length;
     for (var i=0; i<len; i++) {
         var element = document.createElement('div');
@@ -102,8 +104,16 @@ export class AssignmentList {
         } else if (data[i]['status'] === 'submitted') {
           this.submitted_element.append(element);
           (<HTMLDivElement>this.submitted_element.children.namedItem('submitted_assignments_list_placeholder')).hidden = true;
+          
+          if (data[i]['score'] != null && data[i]['max_score'] != null) {
+            total_score += data[i]['score'];
+            total_max_score += data[i]['max_score'];
+          }
         }
     }
+    
+    var total_score_element = document.getElementById(this.options.get('total_score_id'));
+    total_score_element.innerText = total_score + '/' + total_max_score;
 
     var assignments  = this.fetched_element.getElementsByClassName('assignment-notebooks-link');
     for(let a of assignments){
@@ -365,9 +375,9 @@ class Assignment {
     score.setAttribute('style', 'text-align:left');
     row.append(score);
 
-    var score_heading = document.getElementById(this.options.get('score_heading_id'));
-    var show_score = score_heading && this.data['score'] != null && this.data['max_score'] != null;
-    score_heading.style.visibility = show_score ? 'visible' : 'hidden';
+    var score_heading_element = document.getElementById(this.options.get('score_heading_id'));
+    var show_score = score_heading_element && this.data['score'] != null && this.data['max_score'] != null;
+    score_heading_element.style.visibility = show_score ? 'visible' : 'hidden';
 
     var id, element;
     var children = document.createElement('div');

--- a/src/assignment_list/assignmentlist.ts
+++ b/src/assignment_list/assignmentlist.ts
@@ -226,7 +226,7 @@ class Assignment {
 
   private make_link(): HTMLSpanElement {
     var container = document.createElement('span');;
-    container.classList.add('item_name', 'col-sm-6');
+    container.classList.add('item_name', 'col-sm-4');
 
     var link;
     if (this.data['status'] === 'fetched') {
@@ -360,10 +360,22 @@ class Assignment {
     s.classList.add('item_course', 'col-sm-2')
     s.innerText = this.data['course_id']
     row.append(s)
+    var score = document.createElement('span');
+    score.classList.add('item_status', 'col-sm-2');
+    score.setAttribute('style', 'text-align:left');
+    row.append(score);
+
+    var score_heading = document.getElementById(this.options.get('score_heading_id'));
+    var show_score = score_heading && this.data['score'] != null && this.data['max_score'] != null;
+    score_heading.style.visibility = show_score ? 'visible' : 'hidden';
 
     var id, element;
     var children = document.createElement('div');
     if (this.data['status'] == 'submitted') {
+      if (show_score) {
+        score.innerText = this.data['score'] + '/' + this.data['max_score'];
+      }
+
       id = this.escape_id() + '-submissions';
       children.id = id;
       children.classList.add('panel-collapse', 'list_container', 'assignment-notebooks');

--- a/src/assignment_list/index.ts
+++ b/src/assignment_list/index.ts
@@ -98,6 +98,10 @@ export class AssignmentListWidget extends Widget {
       '          </div>',
       '        </div>',
       '      </div>',
+      '      <div class="panel-heading">',
+      '        <span class="col-sm-6"><b>Total Score</b></span>',
+      '        <b id="total-score"></b>',
+      '      </div>',
       '    </div>',
       '  </div>   ',
       '</div>'
@@ -110,6 +114,7 @@ export class AssignmentListWidget extends Widget {
     let options = new Map();
     options.set('base_url',base_url);
     options.set('score_heading_id', 'score-heading');
+    options.set('total_score_id', 'total-score');
     var assignment_l = new AssignmentList(this,
       'released_assignments_list',
       'fetched_assignments_list',

--- a/src/assignment_list/index.ts
+++ b/src/assignment_list/index.ts
@@ -82,7 +82,8 @@ export class AssignmentListWidget extends Widget {
       '    </div>',
       '    <div class="panel panel-default">',
       '      <div class="panel-heading">',
-      '        Submitted assignments',
+      '        <span class="col-sm-6">Submitted assignments</span>',
+      '        <span id="score-heading">Score</span>',
       '      </div>',
       '      <div class="panel-body">',
       '        <div id="submitted_assignments_list" class="list_container">',
@@ -108,6 +109,7 @@ export class AssignmentListWidget extends Widget {
     let base_url = PageConfig.getBaseUrl();
     let options = new Map();
     options.set('base_url',base_url);
+    options.set('score_heading_id', 'score-heading');
     var assignment_l = new AssignmentList(this,
       'released_assignments_list',
       'fetched_assignments_list',


### PR DESCRIPTION
With this PR, the scores for each assignment are displayed directly on the assignment list page, significantly enhancing the course overview from the student's perspective.

- **Updated feedback template**
The only source of scores accessible to students is the feedback.html file. To facilitate easier parsing, the default template has been modified by adding <meta> tags to store the student's earned score. This change also allows custom templates to be parsed conveniently, provided they incorporate these meta tags.

- **Updated Exchange**
The default exchange now parses the feedback file and retrieves the score and max_score attributes for each submission. If multiple feedbacks are available, the score from the last one is returned.

- **Backward Compatibility**
  - Since this update relies on the new <meta> tags in feedback files, scores will not be displayed for older assignments.
  - If a custom exchange does not return scores, they will not appear in the UI.

![image](https://github.com/user-attachments/assets/9ff0ffa5-690a-4181-b4a3-be170b4b411c)