### PR TITLE
Update the check link action to use maintainer tools

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -1,7 +1,7 @@
 name: Check Release
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
   pull_request:
     branches: ["*"]
 
@@ -10,23 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        group: [check_release, link_check]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - name: Check Release
-        if: ${{ matrix.group == 'check_release' }}
         uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Link Check
-        if: ${{ matrix.group == 'link_check' }}
         steps:
-          - uses: actions/checkout@v4
-          - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
           - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
             with:
               ignore_links: http://www.opensource.org/licenses/mit-license.php

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -24,7 +24,12 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Link Check
         if: ${{ matrix.group == 'link_check' }}
-        uses: jupyter-server/jupyter_releaser/.github/actions/check-links@v1
+        steps:
+          - uses: actions/checkout@v4
+          - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+          - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
+            with:
+              ignore_links: http://www.opensource.org/licenses/mit-license.php
       - name: Upload Distributions
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -20,10 +20,9 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Link Check
-        steps:
-          - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
-            with:
-              ignore_links: http://www.opensource.org/licenses/mit-license.php
+        uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
+        with:
+          ignore_links: http://www.opensource.org/licenses/mit-license.php
       - name: Upload Distributions
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -8,27 +8,31 @@ on:
 jobs:
   check_release:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        group: [check_release, link_check]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - name: Check Release
-        if: ${{ matrix.group == 'check_release' }}
         uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run Link Check
-        if: ${{ matrix.group == 'link_check' }}
-        uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
-        with:
-          ignore_links: http://www.opensource.org/licenses/mit-license.php
       - name: Upload Distributions
         uses: actions/upload-artifact@v4
         with:
           name: nbgrader-jupyter-releaser-dist-${{ github.run_number }}
           path: .jupyter_releaser_checkout/dist
+
+  check_links:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - name: Install dependencies
+        run: pip install -e .
+      - name: Run Link Check
+        uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
+        with:
+          ignore_links: http://www.opensource.org/licenses/mit-license.php

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -10,16 +10,20 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      matrix:
+        group: [check_release, link_check]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - name: Check Release
+        if: ${{ matrix.group == 'check_release' }}
         uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Link Check
+        if: ${{ matrix.group == 'link_check' }}
         uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
         with:
           ignore_links: http://www.opensource.org/licenses/mit-license.php


### PR DESCRIPTION
This PR update the `check_links` to use the one from [maintainer_tools](https://github.com/jupyterlab/maintainer-tools/blob/main/.github/actions/check-links/action.yml) instead of the old one from [jupyter_releaser](https://github.com/jupyter-server/jupyter_releaser/blob/1.x/.github/actions/check-links/action.yml).

It also ignore the [MIT link](https://github.com/jupyter/nbgrader/blob/8563de4fae20d43b1035b967a3431b1d2d4eeaf1/nbgrader/server_extensions/formgrader/static/components/autosize/readme.md?plain=1#L39) from a javascript dependency, which constantly fails.
