### PR TITLE
fix: Use cross-platform shortcuts in ui-tests

### DIFF
--- a/nbgrader/tests/ui-tests/assignment_list.spec.ts
+++ b/nbgrader/tests/ui-tests/assignment_list.spec.ts
@@ -151,7 +151,7 @@ const openAssignmentList = async (page: IJupyterLabPageFixture) => {
     mainPanelTabCount
   );
 
-  await page.keyboard.press("Control+Shift+c");
+  await page.keyboard.press("ControlOrMeta+Shift+c");
   await page
     .locator(
       '#modal-command-palette li[data-command="nbgrader:open-assignment-list"]'

--- a/nbgrader/tests/ui-tests/course_list.spec.ts
+++ b/nbgrader/tests/ui-tests/course_list.spec.ts
@@ -98,7 +98,7 @@ const openCoursesList = async (page: IJupyterLabPageFixture) => {
     mainPanelTabCount
   );
 
-  await page.keyboard.press("Control+Shift+c");
+  await page.keyboard.press("ControlOrMeta+Shift+c");
   await page
     .locator(
       '#modal-command-palette li[data-command="nbgrader:open-course-list"]'

--- a/nbgrader/tests/ui-tests/formgrader.spec.ts
+++ b/nbgrader/tests/ui-tests/formgrader.spec.ts
@@ -227,7 +227,7 @@ const openFormgrader = async (page: IJupyterLabPageFixture) => {
     mainPanelTabCount
   );
 
-  await page.keyboard.press("Control+Shift+c");
+  await page.keyboard.press("ControlOrMeta+Shift+c");
   await page
     .locator(
       '#modal-command-palette li[data-command="nbgrader:open-formgrader"]'


### PR DESCRIPTION
Previously, UI tests failed on macOS because the required keyboard shortcuts are slightly different on macOS from Windows and Linux. This commit updates them to use the ControlOrMeta key, which handles both cases.