### PR TITLE
Set defaults for date/time picker and timezone

### DIFF
--- a/nbgrader/server_extensions/formgrader/handlers.py
+++ b/nbgrader/server_extensions/formgrader/handlers.py
@@ -9,6 +9,7 @@ from traitlets.config.loader import Config
 
 from .base import BaseHandler, check_xsrf, check_notebook_dir
 from ...api import MissingEntry
+from ...utils import to_numeric_tz
 
 
 class FormgraderHandler(BaseHandler):
@@ -56,7 +57,8 @@ class ManageAssignmentsHandler(BaseHandler):
             course_id=api.course_id,
             exchange=api.exchange_root,
             exchange_missing=api.exchange_missing,
-            current_config= current_config)
+            current_config=current_config,
+            default_timezone=to_numeric_tz(api.timezone))
         self.write(html)
 
 

--- a/nbgrader/server_extensions/formgrader/static/js/manage_assignments.js
+++ b/nbgrader/server_extensions/formgrader/static/js/manage_assignments.js
@@ -1,3 +1,11 @@
+var getDefaultDuedate = function () {
+    var now = new Date();
+    var year = now.getFullYear();
+    var month = String(now.getMonth() + 1).padStart(2, '0');
+    var day = String(now.getDate()).padStart(2, '0');
+    return year + '-' + month + '-' + day + 'T00:00';
+};
+
 var Assignment = Backbone.Model.extend({
     idAttribute: 'name',
     urlRoot: base_url + "/formgrader/api/assignment"
@@ -74,6 +82,13 @@ var AssignmentUI = Backbone.View.extend({
         this.$modal.find("input.modal-name").val(this.model.get("name"));
         this.$modal_duedate = this.$modal.find("input.modal-duedate");
         this.$modal_duedate.val(this.model.get("duedate_notimezone"));
+        if (!this.model.get("duedate_notimezone")) {
+            this.$modal_duedate.one('focus', function () {
+                if (!$(this).val()) {
+                    $(this).val(getDefaultDuedate());
+                }
+            });
+        }
         this.$modal_timezone = this.$modal.find("input.modal-timezone");
         this.$modal_timezone.val(this.model.get("duedate_timezone"));
         this.$modal_save = this.$modal.find("button.save");
@@ -577,6 +592,15 @@ var createAssignmentModal = function () {
         .text("Cancel"));
 
     modal = createModal("add-assignment-modal", "Add New Assignment", body, footer);
+
+    // Default to today-at-midnight on first interaction
+    modal.find(".duedate").one('focus', function () {
+        if (!$(this).val()) {
+            $(this).val(getDefaultDuedate());
+        }
+    });
+    // Pre-fill timezone from server config
+    modal.find(".timezone").val(default_timezone);
 };
 
 var loadAssignments = function () {

--- a/nbgrader/server_extensions/formgrader/templates/manage_assignments.tpl
+++ b/nbgrader/server_extensions/formgrader/templates/manage_assignments.tpl
@@ -3,6 +3,7 @@
 {%- block head -%}
 <script>
 var url_prefix = "{{ url_prefix }}";
+var default_timezone = "{{ default_timezone }}";
 </script>
 
 <script src="{{ base_url }}/formgrader/static/js/manage_assignments.js"></script>

--- a/nbgrader/tests/apps/test_api.py
+++ b/nbgrader/tests/apps/test_api.py
@@ -245,6 +245,34 @@ class TestNbGraderAPI(BaseTestApp):
         target["num_submissions"] = 2
         assert a == target
 
+    @notwindows
+    def test_get_assignment_custom_timezone(self, api, course_dir, db, exchange):
+        """Test that duedate_timezone reflects a non-UTC configured timezone."""
+        self._copy_file(join("files", "test.ipynb"), join(course_dir, "source", "ps1", "p1.ipynb"))
+
+        # Default (UTC) should return +0000
+        a = api.get_assignment("ps1")
+        assert a["duedate_timezone"] == "+0000"
+        assert a["duedate_notimezone"] is None
+        assert a["display_duedate"] is None
+
+        # Configure a non-UTC timezone
+        api.timezone = "US/Eastern"
+        a = api.get_assignment("ps1")
+        assert a["duedate_timezone"] in ["-0400", "-0500"]
+
+        # Verify duedate with non-UTC timezone
+        with api.gradebook as gb:
+            assignment = gb.find_assignment("ps1")
+            assignment.duedate = parse_utc("2017-07-05 12:00:00 UTC")
+            gb.db.commit()
+
+        a = api.get_assignment("ps1")
+        assert a["duedate_timezone"] in ["-0400", "-0500"]
+        # July is EDT (-0400), so 12:00 UTC = 08:00 EDT
+        assert a["duedate_notimezone"] == "2017-07-05T08:00:00"
+        assert "EDT" in a["display_duedate"] or "EST" in a["display_duedate"]
+
     def test_get_assignments(self, api, course_dir):
         assert api.get_assignments() == []
 

--- a/nbgrader/tests/apps/test_api.py
+++ b/nbgrader/tests/apps/test_api.py
@@ -261,6 +261,9 @@ class TestNbGraderAPI(BaseTestApp):
         a = api.get_assignment("ps1")
         assert a["duedate_timezone"] in ["-0400", "-0500"]
 
+        # Generate the assignment so it exists in the database
+        run_nbgrader(["generate_assignment", "ps1", "--db", db])
+
         # Verify duedate with non-UTC timezone
         with api.gradebook as gb:
             assignment = gb.find_assignment("ps1")

--- a/nbgrader/tests/ui-tests/formgrader.spec.ts
+++ b/nbgrader/tests/ui-tests/formgrader.spec.ts
@@ -861,7 +861,7 @@ test("Due date defaults", async ({ page, baseURL, request, tmpPath }) => {
   const iframe = page.mainFrame().childFrames()[0];
 
   // Test 1: Create modal — timezone should be pre-filled, date field empty
-  await iframe.click('text=Add new assignment...');
+  await iframe.click('a:text("Add new assignment...")');
   const createModal = iframe.locator('#add-assignment-modal');
   await expect(createModal).toBeVisible();
 
@@ -882,7 +882,7 @@ test("Due date defaults", async ({ page, baseURL, request, tmpPath }) => {
   await createModal.locator('button.save').click();
 
   // Test 4: Create an assignment without touching the date field — should have no due date
-  await iframe.click('text=Add new assignment...');
+  await iframe.click('a:text("Add new assignment...")');
   const createModal2 = iframe.locator('#add-assignment-modal');
   await expect(createModal2).toBeVisible();
 

--- a/nbgrader/tests/ui-tests/formgrader.spec.ts
+++ b/nbgrader/tests/ui-tests/formgrader.spec.ts
@@ -844,6 +844,58 @@ test("Load students submissions", async ({
 });
 
 /*
+ * Test due date defaults in create and edit modals
+ */
+test("Due date defaults", async ({ page, baseURL, request, tmpPath }) => {
+  test.skip(isWindows, "This test does not work on Windows");
+
+  if (baseURL === undefined) throw new Error("BaseURL is undefined.");
+
+  if (isNotebook) await page.goto(`tree/${tmpPath}`);
+
+  // create environment
+  await createEnv(testDir, tmpPath, exchange_dir, cache_dir, isWindows);
+  await addCourses(request, page, tmpPath);
+  await openFormgrader(page);
+
+  const iframe = page.mainFrame().childFrames()[0];
+
+  // Test 1: Create modal — timezone should be pre-filled, date field empty
+  await iframe.click('text=Add new assignment...');
+  const createModal = iframe.locator('#add-assignment-modal');
+  await expect(createModal).toBeVisible();
+
+  // Timezone should be pre-filled with server default
+  const timezoneValue = await createModal.locator('input.timezone').inputValue();
+  expect(timezoneValue).toMatch(/^[+-]\d{4}$/);
+
+  // Date field should be empty before interaction
+  const duedateBeforeFocus = await createModal.locator('input.duedate').inputValue();
+  expect(duedateBeforeFocus).toBe('');
+
+  // Test 2: Clicking into the date field should default to today at midnight
+  await createModal.locator('input.duedate').click();
+  const duedateAfterFocus = await createModal.locator('input.duedate').inputValue();
+  expect(duedateAfterFocus).toMatch(/^\d{4}-\d{2}-\d{2}T00:00$/);
+
+  // Test 3: Save without a name should dismiss the modal (no assignment created)
+  await createModal.locator('button.save').click();
+
+  // Test 4: Create an assignment without touching the date field — should have no due date
+  await iframe.click('text=Add new assignment...');
+  const createModal2 = iframe.locator('#add-assignment-modal');
+  await expect(createModal2).toBeVisible();
+
+  await createModal2.locator('input.name').fill('test-no-duedate');
+  // Clear the duedate field (in case focus triggered during name entry)
+  await createModal2.locator('input.duedate').fill('');
+  await createModal2.locator('button.save').click();
+
+  // Verify the assignment shows "None" for due date
+  await expect(iframe.locator('td.duedate:text("None")')).toHaveCount(2);
+});
+
+/*
  * Switch views
  */
 test("Switch views", async ({ page, baseURL, request, tmpPath }) => {


### PR DESCRIPTION
## Summary                                                                                                                     
                                                                                                                               
Fixes https://github.com/jupyter/nbgrader/issues/1884                                                                          
   
The due date picker in the formgrader's "Manage Assignments" page had two UX issues: the time component defaulted to the current time instead of midnight, and the timezone field was empty in the create modal. Faculty would unintentionally save inconsistent due times like `14:37` when they only changed the date.                                                           
                                                                                                                               
  ## Changes

  - Pass the server's configured timezone offset to the template and pre-fill it in the create modal                             
  - On first click into an empty date field, default to today at `00:00` (using a one-time `focus` handler so users who skip the field get no due date)                                                                                                         
  - Existing due dates in the edit modal are preserved unchanged                                                               
                                                                                                                                 
  ## Tests                                                                                                                     
                                                                                                                                 
  - **Backend**: `test_get_assignment_custom_timezone`: verifies non-UTC timezone propagation                                   
  - **E2E**: `Due date defaults`: validates midnight default on focus, timezone pre-fill, and no-date regression
                                                                                                                                 
  ## Manual verification                                                                                                         
                                                                                                                                 
  1. "Add new assignment..." --> timezone pre-filled, date empty                                                                   
  2. Click into date field --> defaults to today at `00:00`                                                                      
  3. Save without touching date --> due date is "None"                                                                             
  4. Edit existing assignment --> original date/time preserved                                                                     
                                                                                                                                 
  Per the [pull request guidelines](https://nbgrader.readthedocs.io/en/stable/contributor_guide/pull_request.html):              
  - [x] Added regression tests                                                                                                   
  - [x] No documentation changes needed