### PR TITLE
fix: Allow null kernelspec in OverwriteKernelspec

### DIFF
--- a/nbgrader/preprocessors/overwritekernelspec.py
+++ b/nbgrader/preprocessors/overwritekernelspec.py
@@ -17,8 +17,10 @@ class OverwriteKernelspec(NbGraderPreprocessor):
         db_url = resources['nbgrader']['db_url']
 
         with Gradebook(db_url) as gb:
-            kernelspec = json.loads(
-                gb.find_notebook(notebook_id, assignment_id).kernelspec)
+            kernelspec = gb.find_notebook(notebook_id, assignment_id).kernelspec
+            if kernelspec is not None:
+                kernelspec = json.loads(kernelspec)
+
             self.log.debug("Source notebook kernelspec: {}".format(kernelspec))
             self.log.debug(
                 "Submitted notebook kernelspec: {}"

--- a/nbgrader/tests/preprocessors/test_overwritekernelspec.py
+++ b/nbgrader/tests/preprocessors/test_overwritekernelspec.py
@@ -57,3 +57,22 @@ class TestOverwriteKernelSpec(BaseTestPreprocessor):
         notebook = gradebook.find_notebook("test", "ps0")
         assert nb.metadata['kernelspec'] == kernelspec
         assert json.loads(notebook.kernelspec) == kernelspec
+
+    def test_overwrite_kernelspec_null_spec(self, preprocessors, resources, gradebook):
+        # Create a notebook without a kernelspec
+        gradebook.add_notebook("test", "ps0")
+
+        kernelspec = dict(
+            display_name="Python 3",
+            name="python3",
+            language="python",
+        )
+
+        nb = new_notebook()
+        nb.metadata["kernelspec"] = kernelspec
+        nb, resources = preprocessors[1].preprocess(nb, resources)
+
+        validate(nb)
+        notebook = gradebook.find_notebook("test", "ps0")
+        assert notebook.kernelspec is None
+        assert nb.metadata["kernelspec"] == kernelspec


### PR DESCRIPTION
The `Notebook.kernelspec` field is nullable, so in the event of a null value, OverwriteKernelspec should not fail. This commit checks for that case before trying to `json.loads` the value.