### PR TITLE
Prevent dependabot from using yarn 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,5 +109,6 @@
     "extension": true,
     "outputDir": "nbgrader/labextension",
     "schemaDir": "schema"
-  }
+  },
+  "packageManager": "yarn@3.5.0"
 }


### PR DESCRIPTION
This PR should prevent dependabot from using yarn 4, and change the whole dependencies in `yarn.lock`.

See https://github.com/jupyterlab/extension-template/pull/79 for more information.