### PR TITLE
Fix Path Traversal in validate_assignment via Path Normalization

### DIFF
--- a/nbgrader/server_extensions/validate_assignment/handlers.py
+++ b/nbgrader/server_extensions/validate_assignment/handlers.py
@@ -38,7 +38,10 @@ class ValidateAssignmentHandler(JupyterHandler):
         return app.config
 
     def validate_notebook(self, path):
-        fullpath = os.path.join(self.root_dir, path)
+        fullpath = os.path.normpath(os.path.join(self.root_dir, path))
+        root_normalized = os.path.normpath(self.root_dir)
+        if not fullpath.startswith(root_normalized + os.sep):
+            raise web.HTTPError(403, "Access denied: path outside allowed directory")
 
         try:
             config = self.load_config()

--- a/nbgrader/server_extensions/validate_assignment/handlers.py
+++ b/nbgrader/server_extensions/validate_assignment/handlers.py
@@ -44,7 +44,6 @@ class ValidateAssignmentHandler(JupyterHandler):
         if not target.is_relative_to(root):
             raise web.HTTPError(403, "Access denied: path outside allowed directory")
         fullpath = str(target)
-        
         try:
             config = self.load_config()
             validator = Validator(config=config)

--- a/nbgrader/server_extensions/validate_assignment/handlers.py
+++ b/nbgrader/server_extensions/validate_assignment/handlers.py
@@ -6,6 +6,7 @@ import traceback
 
 from tornado import web
 from textwrap import dedent
+from pathlib import Path
 
 from jupyter_server.utils import url_path_join as ujoin
 from jupyter_server.base.handlers import JupyterHandler
@@ -38,11 +39,12 @@ class ValidateAssignmentHandler(JupyterHandler):
         return app.config
 
     def validate_notebook(self, path):
-        fullpath = os.path.normpath(os.path.join(self.root_dir, path))
-        root_normalized = os.path.normpath(self.root_dir)
-        if not fullpath.startswith(root_normalized + os.sep):
+        root = Path(self.root_dir).resolve()
+        target = (root / path).resolve()
+        if not target.is_relative_to(root):
             raise web.HTTPError(403, "Access denied: path outside allowed directory")
-
+        fullpath = str(target)
+        
         try:
             config = self.load_config()
             validator = Validator(config=config)


### PR DESCRIPTION
## Description
This PR fixes a path traversal vulnerability in `nbgrader/server_extensions/validate_assignment/handlers.py`.

Following the merge of #1984 (Python ≥3.10), the fix has been updated to use `pathlib` as suggested.

## Changes
- Replaced `os.path.normpath` approach with `pathlib.Path` for path resolution.
- Used `Path.resolve()` to handle `../` sequences and symlinks.
- Used `Path.is_relative_to()` to ensure the path stays within `root_dir`.
- Requests outside the root directory now raise a `403 Access denied` error.

## Testing
- Valid notebook paths within `root_dir` work correctly.
- Malicious paths (e.g., `../../../etc/passwd`) are blocked with a 403 response.
- Updated tests to reflect the new pathlib-based implementation.